### PR TITLE
Run normalizers on init

### DIFF
--- a/packages/docnode/src/main.ts
+++ b/packages/docnode/src/main.ts
@@ -752,9 +752,8 @@ export class Doc {
     config.extensions.forEach((extension) => {
       extension.register?.(this);
     });
-    operations.maybeTriggerListeners(this, true);
     this._lifeCycleStage = "idle";
-    this.forceCommit();
+    this.forceCommit(true);
   }
 
   getNodeById(docNodeId: string): DocNode | undefined {
@@ -964,14 +963,14 @@ export class Doc {
    * Terminates the transaction early and synchronously, triggering events.
    * Using forceCommit is uncommon and can hurt your app's performance.
    */
-  forceCommit() {
+  forceCommit(ignoreEmptyDiff = false) {
     if (this._lifeCycleStage === "change")
       throw new Error("You can't trigger an update inside a change event");
     // push + reverse is more performant than unshift at insertion time
     this._inverseOperations[0].reverse();
     // End update stage before normalization
     this._lifeCycleStage = "idle";
-    operations.maybeTriggerListeners(this);
+    operations.maybeTriggerListeners(this, ignoreEmptyDiff);
     this._operations = [[], {}];
     this._inverseOperations = [[], {}];
     this._diff = {

--- a/packages/docnode/src/main.ts
+++ b/packages/docnode/src/main.ts
@@ -752,6 +752,7 @@ export class Doc {
     config.extensions.forEach((extension) => {
       extension.register?.(this);
     });
+    operations.maybeTriggerListeners(this, true);
     this._lifeCycleStage = "idle";
   }
 

--- a/packages/docnode/src/main.ts
+++ b/packages/docnode/src/main.ts
@@ -754,6 +754,7 @@ export class Doc {
     });
     operations.maybeTriggerListeners(this, true);
     this._lifeCycleStage = "idle";
+    this.forceCommit();
   }
 
   getNodeById(docNodeId: string): DocNode | undefined {

--- a/packages/docnode/src/operations.ts
+++ b/packages/docnode/src/operations.ts
@@ -310,7 +310,7 @@ export const onApplyOperations = (doc: Doc, operations: Operations) => {
 };
 
 /** We trigger listeners at the end of each update if there were operations (i.e. something changed) */
-export const maybeTriggerListeners = (doc: Doc) => {
+export const maybeTriggerListeners = (doc: Doc, forceNormalizers = false) => {
   const hasChanges = () => {
     const { inserted, deleted, moved } = doc["_diff"];
     return (
@@ -320,7 +320,7 @@ export const maybeTriggerListeners = (doc: Doc) => {
       !isObjectEmpty(doc["_operations"][1])
     );
   };
-  if (!hasChanges()) return;
+  if (!hasChanges() && !forceNormalizers) return;
   doc["_lifeCycleStage"] = "normalize";
   doc["_normalizeListeners"].forEach((listener) =>
     listener({ diff: doc["_diff"] }),

--- a/packages/docnode/src/operations.ts
+++ b/packages/docnode/src/operations.ts
@@ -310,7 +310,7 @@ export const onApplyOperations = (doc: Doc, operations: Operations) => {
 };
 
 /** We trigger listeners at the end of each update if there were operations (i.e. something changed) */
-export const maybeTriggerListeners = (doc: Doc, forceNormalizers = false) => {
+export const maybeTriggerListeners = (doc: Doc, ignoreEmptyDiff = false) => {
   const hasChanges = () => {
     const { inserted, deleted, moved } = doc["_diff"];
     return (
@@ -320,7 +320,7 @@ export const maybeTriggerListeners = (doc: Doc, forceNormalizers = false) => {
       !isObjectEmpty(doc["_operations"][1])
     );
   };
-  if (!hasChanges() && !forceNormalizers) return;
+  if (!hasChanges() && !ignoreEmptyDiff) return;
   doc["_lifeCycleStage"] = "normalize";
   doc["_normalizeListeners"].forEach((listener) =>
     listener({ diff: doc["_diff"] }),

--- a/tests/docnode/lifecycle.test.ts
+++ b/tests/docnode/lifecycle.test.ts
@@ -234,13 +234,15 @@ describe("doc.onNormalize", () => {
       strictMode: false,
     });
 
+    expect(callOrder).toStrictEqual([1, 2]);
+
     checkUndoManager(1, doc, () => {
       const node = doc.createNode(Text);
       node.state.value.set("test");
       doc.root.append(node);
     });
 
-    expect(callOrder).toStrictEqual([1, 2]);
+    expect(callOrder).toStrictEqual([1, 2, 1, 2]);
   });
 
   test("onNormalize can mutate the document", () => {
@@ -265,17 +267,7 @@ describe("doc.onNormalize", () => {
       strictMode: false,
     });
 
-    // Initially, root should be empty
-    expect(doc.root.first).toBeFalsy();
-
-    checkUndoManager(1, doc, () => {
-      // Trigger a transaction that will call normalize
-      const text = doc.createNode(Text);
-      text.state.value.set("test");
-      doc.root.append(text);
-    });
-
-    // After the transaction, there should be at least the text node we added
+    // Initially, root should have a container node
     expect(doc.root.first).toBeTruthy();
   });
 
@@ -313,15 +305,12 @@ describe("doc.onNormalize", () => {
   });
 
   test("onNormalize callback can access document state", () => {
-    let normalizeRan = false;
-
     const TestExtension: Extension = {
       nodes: [Text],
       register: (doc) => {
         doc.onNormalize(() => {
           // Ensure we always have at least one text node
           if (!doc.root.first) {
-            normalizeRan = true;
             const node = doc.createNode(Text);
             node.state.value.set("default");
             doc.root.append(node);
@@ -336,22 +325,50 @@ describe("doc.onNormalize", () => {
       strictMode: false,
     });
 
-    // Root should be empty initially
-    expect(doc.root.first).toBeFalsy();
-
-    // Add a node
-    const node = doc.createNode(Text);
-    node.state.value.set("temp");
-    doc.root.append(node);
-    doc.forceCommit();
-    expect(doc.root.first).toBeTruthy();
-
-    // Delete it, which will trigger normalize to add default
-    node.delete();
+    assertDoc(doc, ["default"]);
+    // Delete the node which will trigger normalize to add default
+    doc.root.first!.delete();
+    assertDoc(doc, []);
     doc.forceCommit();
 
     // After normalize, there should be a default text node
-    expect(normalizeRan).toBe(true);
+    assertDoc(doc, ["default"]);
+  });
+
+  test("There is an initial transaction separate from the subsequent update", () => {
+    // Note: this is on purpose the same as the test above, but
+    // the title is different because it test different things.
+    const TestExtension: Extension = {
+      nodes: [Text],
+      register: (doc) => {
+        doc.onNormalize(() => {
+          // Ensure we always have at least one text node
+          if (!doc.root.first) {
+            const node = doc.createNode(Text);
+            node.state.value.set("default");
+            doc.root.append(node);
+          }
+        });
+      },
+    };
+
+    const doc = new Doc({
+      type: "root",
+      extensions: [TestExtension],
+      strictMode: false,
+    });
+
+    assertDoc(doc, ["default"]);
+    // Delete the node which will trigger normalize to add default
+    doc.root.first!.delete();
+    assertDoc(doc, []);
+    doc.forceCommit();
+
+    // If it weren't for the `forceCommit` that `main`
+    // has after the register events, the `delete` would
+    // be considered part of the same transaction, and
+    // we would have square brackets here because `normalize`
+    // wouldn't trigger again
     assertDoc(doc, ["default"]);
   });
 });
@@ -370,18 +387,9 @@ describe("onNormalize in strict mode", () => {
       },
     };
 
-    const doc = new Doc({
-      type: "root",
-      extensions: [TestExtension],
-      strictMode: true,
-    });
-
     // This should throw because normalize keeps mutating on second pass
     expect(() => {
-      const node = doc.createNode(Text);
-      node.state.value.set("initial");
-      doc.root.append(node);
-      doc.forceCommit();
+      new Doc({ type: "root", extensions: [TestExtension], strictMode: true });
     }).toThrowError(
       /Strict mode has caught an error: normalize listeners are not idempotent. I.e, they should not mutate the document on the second pass./,
     );
@@ -411,18 +419,9 @@ describe("onNormalize in strict mode", () => {
       },
     };
 
-    const doc = new Doc({
-      type: "root",
-      extensions: [TestExtension],
-      strictMode: true,
-    });
-
     // In strict mode, this should throw because normalize keeps adding nodes
     expect(() => {
-      const node = doc.createNode(Text);
-      node.state.value.set("initial");
-      doc.root.append(node);
-      doc.forceCommit();
+      new Doc({ type: "root", extensions: [TestExtension], strictMode: true });
     }).toThrowError(
       /Strict mode has caught an error: normalize listeners are not idempotent. I.e, they should not mutate the document on the second pass./,
     );
@@ -532,8 +531,7 @@ describe("lifecycle transitions", () => {
     stages.push(doc["_lifeCycleStage"] as string);
 
     // Should start in init, then move to idle
-    expect(stages[0]).toBe("init");
-    expect(stages[1]).toBe("idle");
+    expect(stages).toStrictEqual(["init", "normalize", "normalize2", "idle"]);
 
     checkUndoManager(1, doc, () => {
       const node = doc.createNode(Text);

--- a/tests/docnode/lifecycle.test.ts
+++ b/tests/docnode/lifecycle.test.ts
@@ -118,6 +118,26 @@ describe("register lifecycle", () => {
     assertDoc(doc, ["test"]);
   });
 
+  test("onChange fires only once for init normalizer mutations", () => {
+    const changeLogs: number[] = [];
+    const TestExtension: Extension = {
+      nodes: [Text],
+      register: (doc) => {
+        doc.onNormalize(() => {
+          if (doc.root.first) return;
+          const node = doc.createNode(Text);
+          node.state.value.set("initial");
+          doc.root.append(node);
+        });
+        doc.onChange(() => {
+          changeLogs.push(1);
+        });
+      },
+    };
+    new Doc({ type: "root", extensions: [TestExtension] });
+    expect(changeLogs).toStrictEqual([1]);
+  });
+
   test("can register change event inside and outside register", () => {
     const logs: string[] = [];
     const doc = new Doc({

--- a/tests/docnode/lifecycle.test.ts
+++ b/tests/docnode/lifecycle.test.ts
@@ -99,9 +99,23 @@ describe("register lifecycle", () => {
       },
     };
     const doc = new Doc({ type: "root", extensions: [TestExtension] });
-    assertDoc(doc, ["test"]);
-    doc.forceCommit();
     assertDoc(doc, ["test", "test2"]);
+  });
+
+  test("normalizer is called onInit", () => {
+    const TestExtension: Extension = {
+      nodes: [Text],
+      register: (doc) => {
+        doc.onNormalize(() => {
+          if (doc.root.first) return;
+          const node = doc.createNode(Text);
+          node.state.value.set("test");
+          doc.root.append(node);
+        });
+      },
+    };
+    const doc = new Doc({ type: "root", extensions: [TestExtension] });
+    assertDoc(doc, ["test"]);
   });
 
   test("can register change event inside and outside register", () => {
@@ -601,6 +615,7 @@ describe("onNormalize edge cases", () => {
       nodes: [Text],
       register: (doc) => {
         doc.onNormalize(() => {
+          if (!doc.root.first) return;
           throw new Error("Normalize error");
         });
       },

--- a/tests/docnode/state.test.ts
+++ b/tests/docnode/state.test.ts
@@ -120,7 +120,6 @@ describe("getState", () => {
     expect(x1.state.string.get()).toStrictEqual("foo");
   });
   test("in normalize and change events", () => {
-    let firstNormalize = true;
     const doc = new Doc({
       type: "root",
       extensions: [
@@ -134,7 +133,7 @@ describe("getState", () => {
               expect(x1.state.string.get()).toStrictEqual("baz");
             });
             doc.onNormalize(() => {
-              if (firstNormalize) return;
+              if (!doc.root.first) return;
               expect(stage).toBe(1);
               stage++;
               const x1 = doc.root.first as DocNode<typeof TestNode>;
@@ -142,10 +141,7 @@ describe("getState", () => {
               x1.state.string.set("bar");
             });
             doc.onNormalize(() => {
-              if (firstNormalize) {
-                firstNormalize = false;
-                return;
-              }
+              if (!doc.root.first) return;
               expect(stage).toBe(2);
               stage++;
               const x1 = doc.root.first as DocNode<typeof TestNode>;

--- a/tests/docnode/state.test.ts
+++ b/tests/docnode/state.test.ts
@@ -120,6 +120,7 @@ describe("getState", () => {
     expect(x1.state.string.get()).toStrictEqual("foo");
   });
   test("in normalize and change events", () => {
+    let firstNormalize = true;
     const doc = new Doc({
       type: "root",
       extensions: [
@@ -133,6 +134,7 @@ describe("getState", () => {
               expect(x1.state.string.get()).toStrictEqual("baz");
             });
             doc.onNormalize(() => {
+              if (firstNormalize) return;
               expect(stage).toBe(1);
               stage++;
               const x1 = doc.root.first as DocNode<typeof TestNode>;
@@ -140,6 +142,10 @@ describe("getState", () => {
               x1.state.string.set("bar");
             });
             doc.onNormalize(() => {
+              if (firstNormalize) {
+                firstNormalize = false;
+                return;
+              }
               expect(stage).toBe(2);
               stage++;
               const x1 = doc.root.first as DocNode<typeof TestNode>;
@@ -309,6 +315,7 @@ describe("getPrev", () => {
           register(doc) {
             doc.onNormalize(() => {
               const node = doc.root.last as DocNode<typeof Text>;
+              if (!node) return;
               if (node.state.value.get() === "") {
                 expect(() => node.state.value.getPrev()).toThrowError(
                   getPrevError,


### PR DESCRIPTION
Normalizers now run during `Doc` initialization, so extensions can establish document invariants (e.g., ensuring a default node exists) without requiring an explicit user transaction.