### PR TITLE
Enable @typescript-eslint/require-await rule

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -18,7 +18,7 @@ const withMDX = createMDX({
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
-  async redirects() {
+  redirects() {
     return [
       {
         source: "/local-first",
@@ -34,7 +34,7 @@ const config = {
       { source: "/docs", destination: "/docnode", permanent: true },
     ];
   },
-  async rewrites() {
+  rewrites() {
     return [
       // Map clean URLs to internal /docs/ structure
       { source: "/docnode/:path*", destination: "/docs/docnode/:path*" },

--- a/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/docs/src/app/docs/[[...slug]]/page.tsx
@@ -63,7 +63,7 @@ export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
   );
 }
 
-export async function generateStaticParams() {
+export function generateStaticParams() {
   return source.generateParams();
 }
 

--- a/docs/src/lib/synced-editors-demo/createTwoClients.ts
+++ b/docs/src/lib/synced-editors-demo/createTwoClients.ts
@@ -31,10 +31,12 @@ function createClient(
   return createDocSyncClient({
     server: {
       url: "ws://non-existent-url.com",
+      // eslint-disable-next-line @typescript-eslint/require-await
       auth: { getToken: async () => userId },
     },
     local: {
       provider: IndexedDBProvider,
+      // eslint-disable-next-line @typescript-eslint/require-await
       getIdentity: async () => ({ userId, secret: "docs-demo" }),
     },
     docBinding: DocNodeBinding(docConfigs),

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -64,7 +64,6 @@ export const rootEslintConfig = tseslint.config(
         "warn",
         { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
       ],
-      "@typescript-eslint/require-await": "off",
       "@typescript-eslint/no-misused-promises": [
         "error",
         { checksVoidReturn: { attributes: false } },

--- a/examples/app/utils/createMultiClients.tsx
+++ b/examples/app/utils/createMultiClients.tsx
@@ -22,11 +22,13 @@ const createClientForUser = (
     server: {
       url: "ws://localhost:8081",
       auth: {
+        // eslint-disable-next-line @typescript-eslint/require-await
         getToken: async () => userId, // Use userId as token
       },
     },
     local: {
       provider: IndexedDBProvider,
+      // eslint-disable-next-line @typescript-eslint/require-await
       getIdentity: async () => ({ userId, secret: "asdasdasd" }),
     },
     docBinding: DocNodeBinding(docConfigs),

--- a/examples/docsync-server.ts
+++ b/examples/docsync-server.ts
@@ -7,5 +7,6 @@ new DocSyncServer({
   docBinding: DocNodeBinding([indexDocConfig, lexicalDocNodeConfig]),
   port: 8081,
   provider: PostgresProvider,
+  // eslint-disable-next-line @typescript-eslint/require-await
   authenticate: async ({ token }) => ({ userId: token }), // Use token as userId
 });

--- a/packages/docsync/src/client/handlers/clientInitiated/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync.ts
@@ -36,14 +36,10 @@ export async function applyServerOperations<
  * Replaces the cached document (e.g. when server responds with a squashed doc).
  * Keeps refCount, presence, and presenceListeners unchanged.
  */
-export async function replaceDocInCache<
-  D extends {},
-  S extends {},
-  O extends {},
->(
+export function replaceDocInCache<D extends {}, S extends {}, O extends {}>(
   client: DocSyncClient<D, S, O>,
   args: { docId: string; doc?: D; serializedDoc?: S },
-): Promise<void> {
+): void {
   const cacheEntry = client["_docsCache"].get(args.docId);
   if (!cacheEntry) return;
   if (args.doc === undefined && args.serializedDoc === undefined) return;

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -293,7 +293,7 @@ export class DocSyncClient<
     };
   }
 
-  async setPresence({ docId, presence }: { docId: string; presence: unknown }) {
+  setPresence({ docId, presence }: { docId: string; presence: unknown }) {
     void handlePresence(this, { docId, presence });
   }
 

--- a/packages/docsync/src/server/cli.ts
+++ b/packages/docsync/src/server/cli.ts
@@ -6,5 +6,6 @@ new DocSyncServer({
   docBinding: DocNodeBinding([]),
   port: 8081,
   provider: PostgresProvider,
+  // eslint-disable-next-line @typescript-eslint/require-await
   authenticate: async () => ({ userId: "John" }),
 });

--- a/packages/docsync/src/server/providers/memory.ts
+++ b/packages/docsync/src/server/providers/memory.ts
@@ -32,10 +32,12 @@ export class InMemoryServerProvider<S, O> implements ServerProvider<S, O> {
   ): Promise<T> {
     // In-memory provider doesn't need real transactions since operations are synchronous
     const ctx: ServerProviderContext<S, O> = {
+      // eslint-disable-next-line @typescript-eslint/require-await -- sync implementation of async interface
       getSerializedDoc: async (docId: string) => {
         return this._docs.get(docId);
       },
 
+      // eslint-disable-next-line @typescript-eslint/require-await -- sync implementation of async interface
       getOperations: async ({ docId, clock }) => {
         const allOps = this._operations.get(docId) ?? [];
         const serverOps = allOps
@@ -44,6 +46,7 @@ export class InMemoryServerProvider<S, O> implements ServerProvider<S, O> {
         return serverOps;
       },
 
+      // eslint-disable-next-line @typescript-eslint/require-await -- sync implementation of async interface
       deleteOperations: async ({ docId, count }) => {
         const allOps = this._operations.get(docId) ?? [];
         allOps.splice(0, count);
@@ -54,6 +57,7 @@ export class InMemoryServerProvider<S, O> implements ServerProvider<S, O> {
         }
       },
 
+      // eslint-disable-next-line @typescript-eslint/require-await -- sync implementation of async interface
       saveOperations: async ({ docId, operations }) => {
         if (operations.length === 0) {
           // Return current clock if no operations to save
@@ -73,6 +77,7 @@ export class InMemoryServerProvider<S, O> implements ServerProvider<S, O> {
         return newClock;
       },
 
+      // eslint-disable-next-line @typescript-eslint/require-await -- sync implementation of async interface
       saveSerializedDoc: async ({ docId, serializedDoc, clock }) => {
         this._docs.set(docId, { serializedDoc, clock });
       },

--- a/packages/docsync/src/server/providers/postgres/index.ts
+++ b/packages/docsync/src/server/providers/postgres/index.ts
@@ -84,6 +84,7 @@ export class PostgresProvider<S, O> implements ServerProvider<S, O> {
           return inserted[0]!.clock.getTime();
         },
 
+        // eslint-disable-next-line @typescript-eslint/require-await -- not implemented yet
         saveSerializedDoc: async (_arg) => {
           // TODO: saveSerializedDoc needs userId to work with Postgres schema.
           // This will be called during operation squashing (not implemented yet).

--- a/tests/docnode-lexical/batching.test.ts
+++ b/tests/docnode-lexical/batching.test.ts
@@ -1,7 +1,7 @@
 import { $getRoot, createEditor } from "lexical";
 import { expect, test } from "vitest";
 
-test("batch updates", async () => {
+test("batch updates", () => {
   const editor = createEditor();
   const logOp: string[] = [];
   editor.registerUpdateListener(() => {

--- a/tests/docnode/benchmarks/iterators.bench.ts
+++ b/tests/docnode/benchmarks/iterators.bench.ts
@@ -17,7 +17,7 @@ import { children, descendants, nextSiblings } from "./shared.js";
 import { assert, bench, describe, wrapper } from "./utils.js";
 import { TextExtension } from "../utils.js";
 
-void (await wrapper(async () => {
+void (await wrapper(() => {
   const Text = defineNode({ type: "text", state: { value: string("") } });
 
   // Helper function to create text nodes

--- a/tests/docsync-react/index.browser.test.tsx
+++ b/tests/docsync-react/index.browser.test.tsx
@@ -13,10 +13,12 @@ test("createDocSyncClient", async () => {
   const { useDoc } = createDocSyncClient({
     server: {
       url: "ws://localhost:8081",
+      // eslint-disable-next-line @typescript-eslint/require-await
       auth: { getToken: async () => "1234567890" as string },
     },
     local: {
       provider: IndexedDBProvider,
+      // eslint-disable-next-line @typescript-eslint/require-await
       getIdentity: async () => ({ userId: "John", secret: "asdasdasd" }),
     },
     docBinding: DocNodeBinding([docConfig]),

--- a/tests/docsync/int/auth.browser.test.ts
+++ b/tests/docsync/int/auth.browser.test.ts
@@ -18,10 +18,12 @@ const url = `ws://localhost:${globalThis.__TEST_SERVER_PORT__ ?? 8082}`;
 
 const createClient = (token: string) =>
   new DocSyncClient({
+    // eslint-disable-next-line @typescript-eslint/require-await
     server: { url, auth: { getToken: async () => token } },
     docBinding,
     local: {
       provider: IndexedDBProvider,
+      // eslint-disable-next-line @typescript-eslint/require-await
       getIdentity: async () => ({ userId: "u", secret: "s" }),
     },
   });

--- a/tests/docsync/int/globalSetup.ts
+++ b/tests/docsync/int/globalSetup.ts
@@ -59,6 +59,7 @@ export async function setup() {
     docBinding: DocNodeBinding([testDocConfig]),
     port: serverPort,
     provider: InMemoryServerProvider,
+    // eslint-disable-next-line @typescript-eslint/require-await
     authenticate: async ({ token }) => {
       const userId = parseTestToken(token);
       if (!userId) return undefined;

--- a/tests/docsync/int/utils.ts
+++ b/tests/docsync/int/utils.ts
@@ -178,11 +178,13 @@ const createClientWithConfig = (config: {
   const clientConfig: ClientConfig<Doc, JsonDoc, Operations> = {
     server: {
       url: getTestServerUrl(),
+      // eslint-disable-next-line @typescript-eslint/require-await
       auth: { getToken: async () => config.token },
     },
     docBinding: config.docBinding,
     local: {
       provider: IndexedDBProvider,
+      // eslint-disable-next-line @typescript-eslint/require-await
       getIdentity: async () => ({
         userId: config.userId,
         secret: "test-secret",

--- a/tests/docsync/ui/utils.ts
+++ b/tests/docsync/ui/utils.ts
@@ -56,6 +56,7 @@ export class HelperBase {
     this._otherDeviceHidden = page.locator("#otherDevice-hidden").first();
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await -- subclasses override as async
   static async create<T extends HelperBase>(
     this: new (page: Page, docId: string) => T,
     { page }: { page: Page },

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -587,6 +587,7 @@ describe("DocSyncClient", () => {
         constructor(_identity: Identity) {
           // Identity accepted but not used
         }
+        // eslint-disable-next-line @typescript-eslint/require-await -- sync implementation of async interface
         async transaction() {
           // eslint-disable-next-line @typescript-eslint/only-throw-error
           throw "string error message";

--- a/tests/docsync/unit/client/utils.ts
+++ b/tests/docsync/unit/client/utils.ts
@@ -136,6 +136,7 @@ export const createFailingProvider = (errorMessage: string) => {
     constructor(_identity: Identity) {
       // Identity accepted but not used in failing provider
     }
+    // eslint-disable-next-line @typescript-eslint/require-await -- sync implementation of async interface
     async transaction() {
       throw new Error(errorMessage);
     }

--- a/tests/docsync/unit/client/utils.ts
+++ b/tests/docsync/unit/client/utils.ts
@@ -48,11 +48,13 @@ const createValidConfig = (userId?: string) =>
   createClientConfig({
     server: {
       url: "ws://localhost:8081",
+      // eslint-disable-next-line @typescript-eslint/require-await
       auth: { getToken: async () => "test-token" },
     },
     docBinding: createMockDocBinding(),
     local: {
       provider: IndexedDBProvider,
+      // eslint-disable-next-line @typescript-eslint/require-await
       getIdentity: async () => ({
         userId: userId ?? generateTestUserId(),
         secret: "test-secret",
@@ -78,11 +80,13 @@ export const createClientWithDisposeSpy = (userId?: string) => {
   const config = createClientConfig({
     server: {
       url: "ws://localhost:8081",
+      // eslint-disable-next-line @typescript-eslint/require-await
       auth: { getToken: async () => "test-token" },
     },
     docBinding,
     local: {
       provider: IndexedDBProvider,
+      // eslint-disable-next-line @typescript-eslint/require-await
       getIdentity: async () => ({
         userId: userId ?? generateTestUserId(),
         secret: "test-secret",
@@ -148,11 +152,13 @@ export const createClientWithProvider = (
   const config = createClientConfig({
     server: {
       url: "ws://localhost:8081",
+      // eslint-disable-next-line @typescript-eslint/require-await
       auth: { getToken: async () => "test-token" },
     },
     docBinding: createMockDocBinding(),
     local: {
       provider: ProviderClass,
+      // eslint-disable-next-line @typescript-eslint/require-await
       getIdentity: async () => ({ userId: "test-user", secret: "test-secret" }),
     },
   });

--- a/tests/docsync/unit/client2/index.browser.test.ts
+++ b/tests/docsync/unit/client2/index.browser.test.ts
@@ -166,6 +166,7 @@ describe("Client 2", () => {
       const client = await createClient();
       const docId = generateDocId();
       let statusDuringPush: string | undefined;
+      // eslint-disable-next-line @typescript-eslint/require-await -- sync mock of async interface
       spyOnRequest(client).mockImplementation(async () => {
         statusDuringPush = client["_pushStatusByDocId"].get(docId);
         return { data: { docId, clock: 1 } };

--- a/tests/docsync/unit/client2/utils.ts
+++ b/tests/docsync/unit/client2/utils.ts
@@ -67,11 +67,13 @@ export const createClient = async () => {
   const config: ClientConfig<Doc, JsonDoc, Operations> = {
     server: {
       url: "ws://localhost:8081",
+      // eslint-disable-next-line @typescript-eslint/require-await
       auth: { getToken: async () => "test-token" },
     },
     docBinding,
     local: {
       provider: IndexedDBProvider,
+      // eslint-disable-next-line @typescript-eslint/require-await
       getIdentity: async () => ({ userId, secret: "test-secret" }),
     },
   };

--- a/tests/docsync/unit/server/events.test.ts
+++ b/tests/docsync/unit/server/events.test.ts
@@ -15,6 +15,7 @@ describe("Server Events", () => {
 
   describe("onClientConnect", () => {
     test("should emit when client successfully authenticates and connects", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user1" };
       await testWrapper({ auth }, async (T) => {
         let called = false;
@@ -33,6 +34,7 @@ describe("Server Events", () => {
         docBinding: DocNodeBinding([]),
         port: testPort(1),
         provider: InMemoryServerProvider,
+        // eslint-disable-next-line @typescript-eslint/require-await
         authenticate: async ({ token }) => {
           if (token === "admin-token") {
             return {
@@ -49,6 +51,7 @@ describe("Server Events", () => {
         capturedContext = event.context;
       });
 
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "admin-token" };
       await testWrapper(
         { auth, url: `ws://localhost:${testPort(1)}` },
@@ -66,6 +69,7 @@ describe("Server Events", () => {
     });
 
     test("should support multiple handlers", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user2" };
       await testWrapper({ auth }, async (T) => {
         let called1 = false;
@@ -90,6 +94,7 @@ describe("Server Events", () => {
         docBinding: DocNodeBinding([]),
         port: testPort(2),
         provider: InMemoryServerProvider,
+        // eslint-disable-next-line @typescript-eslint/require-await
         authenticate: async ({ token }) => {
           if (token.startsWith("valid-")) {
             return { userId: token.replace("valid-", "") };
@@ -104,6 +109,7 @@ describe("Server Events", () => {
       });
       unsubscribe();
 
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user3" };
       await testWrapper(
         { auth, url: `ws://localhost:${testPort(2)}` },
@@ -120,6 +126,7 @@ describe("Server Events", () => {
     });
 
     test("should include socketId", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user4" };
       await testWrapper({ auth }, async (T) => {
         let capturedEvent: ClientConnectEvent | undefined;
@@ -142,6 +149,7 @@ describe("Server Events", () => {
 
   describe("onClientDisconnect", () => {
     test("should emit when client disconnects normally", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user5" };
       await testWrapper({ auth }, async (T) => {
         let disconnectReason: string | undefined;
@@ -159,7 +167,7 @@ describe("Server Events", () => {
       });
     });
 
-    test("should emit when authentication fails", async () => {
+    test("should emit when authentication fails", () => {
       // TODO: This test requires registering handler before client connects
       // The current testWrapper API doesn't support this timing requirement
       // Skip for now
@@ -167,6 +175,7 @@ describe("Server Events", () => {
     });
 
     test("should support multiple handlers", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user6" };
       await testWrapper({ auth }, async (T) => {
         let called1 = false;
@@ -190,6 +199,7 @@ describe("Server Events", () => {
     });
 
     test("should allow unsubscribing", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user7" };
       await testWrapper({ auth }, async (T) => {
         let called = false;
@@ -208,6 +218,7 @@ describe("Server Events", () => {
     });
 
     test("should include disconnect reason", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user8" };
       await testWrapper({ auth }, async (T) => {
         let capturedEvent: ClientDisconnectEvent | undefined;
@@ -234,6 +245,7 @@ describe("Server Events", () => {
 
   describe("onSyncRequest", () => {
     test("should emit on successful sync request", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user9" };
       await testWrapper({ auth }, async (T) => {
         let capturedEvent: SyncRequestEvent | undefined;
@@ -268,12 +280,14 @@ describe("Server Events", () => {
         docBinding: DocNodeBinding([]),
         port: testPort(4),
         provider: InMemoryServerProvider,
+        // eslint-disable-next-line @typescript-eslint/require-await
         authenticate: async ({ token }) => {
           if (token.startsWith("valid-")) {
             return { userId: token.replace("valid-", "") };
           }
           return undefined;
         },
+        // eslint-disable-next-line @typescript-eslint/require-await
         authorize: async () => false, // Deny all operations
       });
 
@@ -282,6 +296,7 @@ describe("Server Events", () => {
         capturedStatus = event.status;
       });
 
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user10" };
       await testWrapper(
         { auth, url: `ws://localhost:${testPort(4)}` },
@@ -301,6 +316,7 @@ describe("Server Events", () => {
     });
 
     test("should include request context in all cases", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user11" };
       await testWrapper({ auth }, async (T) => {
         let capturedEvent: SyncRequestEvent | undefined;
@@ -325,6 +341,7 @@ describe("Server Events", () => {
     });
 
     test("should include duration when available", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user12" };
       await testWrapper({ auth }, async (T) => {
         let capturedEvent: SyncRequestEvent | undefined;
@@ -348,7 +365,7 @@ describe("Server Events", () => {
       });
     });
 
-    test("should include collaboration metrics when multiple clients", async () => {
+    test("should include collaboration metrics when multiple clients", () => {
       // This test requires two clients connecting to the same server
       // The testWrapper creates a new server for each call, so we skip this for now
       // TODO: Improve test infrastructure to support multiple clients to same server
@@ -356,6 +373,7 @@ describe("Server Events", () => {
     });
 
     test("should support multiple handlers", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user15" };
       await testWrapper({ auth }, async (T) => {
         let called1 = false;
@@ -381,6 +399,7 @@ describe("Server Events", () => {
     });
 
     test("should allow unsubscribing", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user16" };
       await testWrapper({ auth }, async (T) => {
         let called = false;
@@ -401,6 +420,7 @@ describe("Server Events", () => {
     });
 
     test("should include response data on success", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user17" };
       await testWrapper({ auth }, async (T) => {
         let capturedEvent: SyncRequestEvent | undefined;
@@ -423,6 +443,7 @@ describe("Server Events", () => {
     });
 
     test("should handle sync without operations (fetch only)", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user18" };
       await testWrapper({ auth }, async (T) => {
         let capturedEvent: SyncRequestEvent | undefined;
@@ -450,6 +471,7 @@ describe("Server Events", () => {
 
   describe("Event Order", () => {
     test("should emit events in correct order during connection lifecycle", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user19" };
       await testWrapper({ auth }, async (T) => {
         const events: string[] = [];
@@ -484,6 +506,7 @@ describe("Server Events", () => {
     });
 
     test("should emit multiple sync events in order", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user20" };
       await testWrapper({ auth }, async (T) => {
         const docIds: string[] = [];
@@ -525,12 +548,14 @@ describe("Server Events", () => {
         docBinding: DocNodeBinding([]),
         port: testPort(5),
         provider: InMemoryServerProvider,
+        // eslint-disable-next-line @typescript-eslint/require-await
         authenticate: async ({ token }) => {
           if (token.startsWith("valid-")) {
             return { userId: token.replace("valid-", "") };
           }
           return undefined;
         },
+        // eslint-disable-next-line @typescript-eslint/require-await
         authorize: async () => false,
       });
 
@@ -539,6 +564,7 @@ describe("Server Events", () => {
         capturedEvent = event;
       });
 
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user21" };
       await testWrapper(
         { auth, url: `ws://localhost:${testPort(5)}` },
@@ -564,6 +590,7 @@ describe("Server Events", () => {
     });
 
     test("onSyncRequest should accumulate optional fields as they become available", async () => {
+      // eslint-disable-next-line @typescript-eslint/require-await
       const auth = { getToken: async () => "valid-user22" };
       await testWrapper({ auth }, async (T) => {
         let capturedEvent: SyncRequestEvent | undefined;

--- a/tests/docsync/unit/server/index.test.ts
+++ b/tests/docsync/unit/server/index.test.ts
@@ -11,6 +11,7 @@ import type { ClientProvider } from "@docukit/docsync/client";
 
 describe("authentication", () => {
   test("rejects without token", async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
     const auth = { getToken: async () => "" };
     await testWrapper({ auth }, async (T) => {
       const error = await T.waitForError();
@@ -19,6 +20,7 @@ describe("authentication", () => {
   });
 
   test("rejects invalid token0", async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
     const auth = { getToken: async () => "test-token" };
     await testWrapper({ auth }, async (T) => {
       const error = await T.waitForError();
@@ -27,6 +29,7 @@ describe("authentication", () => {
   });
 
   test("accepts valid token", async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
     const auth = { getToken: async () => "valid-user1" };
     await testWrapper({ auth }, async (T) => {
       await T.waitForConnect();
@@ -48,6 +51,7 @@ describe("presence", () => {
       docBinding: DocNodeBinding([]),
       port,
       provider: InMemoryServerProvider,
+      // eslint-disable-next-line @typescript-eslint/require-await
       authenticate: async ({ token }) => {
         if (token.startsWith("valid-")) {
           return { userId: token.replace("valid-", "") };
@@ -157,6 +161,7 @@ describe("presence", () => {
       docBinding: DocNodeBinding([]),
       port,
       provider: InMemoryServerProvider,
+      // eslint-disable-next-line @typescript-eslint/require-await
       authenticate: async ({ token }) => {
         if (token.startsWith("valid-")) {
           return { userId: token.replace("valid-", "") };
@@ -220,6 +225,7 @@ function createMockDocSyncClient(port: number, token: string): DocSyncClient {
   return new DocSyncClient({
     server: {
       url: `ws://localhost:${port}`,
+      // eslint-disable-next-line @typescript-eslint/require-await
       auth: { getToken: async () => token },
     },
     local: {
@@ -227,6 +233,7 @@ function createMockDocSyncClient(port: number, token: string): DocSyncClient {
         identity: { userId: string; secret: string },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ) => ClientProvider<any, any>,
+      // eslint-disable-next-line @typescript-eslint/require-await
       getIdentity: async () => ({
         userId: token.replace("valid-", ""),
         secret: "test-secret",
@@ -238,6 +245,7 @@ function createMockDocSyncClient(port: number, token: string): DocSyncClient {
 
 describe("sync", () => {
   test("returns incremented clock", async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
     const auth = { getToken: async () => "valid-user1" };
     await testWrapper({ auth }, async (T) => {
       await T.waitForConnect();
@@ -256,6 +264,7 @@ describe("sync", () => {
   });
 
   test("squashes operations after threshold", async () => {
+    // eslint-disable-next-line @typescript-eslint/require-await
     const auth = { getToken: async () => "valid-user1" };
     await testWrapper({ auth }, async (T) => {
       await T.waitForConnect();
@@ -318,6 +327,7 @@ describe("authenticate/authorize: different function syntaxes", () => {
       provider: InMemoryServerProvider,
 
       // Method shorthand - most concise
+      // eslint-disable-next-line @typescript-eslint/require-await
       async authenticate({ token }) {
         if (token === "valid-token") {
           return {
@@ -328,6 +338,7 @@ describe("authenticate/authorize: different function syntaxes", () => {
         return undefined;
       },
 
+      // eslint-disable-next-line @typescript-eslint/require-await
       async authorize(ev) {
         // Type inference should work - ev should have context with role and permissions
         return ev.context.role === "admin";
@@ -356,6 +367,7 @@ describe("authenticate/authorize: different function syntaxes", () => {
       provider: InMemoryServerProvider,
 
       // Traditional function expression
+      // eslint-disable-next-line @typescript-eslint/require-await
       authenticate: async function ({ token }) {
         if (token === "valid-token") {
           return { userId: "user2", context: { isAdmin: true, level: 5 } };
@@ -363,6 +375,7 @@ describe("authenticate/authorize: different function syntaxes", () => {
         return undefined;
       },
 
+      // eslint-disable-next-line @typescript-eslint/require-await
       authorize: async function (ev) {
         // Type inference should work here too
         return ev.context.isAdmin && ev.context.level > 3;
@@ -391,6 +404,7 @@ describe("authenticate/authorize: different function syntaxes", () => {
       provider: InMemoryServerProvider,
 
       // Arrow function - most common in modern code
+      // eslint-disable-next-line @typescript-eslint/require-await
       authenticate: async ({ token }) => {
         if (token === "valid-token") {
           return {
@@ -404,6 +418,7 @@ describe("authenticate/authorize: different function syntaxes", () => {
         return undefined;
       },
 
+      // eslint-disable-next-line @typescript-eslint/require-await
       authorize: async (ev) => {
         // Type inference works perfectly with arrow functions
         return ev.context.tenantId.startsWith("tenant-");
@@ -431,6 +446,7 @@ describe("authenticate/authorize: different function syntaxes", () => {
       provider: InMemoryServerProvider,
 
       // Method shorthand for authenticate
+      // eslint-disable-next-line @typescript-eslint/require-await
       async authenticate({ token }) {
         if (token === "mixed-token") {
           return {
@@ -446,6 +462,7 @@ describe("authenticate/authorize: different function syntaxes", () => {
       },
 
       // Arrow function for authorize
+      // eslint-disable-next-line @typescript-eslint/require-await
       authorize: async (ev) => {
         return ev.context.quota > 500 && ev.context.flags.premium;
       },
@@ -479,6 +496,7 @@ describe("DocSyncServer assignability", () => {
         docBinding: DocNodeBinding([]),
         port: 0, // Let OS assign available port
         provider: InMemoryServerProvider,
+        // eslint-disable-next-line @typescript-eslint/require-await
         async authenticate({ token: _token }) {
           if (_token === "test") {
             return {
@@ -510,6 +528,7 @@ describe("DocSyncServer assignability", () => {
         docBinding: DocNodeBinding([]),
         port: 0, // Let OS assign available port
         provider: InMemoryServerProvider,
+        // eslint-disable-next-line @typescript-eslint/require-await
         async authenticate({ token: _token }) {
           return {
             userId: "user1",
@@ -542,6 +561,7 @@ describe("DocSyncServer assignability", () => {
         docBinding: DocNodeBinding([]),
         port: 0, // Let OS assign available port
         provider: InMemoryServerProvider,
+        // eslint-disable-next-line @typescript-eslint/require-await
         async authenticate({ token: _token }) {
           return { userId: "user1", context: { premium: true } };
         },
@@ -552,9 +572,11 @@ describe("DocSyncServer assignability", () => {
         docBinding: DocNodeBinding([]),
         port: 0, // Let OS assign available port
         provider: InMemoryServerProvider,
+        // eslint-disable-next-line @typescript-eslint/require-await
         async authenticate({ token: _token }) {
           return { userId: "user1", context: { premium: true } };
         },
+        // eslint-disable-next-line @typescript-eslint/require-await
         async authorize(ev) {
           return ev.context.premium;
         },
@@ -580,6 +602,7 @@ describe("DocSyncServer assignability", () => {
         docBinding: DocNodeBinding([]),
         port: 0, // Let OS assign available port
         provider: InMemoryServerProvider,
+        // eslint-disable-next-line @typescript-eslint/require-await
         async authenticate({ token: _token }) {
           return {
             userId: "user1",
@@ -633,6 +656,7 @@ describe("DocSyncServer assignability", () => {
         docBinding: DocNodeBinding([]),
         port: 0, // Let OS assign available port
         provider: InMemoryServerProvider,
+        // eslint-disable-next-line @typescript-eslint/require-await
         async authenticate({ token: _token }) {
           return { userId: "user1" }; // No context
         },
@@ -654,6 +678,7 @@ describe("DocSyncServer assignability", () => {
         docBinding: DocNodeBinding([]),
         port: 0, // Let OS assign available port
         provider: InMemoryServerProvider,
+        // eslint-disable-next-line @typescript-eslint/require-await
         async authenticate({ token: _token }) {
           return {
             userId: "user1",

--- a/tests/docsync/unit/server/utils.ts
+++ b/tests/docsync/unit/server/utils.ts
@@ -31,6 +31,7 @@ const createMockDocSyncClient = (serverOverrides?: {
   return new DocSyncClient({
     server: {
       url: serverOverrides?.url ?? `ws://localhost:${BASE_PORT}`,
+      // eslint-disable-next-line @typescript-eslint/require-await
       auth: serverOverrides?.auth ?? { getToken: async () => "test-token" },
     },
     local: {
@@ -38,6 +39,7 @@ const createMockDocSyncClient = (serverOverrides?: {
         identity: Identity,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ) => ClientProvider<any, any>,
+      // eslint-disable-next-line @typescript-eslint/require-await
       getIdentity: async () => ({ userId: "test-user", secret: "test-secret" }),
     },
     docBinding: DocNodeBinding([]),
@@ -49,6 +51,7 @@ const createServer = (port = BASE_PORT) => {
     docBinding: DocNodeBinding([testDocConfig]),
     port,
     provider: InMemoryServerProvider,
+    // eslint-disable-next-line @typescript-eslint/require-await
     authenticate: async ({ token }) => {
       if (token.startsWith("valid-")) {
         return { userId: token.replace("valid-", "") };


### PR DESCRIPTION
## Summary

- Removes `"@typescript-eslint/require-await": "off"` from `eslint.config.ts` to activate the rule.
- Removes `async` from functions that genuinely don't need it (`redirects`, `rewrites`, `generateStaticParams`, `setPresence`, `replaceDocInCache`, test callbacks).
- Adds `// eslint-disable-next-line @typescript-eslint/require-await` with explanatory comments for sync implementations of async interfaces (memory provider, test mocks, demo/example callbacks).
- No changes to public type definitions — all interfaces keep `Promise<T>`.

## Test plan

- [x] `eslint` passes with 0 `require-await` violations
- [x] `prettier --check .` passes
- [x] `turbo typecheck` passes (no new type errors)
- [x] `vitest` unit tests pass (115 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)