### PR TITLE
chore: custom release workflow (bump CLI, validator, publisher, /release skill)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: release
+description: Orchestrate a DocuKit release end-to-end. Guides the user through branch creation, bump, sanity-check, changelog drafting, approval, and PR opening. Use this whenever the user says "release", "cut a release", or invokes /release.
+---
+
+# Release orchestration
+
+You drive the entire release flow. The user should not have to remember any step — you ask for confirmation at each gate and do the mechanical work in between.
+
+Do not run `pnpm bump` yourself (it is interactive). Do not commit/push until the user explicitly approves the changelog.
+
+## Phase 1 — branch
+
+1. Check `git status --porcelain`. If dirty, stop and tell the user to commit/stash first.
+2. Check the current branch with `git rev-parse --abbrev-ref HEAD`.
+3. If on `main`, create `release/pending` (or similar) from `origin/main`: `git fetch origin main && git checkout -b release/pending origin/main`.
+4. If already on a non-main branch, ask the user: "You are on `<branch>`. Keep this branch for the release, or branch off `origin/main`?"
+5. Confirm the branch to the user before moving on.
+
+## Phase 2 — bump
+
+Tell the user to run `pnpm bump` in their terminal and follow the prompts. The script is interactive; do not try to run it non-interactively.
+
+When the user reports the bump is done, continue.
+
+## Phase 3 — sanity check the bump (no user action)
+
+Silently verify the bump makes sense. If anything is off, flag it to the user before drafting notes.
+
+1. Run `git diff --name-only` — should show only `*/package.json` files. Flag anything else.
+2. Read each bumped `package.json` and confirm all publishable packages agree on `major.minor.patch`. Alpha packages may carry `-alpha.N`.
+3. Derive the target release tag:
+   - If at least one publishable package is stable (no `-alpha.`), tag = `v<major>.<minor>.<patch>`.
+   - Otherwise (alpha-only release), tag = `v<major>.<minor>.<patch>-alpha.<N>`.
+4. Determine the baseline: the most recent `changelog/v*.md` file, or the first commit if none exists.
+5. Count commits between baseline and HEAD (`git log BASELINE..HEAD --no-merges --oneline | wc -l`). If zero, stop — there is nothing to release.
+6. Look at the magnitude of the bump (patch / minor / major / alpha) and compare it to what you'll discover in Phase 4. If in Phase 4 you find breaking changes but the user picked `patch`, or no user-facing changes but they picked `major`, say so before drafting — the user may want to re-bump.
+
+## Phase 4 — draft changelog
+
+Produce two files: `changelog/<tag>.md` (committed) and `changelog/<tag>_DISCORD.md` (gitignored).
+
+### Investigating the diff
+
+This repo does **not** use conventional commits. Commit titles are hints, not truth — breaking changes will **not** reliably be marked. You must read the diff itself.
+
+Commands:
+
+- `git log BASELINE..HEAD --no-merges --format='%h %s'` — short SHAs + titles (hints)
+- `git diff BASELINE..HEAD -- packages/` — the substantive diff
+- `git diff BASELINE..HEAD -- 'packages/*/package.json'` — exports/peerDeps/deps shifts
+
+Classify every change into: **Breaking**, **Features**, **Fixes**, **Docs**, **Internal**.
+
+**Breaking-change patterns — hunt actively:**
+
+- Removed or renamed exports in `src/exports/` (deletions; renamed files)
+- Changed function/method signatures: params added/removed/reordered/retyped
+- Changed return types on public functions
+- Renamed, removed, or retyped fields on exported types/interfaces
+- Changed default behavior on the same inputs (behavior change with no API change still breaks consumers that depend on it)
+- `exports` field changes in `package.json`: removed subpaths, reordered `types`/`default`
+- Peer-dep range bumps that force consumer upgrades
+- Removed or renamed public constants/enums
+
+For every breaking change, include a **Migration:** note that tells the consumer exactly what to change.
+
+**Features / Fixes / Docs / Internal:**
+
+- **Features**: new public exports, new options/props, new subpaths.
+- **Fixes**: behavior-correcting diffs in existing code paths with no API change.
+- **Docs**: changes under `docs/`. Only note if user-facing.
+- **Internal**: tests, CI, build, refactors with no external effect. Keep short.
+
+Attribute each bullet to a PR number (squash-merge titles often end with `(#123)`) or a short SHA.
+
+### Template — `changelog/<tag>.md`
+
+```
+# <tag> — YYYY-MM-DD
+
+## Breaking changes
+
+- [Short description.] **Migration:** [what the consumer changes]. (#123)
+
+## Features
+
+- [Description] (#124)
+
+## Fixes
+
+- [Description] (#125)
+
+## Docs
+
+- ...
+
+## Internal
+
+- ...
+```
+
+Rules:
+
+- If no breaking changes were found, write `_No breaking changes in this release._` under that section. **Do not omit the section** — explicit emptiness lets a reviewer catch a false negative.
+- Keep bullets user-facing. "Renamed `foo` → `bar`" — not "refactored internal foo helpers".
+- Group bullets that share a migration.
+- Omit empty Features/Fixes/Docs/Internal sections silently — only Breaking is mandatory.
+
+Use today's date from the environment.
+
+### Discord sibling — `changelog/<tag>_DISCORD.md`
+
+Same content, transformed:
+
+- **No `#` headings.** Use `**BREAKING CHANGES**`, `**FEATURES**`, etc. in bold+caps.
+- Emojis per section: 🚨 Breaking, ✨ Features, 🐛 Fixes, 📚 Docs, 🛠 Internal.
+- URLs as plain text — paste `https://github.com/docukit/docukit/pull/123` literally. **No `[text](url)` markdown link syntax.**
+- Open with a one-line summary: `🚀 DocuKit <tag> released!` then a blank line.
+- Keep it skimmable.
+
+This file is gitignored (`changelog/*_DISCORD.md`) — never let it be committed.
+
+## Phase 5 — approval
+
+Show the user:
+
+1. The path of both changelog files.
+2. Breaking-change count (prominently if non-zero).
+3. Total commit count you analyzed.
+4. A short snippet of the changelog (first ~20 lines) inline.
+5. "Review `<path>` and tell me: approve, revise, or abort."
+
+Wait for explicit approval before continuing. If the user asks for revisions, edit the file and re-show. Do not proceed on implicit agreement.
+
+## Phase 6 — commit and push
+
+On approval:
+
+1. `git add changelog/<tag>.md packages/*/package.json` — plus `docs/package.json` / `examples/package.json` only if their versions were bumped (they should not be, but check).
+2. Verify `git status` shows only expected files. If `_DISCORD.md` shows up, abort and check `.gitignore`.
+3. `git commit -m "chore: release <tag>"`.
+4. `git push -u origin HEAD`.
+
+## Phase 7 — open the PR
+
+`gh pr create --base main --title "chore: release <tag>" --body "Release PR. See \`changelog/<tag>.md\` for notes."`
+
+Report the PR URL back. Remind the user:
+
+- The `validate` workflow job runs on PR open — it should turn green.
+- Merging into main (squash merge) triggers the `publish` job, which pushes to npm and creates the GitHub release.
+- The Discord copy is ready at `changelog/<tag>_DISCORD.md` for after publish.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -13,7 +13,7 @@ Do not run `pnpm bump` yourself (it is interactive). Do not commit/push until th
 
 1. Check `git status --porcelain`. If dirty, stop and tell the user to commit/stash first.
 2. Check the current branch with `git rev-parse --abbrev-ref HEAD`.
-3. If on `main`, create `release/pending` (or similar) from `origin/main`: `git fetch origin main && git checkout -b release/pending origin/main`.
+3. If on `main`, create a release branch from `origin/main`. Use the intended version if known (e.g. `release/v0.3.2`); otherwise use a placeholder you'll rename once the bump fixes the version: `git fetch origin main && git checkout -b release/pending origin/main`.
 4. If already on a non-main branch, ask the user: "You are on `<branch>`. Keep this branch for the release, or branch off `origin/main`?"
 5. Confirm the branch to the user before moving on.
 
@@ -27,14 +27,13 @@ When the user reports the bump is done, continue.
 
 Silently verify the bump makes sense. If anything is off, flag it to the user before drafting notes.
 
-1. Run `git diff --name-only` — should show only `*/package.json` files. Flag anything else.
+1. Run `git diff --name-only` — should show only `packages/*/package.json` files. Flag anything else.
 2. Read each bumped `package.json` and confirm all publishable packages agree on `major.minor.patch`. Alpha packages may carry `-alpha.N`.
 3. Derive the target release tag:
    - If at least one publishable package is stable (no `-alpha.`), tag = `v<major>.<minor>.<patch>`.
    - Otherwise (alpha-only release), tag = `v<major>.<minor>.<patch>-alpha.<N>`.
 4. Determine the baseline: the most recent `changelog/v*.md` file, or the first commit if none exists.
 5. Count commits between baseline and HEAD (`git log BASELINE..HEAD --no-merges --oneline | wc -l`). If zero, stop — there is nothing to release.
-6. Look at the magnitude of the bump (patch / minor / major / alpha) and compare it to what you'll discover in Phase 4. If in Phase 4 you find breaking changes but the user picked `patch`, or no user-facing changes but they picked `major`, say so before drafting — the user may want to re-bump.
 
 ## Phase 4 — draft changelog
 
@@ -51,6 +50,8 @@ Commands:
 - `git diff BASELINE..HEAD -- 'packages/*/package.json'` — exports/peerDeps/deps shifts
 
 Classify every change into: **Breaking**, **Features**, **Fixes**, **Docs**, **Internal**.
+
+**Before drafting, sanity-check the bump magnitude against what you find.** If the user picked `patch` but the diff contains breaking changes, or picked `major` but nothing is user-facing, surface that to the user before writing the changelog — they may want to `pnpm bump` again with a different kind.
 
 **Breaking-change patterns — hunt actively:**
 
@@ -137,8 +138,8 @@ Wait for explicit approval before continuing. If the user asks for revisions, ed
 
 On approval:
 
-1. `git add changelog/<tag>.md packages/*/package.json` — plus `docs/package.json` / `examples/package.json` only if their versions were bumped (they should not be, but check).
-2. Verify `git status` shows only expected files. If `_DISCORD.md` shows up, abort and check `.gitignore`.
+1. `git add changelog/<tag>.md packages/*/package.json`.
+2. Verify `git status` shows only expected files. If `_DISCORD.md` shows up, abort and check `.gitignore`. If `docs/package.json` or `examples/package.json` appear, abort — those are private and should never change during a release.
 3. `git commit -m "chore: release <tag>"`.
 4. `git push -u origin HEAD`.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    if: "github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'chore: release v')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: "pnpm"
+
+      - name: Validate release PR
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: node scripts/validate-release-pr.ts
+
+  publish:
+    if: "github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore: release v')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: release-publish
+      cancel-in-progress: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers (for browser tests)
+        run: pnpm exec playwright install chromium
+
+      - name: Build
+        run: pnpm build
+
+      - name: Lint, format, typecheck
+        run: pnpm check
+
+      - name: Tests
+        run: pnpm test:ci
+
+      - name: Publish to npm
+        id: publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: node scripts/publish.ts
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.publish.outputs.release_tag }}"
+          if [ -z "$TAG" ]; then
+            echo "✖ release_tag output not set — aborting release creation"
+            exit 1
+          fi
+          NOTES="changelog/${TAG}.md"
+          if [ ! -f "$NOTES" ]; then
+            echo "✖ changelog file $NOTES not found"
+            exit 1
+          fi
+          gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
+
+      - name: Deploy docs to Vercel
+        working-directory: docs
+        env:
+          VERCEL_ORG_ID: team_fCh184rIrqEO1RmklNmEH6dR
+          VERCEL_PROJECT_ID: prj_6hZQc795Nzc7Vuh7CTpS4yJhbblR
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          npx vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+          npx vercel build --prod --token=$VERCEL_TOKEN
+          npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,17 +59,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright browsers (for browser tests)
-        run: pnpm exec playwright install chromium
-
       - name: Build
         run: pnpm build
-
-      - name: Lint, format, typecheck
-        run: pnpm check
-
-      - name: Tests
-        run: pnpm test:ci
 
       - name: Publish to npm
         id: publish
@@ -100,6 +91,6 @@ jobs:
           VERCEL_PROJECT_ID: prj_6hZQc795Nzc7Vuh7CTpS4yJhbblR
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          npx vercel pull --yes --environment=production --token=$VERCEL_TOKEN
-          npx vercel build --prod --token=$VERCEL_TOKEN
-          npx vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN
+          npx vercel@51 pull --yes --environment=production
+          npx vercel@51 build --prod
+          npx vercel@51 deploy --prebuilt --prod

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ tsconfig.vitest-temp.json
 .contentlayer
 .content-collections
 .source
+
+# release notes — discord variant is not intended to be committed
+changelog/*_DISCORD.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,10 @@ By submitting a contribution to this repository, you agree to the following:
 
 ## Release Process
 
-1. **Update version in `package.json`**
-   - Modify **only** the `version` field of the packages you are releasing.
-   - Commit the changes to `main` with the message: `chore: release v${version}`
+Releases are driven end-to-end by the `/release` skill in Claude Code. From a clean working tree, run:
 
-2. **Publish packages to npm**
-   - `npm login`
-   - `pnpm publish`. You'll need to add the 2FA code with --otp=XXXXXX.
+```
+/release
+```
 
-3. **Create GitHub release notes**
-   - Use Automatic Release Notes. Assign a tag v${version} to the commit you created in step 1.
+The skill walks you through every step: creating the release branch, running `pnpm bump`, sanity-checking the bump, drafting the changelog, reviewing, and opening the PR. Merging the resulting `chore: release v<version>` PR into `main` triggers the GitHub Actions workflow that publishes to npm and creates the GitHub release.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@docukit/docs",
-  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docukit/docs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -120,6 +120,7 @@ export const rootEslintConfig = tseslint.config(
             "**/drizzle.config.ts",
             "**/*.config.ts",
             "**/benchmarks/**",
+            "scripts/**",
           ],
         },
       ],

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,5 @@
 {
   "name": "examples",
-  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "examples",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     ]
   },
   "devDependencies": {
+    "@clack/prompts": "^1.2.0",
     "@playwright/test": "1.51.0",
     "@types/node": "^22.10.7",
     "@vitejs/plugin-react": "^5.1.2",
@@ -58,12 +59,13 @@
     "eslint-plugin-barrel-files": "^3.0.1",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-playwright": "^2.2.0",
-    "eslint-plugin-regexp": "^2.10.0",
     "eslint-plugin-prefer-inline-types": "^1.0.3",
+    "eslint-plugin-regexp": "^2.10.0",
     "jiti": "^2.4.2",
     "knip": "^5.82.1",
     "lint-staged": "15.4.1",
     "mitata": "^1.0.34",
+    "picocolors": "^1.1.1",
     "playwright": "1.51.0",
     "prettier": "3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@docukit/monorepo",
   "private": true,
   "engines": {
-    "node": ">=22"
+    "node": ">=22.18"
   },
   "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
@@ -30,8 +30,7 @@
     "bench:vitest": "vitest bench",
     "bench:bun": "MITATA=1 bun run tests/core/benchmarks/iterators.bench.ts",
     "dev:docnode": "pnpm --filter @docukit/docnode dev",
-    "publish-docnode": "pnpm build && pnpm check && pnpm test:ci && pnpm publish --filter '@docukit/docnode*' --access public",
-    "publish-docsync": "pnpm build && pnpm check && pnpm test:ci && pnpm publish --filter '@docukit/docsync*' --access public --tag alpha"
+    "bump": "node scripts/bump.ts"
   },
   "packageManager": "pnpm@9.10.0",
   "lint-staged": {

--- a/packages/docnode-lexical/package.json
+++ b/packages/docnode-lexical/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docukit/docnode-lexical",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://docukit.dev",

--- a/packages/docnode/package.json
+++ b/packages/docnode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docukit/docnode",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "description": "Type-safe documents with conflict resolution. Faster than any CRDT.",
   "type": "module",

--- a/packages/docsync-react/package.json
+++ b/packages/docsync-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docukit/docsync-react",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.1-alpha.2",
   "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "homepage": "https://docukit.dev/docsync",

--- a/packages/docsync/package.json
+++ b/packages/docsync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docukit/docsync",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.1-alpha.2",
   "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "homepage": "https://docukit.dev/docsync",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@clack/prompts':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@playwright/test':
         specifier: 1.51.0
         version: 1.51.0
@@ -71,6 +74,9 @@ importers:
       mitata:
         specifier: ^1.0.34
         version: 1.0.34
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
       playwright:
         specifier: 1.51.0
         version: 1.51.0
@@ -649,6 +655,12 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@clack/core@1.2.0':
+    resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
+
+  '@clack/prompts@1.2.0':
+    resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -3545,6 +3557,7 @@ packages:
 
   bun@1.3.6:
     resolution: {integrity: sha512-Tn98GlZVN2WM7+lg/uGn5DzUao37Yc0PUz7yzYHdeF5hd+SmHQGbCUIKE4Sspdgtxn49LunK3mDNBC2Qn6GJjw==}
+    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -4105,7 +4118,6 @@ packages:
     resolution: {integrity: sha512-/baBXDqkfW8x0UlqfYAfRCkmVWiH8qFZ4uhT6yLVBLssiypDTbe78W6lNBse7huBFv1ipR5PG9evkxEnIXDxjA==}
     peerDependencies:
       eslint: '>= 5'
-    bundledDependencies: []
 
   eslint-plugin-import@2.32.0:
     resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
@@ -4250,6 +4262,15 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-string-truncated-width@1.2.1:
+    resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
+
+  fast-string-width@1.1.0:
+    resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
+  fast-wrap-ansi@0.1.6:
+    resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
 
   fast-xml-parser@5.2.5:
     resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
@@ -5803,6 +5824,9 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slice-ansi@5.0.0:
     resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
     engines: {node: '>=12'}
@@ -6950,6 +6974,18 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@clack/core@1.2.0':
+    dependencies:
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.2.0':
+    dependencies:
+      '@clack/core': 1.2.0
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -10477,6 +10513,16 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
+    dependencies:
+      fast-string-truncated-width: 1.2.1
+
+  fast-wrap-ansi@0.1.6:
+    dependencies:
+      fast-string-width: 1.1.0
+
   fast-xml-parser@5.2.5:
     dependencies:
       strnum: 2.1.1
@@ -12469,6 +12515,8 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  sisteransi@1.0.5: {}
 
   slice-ansi@5.0.0:
     dependencies:

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -9,7 +9,18 @@ import {
 import { execSync } from "node:child_process";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import readline from "node:readline";
+import {
+  intro,
+  outro,
+  select,
+  confirm,
+  note,
+  log,
+  cancel,
+  isCancel,
+  spinner,
+} from "@clack/prompts";
+import pc from "picocolors";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -25,18 +36,14 @@ type DistTags = { latest?: string; alpha?: string };
 type Mode = "stable" | "alpha";
 type Kind = "major" | "minor" | "patch";
 
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-});
-const ask = (q: string): Promise<string> =>
-  new Promise((r) => rl.question(q, r));
-const fail = (msg: string): never => {
-  console.error(`\n✖ ${msg}\n`);
-  rl.close();
+const abort = (msg: string): never => {
+  cancel(msg);
   process.exit(1);
 };
-const info = (msg: string) => console.log(msg);
+const unwrap = <T>(value: T | symbol, msg = "Cancelled."): T => {
+  if (isCancel(value)) abort(msg);
+  return value as T;
+};
 
 function readWorkspaceGlobs(): string[] {
   const yaml = readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8");
@@ -102,6 +109,11 @@ function formatVersion(v: Version): string {
   const base = `${v.major}.${v.minor}.${v.patch}`;
   return v.alpha === undefined ? base : `${base}-alpha.${v.alpha}`;
 }
+const compareBase = (a: Version, b: Version): number => {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+};
 const isAlpha = (pkg: Package) => !!pkg.version?.includes("-alpha.");
 const isPublishable = (pkg: Package) => !pkg.private && !!pkg.version;
 
@@ -111,8 +123,8 @@ function assertCleanTree() {
     encoding: "utf8",
   }).trim();
   if (dirty) {
-    fail(
-      `working tree is not clean — commit or stash changes before bumping.\nUncommitted:\n${dirty}`,
+    abort(
+      `Working tree is not clean — commit or stash changes before bumping.\n${dirty}`,
     );
   }
 }
@@ -122,7 +134,7 @@ function assertVersionConsistency(pkgs: Loaded[]) {
   for (const { pkg } of pkgs) {
     const parsed =
       parseVersion(pkg.version) ??
-      fail(`${pkg.name} has invalid version "${pkg.version}"`);
+      abort(`${pkg.name} has invalid version "${pkg.version}"`);
     const key = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
     const arr = groups.get(key) ?? [];
     arr.push(pkg.name);
@@ -132,8 +144,8 @@ function assertVersionConsistency(pkgs: Loaded[]) {
     const lines = [...groups.entries()].map(
       ([k, v]) => `  ${k}: ${v.join(", ")}`,
     );
-    fail(
-      `publishable packages disagree on major.minor.patch — fix before bumping:\n${lines.join("\n")}`,
+    abort(
+      `Publishable packages disagree on major.minor.patch:\n${lines.join("\n")}`,
     );
   }
 }
@@ -187,6 +199,7 @@ function applyBump(
 type GuardResult = { ok: true } | { ok: false; reason: string };
 function guardrail(
   publishedVersion: string,
+  local: Version,
   proposed: Version,
   mode: Mode,
   kind: Kind | undefined,
@@ -198,13 +211,27 @@ function guardrail(
       ok: false,
       reason: `published version "${publishedVersion}" is unparseable`,
     };
+
+  if (mode === "alpha") {
+    // Local base is ahead of the registry (pending unpublished stable bump).
+    // The first alpha on this new base is legitimate — accept it.
+    if (compareBase(local, published) > 0) return { ok: true };
+    // Same base: proposed.alpha must be exactly published.alpha + 1.
+    if (published.alpha === undefined) return { ok: true };
+    if (proposed.alpha !== published.alpha + 1) {
+      return {
+        ok: false,
+        reason: `proposed=${formatVersion(proposed)} but expected=${formatVersion({ ...local, alpha: published.alpha + 1 })} (published alpha: ${publishedVersion})`,
+      };
+    }
+    return { ok: true };
+  }
+
   const expected = applyBump(published, mode, kind, wasAlpha);
-  const proposedStr = formatVersion(proposed);
-  const expectedStr = formatVersion(expected);
-  if (proposedStr !== expectedStr) {
+  if (formatVersion(proposed) !== formatVersion(expected)) {
     return {
       ok: false,
-      reason: `proposed=${proposedStr} but expected=${expectedStr} (published: ${publishedVersion})`,
+      reason: `proposed=${formatVersion(proposed)} but expected=${formatVersion(expected)} (published: ${publishedVersion})`,
     };
   }
   return { ok: true };
@@ -218,69 +245,84 @@ type PlanEntry = Loaded & {
 };
 
 (async () => {
-  info("DocuKit release bump\n");
+  intro(pc.bold(pc.cyan("DocuKit release bump")));
 
-  info("• Checking working tree...");
+  const s = spinner();
+  s.start("Checking working tree and registry");
   assertCleanTree();
-
-  info("• Scanning workspace packages...");
   const dirs = expandGlobs(readWorkspaceGlobs());
   const loaded = dirs
     .map(loadPackage)
     .filter((e): e is Loaded => e !== undefined);
   const publishable = loaded.filter(({ pkg }) => isPublishable(pkg));
-  if (publishable.length === 0) fail("no publishable packages found.");
-
-  info("• Asserting version consistency...");
+  if (publishable.length === 0) {
+    s.stop("No publishable packages found");
+    abort("No publishable packages found.");
+  }
   assertVersionConsistency(publishable);
-
-  info("• Querying npm registry...");
   const distTags: Record<string, DistTags | undefined> = {};
   for (const { pkg } of publishable) {
     distTags[pkg.name] = queryNpmDistTags(pkg.name);
   }
+  s.stop(`Scanned ${publishable.length} publishable package(s)`);
 
   const alphaPkgs = publishable.filter(({ pkg }) => isAlpha(pkg));
 
-  info("\nPublishable packages:");
-  for (const { pkg } of publishable) {
-    const tagged = isAlpha(pkg) ? " [alpha]" : "";
+  const pkgLines = publishable.map(({ pkg }) => {
     const tags = distTags[pkg.name];
+    const tagged = isAlpha(pkg) ? pc.yellow(" [alpha]") : "";
     const registry = tags
-      ? `latest=${tags.latest ?? "-"} alpha=${tags.alpha ?? "-"}`
-      : "never published";
-    info(`  ${pkg.name}@${pkg.version}${tagged}  (registry: ${registry})`);
-  }
+      ? pc.dim(`latest=${tags.latest ?? "—"}  alpha=${tags.alpha ?? "—"}`)
+      : pc.dim("never published");
+    return `${pc.bold(pkg.name)}${pc.dim("@")}${pkg.version}${tagged}\n  ${registry}`;
+  });
+  note(pkgLines.join("\n"), "Publishable packages");
 
-  info("\nBump mode:");
-  info(
-    "  (a) Stable — bumps ALL publishable packages (alpha counter resets to 1)",
+  const mode = unwrap(
+    await select<Mode>({
+      message: "Bump mode",
+      options: [
+        {
+          value: "stable",
+          label: "Stable",
+          hint: "bumps ALL publishable packages (alpha counter resets to 1)",
+        },
+        {
+          value: "alpha",
+          label: "Alpha",
+          hint: "bumps alpha packages only (alpha.N → alpha.N+1)",
+        },
+      ],
+    }),
   );
-  info("  (b) Alpha — bumps alpha packages only (alpha.N → alpha.N+1)");
-  const modeAns = (await ask("Pick (a/b): ")).trim().toLowerCase();
-  const mode: Mode =
-    modeAns === "a" || modeAns === "stable"
-      ? "stable"
-      : modeAns === "b" || modeAns === "alpha"
-        ? "alpha"
-        : fail(`unknown mode "${modeAns}"`);
 
   let kind: Kind | undefined;
   if (mode === "stable") {
-    const k = (await ask("  major | minor | patch: ")).trim().toLowerCase();
-    if (!["major", "minor", "patch"].includes(k)) fail(`unknown kind "${k}"`);
-    kind = k as Kind;
+    kind = unwrap(
+      await select<Kind>({
+        message: "Release kind",
+        options: [
+          { value: "patch", label: "patch", hint: "x.y.Z" },
+          { value: "minor", label: "minor", hint: "x.Y.0" },
+          { value: "major", label: "major", hint: "X.0.0" },
+        ],
+      }),
+    );
   } else {
-    if (alphaPkgs.length === 0) fail("no alpha packages to bump.");
-    info(
-      "\n⚠  In this monorepo, alpha packages publish with BOTH `alpha` and `latest` dist-tags.",
+    if (alphaPkgs.length === 0) abort("No alpha packages to bump.");
+    log.warn(
+      pc.yellow(
+        "Alpha packages publish with BOTH `alpha` and `latest` dist-tags.\n" +
+          "After publish, `npm install @docukit/<pkg>` (no tag) returns the new alpha.",
+      ),
     );
-    info(
-      "   After publish, `npm install @docukit/<pkg>` (no tag) will return the new alpha.",
+    const ok = unwrap(
+      await confirm({
+        message: "Continue with an alpha bump?",
+        initialValue: false,
+      }),
     );
-    info("   Only proceed if that is intended.");
-    const conf = (await ask('Type "yes" to continue: ')).trim();
-    if (conf !== "yes") fail("aborted.");
+    if (!ok) abort("Aborted.");
   }
 
   const targets = mode === "alpha" ? alphaPkgs : publishable;
@@ -290,7 +332,7 @@ type PlanEntry = Loaded & {
   for (const entry of targets) {
     const parsed =
       parseVersion(entry.pkg.version) ??
-      fail(`${entry.pkg.name}: cannot parse "${entry.pkg.version}"`);
+      abort(`${entry.pkg.name}: cannot parse "${entry.pkg.version}"`);
     const wasAlpha = isAlpha(entry.pkg);
     const next = applyBump(parsed, mode, kind, wasAlpha);
     const tag = mode === "alpha" ? "alpha" : wasAlpha ? "alpha" : "latest";
@@ -305,7 +347,7 @@ type PlanEntry = Loaded & {
         `${entry.pkg.name}: proposed ${formatVersion(next)} is ALREADY on the registry`,
       );
     } else {
-      const g = guardrail(publishedVersion, next, mode, kind, wasAlpha);
+      const g = guardrail(publishedVersion, parsed, next, mode, kind, wasAlpha);
       if (!g.ok) {
         status = "warning";
         warnings.push(`${entry.pkg.name}: ${g.reason}`);
@@ -315,51 +357,46 @@ type PlanEntry = Loaded & {
   }
 
   if (hardErrors.length) {
-    fail(
-      "cannot bump — the proposed version is already on the registry:\n  " +
+    abort(
+      "Proposed version is already on the registry:\n  " +
         hardErrors.join("\n  "),
     );
   }
 
-  info("\nProposed bumps:");
-  for (const p of plan) {
+  const planLines = plan.map((p) => {
     const badge =
       p.status === "first-publish"
-        ? " [FIRST PUBLISH]"
+        ? pc.green("  [first publish]")
         : p.status === "warning"
-          ? " [UNUSUAL — see warnings below]"
+          ? pc.yellow("  [unusual]")
           : "";
     const pub = p.publishedVersion ?? "(unpublished)";
-    info(
-      `  ${p.pkg.name}  ${formatVersion(p.parsed)}  →  ${formatVersion(p.next)}  (registry: ${pub})${badge}`,
-    );
-  }
+    return `${pc.bold(p.pkg.name)}  ${formatVersion(p.parsed)} ${pc.dim("→")} ${pc.green(formatVersion(p.next))}${badge}\n  ${pc.dim(`registry: ${pub}`)}`;
+  });
+  note(planLines.join("\n"), "Proposed bumps");
 
   if (warnings.length) {
-    info(
-      "\n⚠  Unusual bump — local versions are not exactly +1 from the registry:",
+    log.warn(
+      pc.yellow(
+        "Unusual bump — local versions are not exactly +1 from the registry:\n" +
+          warnings.map((w) => `  ${w}`).join("\n") +
+          "\nThis usually means a previous release was bumped locally but never published.\n" +
+          "The publish workflow is idempotent — publishing the pending release first is simplest.",
+      ),
     );
-    for (const w of warnings) info(`     ${w}`);
-    info(
-      "   This usually means a previous release was bumped locally but never published.",
+    const ok = unwrap(
+      await confirm({
+        message: "Continue with this bump anyway?",
+        initialValue: false,
+      }),
     );
-    info(
-      "   The publish workflow is idempotent — the simplest fix is to publish the pending",
-    );
-    info(
-      "   release first (re-run the workflow) rather than stacking another bump.",
-    );
-    const ok = (await ask("\nContinue with this bump anyway? [y/N]: "))
-      .trim()
-      .toLowerCase();
-    if (ok !== "y" && ok !== "yes") fail("aborted.");
+    if (!ok) abort("Aborted.");
   }
 
-  const conf = (await ask("\nWrite these changes? [y/N]: "))
-    .trim()
-    .toLowerCase();
-  if (conf !== "y" && conf !== "yes") fail("aborted.");
-  rl.close();
+  const write = unwrap(
+    await confirm({ message: "Write these changes?", initialValue: true }),
+  );
+  if (!write) abort("Aborted.");
 
   for (const p of plan) {
     const newV = formatVersion(p.next);
@@ -377,23 +414,17 @@ type PlanEntry = Loaded & {
     a.pkg.name.localeCompare(b.pkg.name),
   )[0];
   const tagSource =
-    stableEntry ?? fallback ?? fail("internal: no plan entries after bump");
+    stableEntry ?? fallback ?? abort("internal: no plan entries after bump");
   const releaseStr =
     tagSource.next.alpha === undefined
       ? `v${tagSource.next.major}.${tagSource.next.minor}.${tagSource.next.patch}`
       : `v${formatVersion(tagSource.next)}`;
 
-  info(`\n✓ Bumped ${plan.length} package(s).\n`);
-  info("Next steps:");
-  info(
-    `  Return to the /release skill session — it will verify, draft the changelog,`,
-  );
-  info(`  and handle commit + push + PR for release ${releaseStr}.`);
-  info(
-    `  (If not using /release: run /release to orchestrate, or do it manually:`,
-  );
-  info(
-    `   commit as "chore: release ${releaseStr}", open a PR with that title, squash-merge.)\n`,
+  outro(
+    `${pc.green(`✓ Bumped ${plan.length} package(s).`)} ` +
+      pc.dim(
+        `Return to the /release skill — next release: ${pc.bold(releaseStr)}.`,
+      ),
   );
 })().catch((err: unknown) => {
   console.error(err);

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+import {
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  statSync,
+  existsSync,
+} from "node:fs";
+import { execSync } from "node:child_process";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import readline from "node:readline";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+type Version = {
+  major: number;
+  minor: number;
+  patch: number;
+  alpha: number | null;
+};
+type Package = { name: string; version?: string; private?: boolean };
+type Loaded = { dir: string; pkgPath: string; raw: string; pkg: Package };
+type DistTags = { latest?: string; alpha?: string } | null;
+type Mode = "stable" | "alpha";
+type Kind = "major" | "minor" | "patch";
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+const ask = (q: string): Promise<string> =>
+  new Promise((r) => rl.question(q, r));
+const fail = (msg: string): never => {
+  console.error(`\n✖ ${msg}\n`);
+  rl.close();
+  process.exit(1);
+};
+const info = (msg: string) => console.log(msg);
+
+function readWorkspaceGlobs(): string[] {
+  const yaml = readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8");
+  const globs: string[] = [];
+  for (const line of yaml.split("\n")) {
+    const m = line.match(/^\s*-\s*["']?([^"']+?)["']?\s*$/);
+    if (m) globs.push(m[1]);
+  }
+  return globs;
+}
+
+function expandGlobs(globs: string[]): string[] {
+  const dirs = new Set<string>();
+  for (const g of globs) {
+    if (g.endsWith("/*")) {
+      const baseDir = join(ROOT, g.slice(0, -2));
+      if (!existsSync(baseDir)) continue;
+      for (const entry of readdirSync(baseDir)) {
+        const full = join(baseDir, entry);
+        if (statSync(full).isDirectory()) dirs.add(full);
+      }
+    } else {
+      const full = join(ROOT, g);
+      if (existsSync(full) && statSync(full).isDirectory()) dirs.add(full);
+    }
+  }
+  return [...dirs];
+}
+
+function loadPackage(dir: string): Loaded | null {
+  const pkgPath = join(dir, "package.json");
+  if (!existsSync(pkgPath)) return null;
+  const raw = readFileSync(pkgPath, "utf8");
+  return { dir, pkgPath, raw, pkg: JSON.parse(raw) };
+}
+
+const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:-alpha\.(\d+))?$/;
+function parseVersion(v: string | undefined): Version | null {
+  const m = v?.match(VERSION_RE);
+  return m
+    ? {
+        major: +m[1],
+        minor: +m[2],
+        patch: +m[3],
+        alpha: m[4] == null ? null : +m[4],
+      }
+    : null;
+}
+function formatVersion(v: Version): string {
+  const base = `${v.major}.${v.minor}.${v.patch}`;
+  return v.alpha == null ? base : `${base}-alpha.${v.alpha}`;
+}
+const isAlpha = (pkg: Package) => !!pkg.version?.includes("-alpha.");
+const isPublishable = (pkg: Package) => !pkg.private && !!pkg.version;
+
+function assertCleanTree() {
+  const dirty = execSync("git status --porcelain", {
+    cwd: ROOT,
+    encoding: "utf8",
+  }).trim();
+  if (dirty) {
+    fail(
+      `working tree is not clean — commit or stash changes before bumping.\nUncommitted:\n${dirty}`,
+    );
+  }
+}
+
+function assertVersionConsistency(pkgs: Loaded[]) {
+  const groups = new Map<string, string[]>();
+  for (const { pkg } of pkgs) {
+    const parsed = parseVersion(pkg.version);
+    if (!parsed) fail(`${pkg.name} has invalid version "${pkg.version}"`);
+    const key = `${parsed!.major}.${parsed!.minor}.${parsed!.patch}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(pkg.name);
+  }
+  if (groups.size > 1) {
+    const lines = [...groups.entries()].map(
+      ([k, v]) => `  ${k}: ${v.join(", ")}`,
+    );
+    fail(
+      `publishable packages disagree on major.minor.patch — fix before bumping:\n${lines.join("\n")}`,
+    );
+  }
+}
+
+function queryNpmDistTags(name: string): DistTags {
+  try {
+    const out = execSync(`npm view ${name} dist-tags --json 2>/dev/null`, {
+      encoding: "utf8",
+    }).trim();
+    return out ? JSON.parse(out) : null;
+  } catch {
+    return null;
+  }
+}
+
+function bumpStable(parsed: Version, kind: Kind): Version {
+  if (kind === "major")
+    return { major: parsed.major + 1, minor: 0, patch: 0, alpha: null };
+  if (kind === "minor")
+    return {
+      major: parsed.major,
+      minor: parsed.minor + 1,
+      patch: 0,
+      alpha: null,
+    };
+  return {
+    major: parsed.major,
+    minor: parsed.minor,
+    patch: parsed.patch + 1,
+    alpha: null,
+  };
+}
+
+function applyBump(
+  parsed: Version,
+  mode: Mode,
+  kind: Kind | null,
+  wasAlpha: boolean,
+): Version {
+  if (mode === "stable") {
+    const next = bumpStable(parsed, kind!);
+    if (wasAlpha) next.alpha = 1;
+    return next;
+  }
+  if (parsed.alpha == null)
+    throw new Error("cannot alpha-bump a non-alpha package");
+  return { ...parsed, alpha: parsed.alpha + 1 };
+}
+
+type GuardResult = { ok: true } | { ok: false; reason: string };
+function guardrail(
+  publishedVersion: string,
+  proposed: Version,
+  mode: Mode,
+  kind: Kind | null,
+  wasAlpha: boolean,
+): GuardResult {
+  const published = parseVersion(publishedVersion);
+  if (!published)
+    return {
+      ok: false,
+      reason: `published version "${publishedVersion}" is unparseable`,
+    };
+  const expected = applyBump(published, mode, kind, wasAlpha);
+  const proposedStr = formatVersion(proposed);
+  const expectedStr = formatVersion(expected);
+  if (proposedStr !== expectedStr) {
+    return {
+      ok: false,
+      reason: `proposed=${proposedStr} but expected=${expectedStr} (published: ${publishedVersion})`,
+    };
+  }
+  return { ok: true };
+}
+
+type PlanEntry = Loaded & {
+  parsed: Version;
+  next: Version;
+  status: "ok" | "first-publish" | "warning";
+  publishedVersion: string | null;
+};
+
+(async () => {
+  info("DocuKit release bump\n");
+
+  info("• Checking working tree...");
+  assertCleanTree();
+
+  info("• Scanning workspace packages...");
+  const dirs = expandGlobs(readWorkspaceGlobs());
+  const loaded = dirs.map(loadPackage).filter((e): e is Loaded => e != null);
+  const publishable = loaded.filter(({ pkg }) => isPublishable(pkg));
+  if (publishable.length === 0) fail("no publishable packages found.");
+
+  info("• Asserting version consistency...");
+  assertVersionConsistency(publishable);
+
+  info("• Querying npm registry...");
+  const distTags: Record<string, DistTags> = {};
+  for (const { pkg } of publishable) {
+    distTags[pkg.name] = queryNpmDistTags(pkg.name);
+  }
+
+  const alphaPkgs = publishable.filter(({ pkg }) => isAlpha(pkg));
+
+  info("\nPublishable packages:");
+  for (const { pkg } of publishable) {
+    const tagged = isAlpha(pkg) ? " [alpha]" : "";
+    const tags = distTags[pkg.name];
+    const registry = tags
+      ? `latest=${tags.latest ?? "-"} alpha=${tags.alpha ?? "-"}`
+      : "never published";
+    info(`  ${pkg.name}@${pkg.version}${tagged}  (registry: ${registry})`);
+  }
+
+  info("\nBump mode:");
+  info(
+    "  (a) Stable — bumps ALL publishable packages (alpha counter resets to 1)",
+  );
+  info("  (b) Alpha — bumps alpha packages only (alpha.N → alpha.N+1)");
+  const modeAns = (await ask("Pick (a/b): ")).trim().toLowerCase();
+  const mode: Mode | null =
+    modeAns === "a" || modeAns === "stable"
+      ? "stable"
+      : modeAns === "b" || modeAns === "alpha"
+        ? "alpha"
+        : null;
+  if (!mode) fail(`unknown mode "${modeAns}"`);
+
+  let kind: Kind | null = null;
+  if (mode === "stable") {
+    const k = (await ask("  major | minor | patch: ")).trim().toLowerCase();
+    if (!["major", "minor", "patch"].includes(k)) fail(`unknown kind "${k}"`);
+    kind = k as Kind;
+  } else {
+    if (alphaPkgs.length === 0) fail("no alpha packages to bump.");
+    info(
+      "\n⚠  In this monorepo, alpha packages publish with BOTH `alpha` and `latest` dist-tags.",
+    );
+    info(
+      "   After publish, `npm install @docukit/<pkg>` (no tag) will return the new alpha.",
+    );
+    info("   Only proceed if that is intended.");
+    const conf = (await ask('Type "yes" to continue: ')).trim();
+    if (conf !== "yes") fail("aborted.");
+  }
+
+  const targets = mode === "alpha" ? alphaPkgs : publishable;
+  const plan: PlanEntry[] = [];
+  const hardErrors: string[] = [];
+  const warnings: string[] = [];
+  for (const entry of targets) {
+    const parsed = parseVersion(entry.pkg.version)!;
+    const wasAlpha = isAlpha(entry.pkg);
+    const next = applyBump(parsed, mode!, kind, wasAlpha);
+    const tag = mode === "alpha" ? "alpha" : wasAlpha ? "alpha" : "latest";
+    const publishedVersion = distTags[entry.pkg.name]?.[tag] ?? null;
+
+    let status: PlanEntry["status"] = "ok";
+    if (!publishedVersion) {
+      status = "first-publish";
+    } else if (formatVersion(next) === publishedVersion) {
+      status = "warning";
+      hardErrors.push(
+        `${entry.pkg.name}: proposed ${formatVersion(next)} is ALREADY on the registry`,
+      );
+    } else {
+      const g = guardrail(publishedVersion, next, mode!, kind, wasAlpha);
+      if (!g.ok) {
+        status = "warning";
+        warnings.push(`${entry.pkg.name}: ${g.reason}`);
+      }
+    }
+    plan.push({ ...entry, parsed, next, status, publishedVersion });
+  }
+
+  if (hardErrors.length) {
+    fail(
+      "cannot bump — the proposed version is already on the registry:\n  " +
+        hardErrors.join("\n  "),
+    );
+  }
+
+  info("\nProposed bumps:");
+  for (const p of plan) {
+    const badge =
+      p.status === "first-publish"
+        ? " [FIRST PUBLISH]"
+        : p.status === "warning"
+          ? " [UNUSUAL — see warnings below]"
+          : "";
+    const pub = p.publishedVersion ?? "(unpublished)";
+    info(
+      `  ${p.pkg.name}  ${formatVersion(p.parsed)}  →  ${formatVersion(p.next)}  (registry: ${pub})${badge}`,
+    );
+  }
+
+  if (warnings.length) {
+    info(
+      "\n⚠  Unusual bump — local versions are not exactly +1 from the registry:",
+    );
+    for (const w of warnings) info(`     ${w}`);
+    info(
+      "   This usually means a previous release was bumped locally but never published.",
+    );
+    info(
+      "   The publish workflow is idempotent — the simplest fix is to publish the pending",
+    );
+    info(
+      "   release first (re-run the workflow) rather than stacking another bump.",
+    );
+    const ok = (await ask("\nContinue with this bump anyway? [y/N]: "))
+      .trim()
+      .toLowerCase();
+    if (ok !== "y" && ok !== "yes") fail("aborted.");
+  }
+
+  const conf = (await ask("\nWrite these changes? [y/N]: "))
+    .trim()
+    .toLowerCase();
+  if (conf !== "y" && conf !== "yes") fail("aborted.");
+  rl.close();
+
+  for (const p of plan) {
+    const newV = formatVersion(p.next);
+    const updated = p.raw.replace(
+      /("version"\s*:\s*")[^"]+(")/,
+      (_m, a, b) => `${a}${newV}${b}`,
+    );
+    writeFileSync(p.pkgPath, updated);
+  }
+
+  // Release tag: prefer stable (non-alpha) versions. If all bumps are alpha-only, include -alpha.N.
+  const stableEntry = plan.find((p) => p.next.alpha == null);
+  const releaseStr = stableEntry
+    ? `v${stableEntry.next.major}.${stableEntry.next.minor}.${stableEntry.next.patch}`
+    : `v${formatVersion(plan[0].next)}`;
+
+  info(`\n✓ Bumped ${plan.length} package(s).\n`);
+  info("Next steps:");
+  info(
+    `  Return to the /release skill session — it will verify, draft the changelog,`,
+  );
+  info(`  and handle commit + push + PR for release ${releaseStr}.`);
+  info(
+    `  (If not using /release: run /release to orchestrate, or do it manually:`,
+  );
+  info(
+    `   commit as "chore: release ${releaseStr}", open a PR with that title, squash-merge.)\n`,
+  );
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/bump.ts
+++ b/scripts/bump.ts
@@ -17,11 +17,11 @@ type Version = {
   major: number;
   minor: number;
   patch: number;
-  alpha: number | null;
+  alpha: number | undefined;
 };
 type Package = { name: string; version?: string; private?: boolean };
 type Loaded = { dir: string; pkgPath: string; raw: string; pkg: Package };
-type DistTags = { latest?: string; alpha?: string } | null;
+type DistTags = { latest?: string; alpha?: string };
 type Mode = "stable" | "alpha";
 type Kind = "major" | "minor" | "patch";
 
@@ -42,8 +42,16 @@ function readWorkspaceGlobs(): string[] {
   const yaml = readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8");
   const globs: string[] = [];
   for (const line of yaml.split("\n")) {
-    const m = line.match(/^\s*-\s*["']?([^"']+?)["']?\s*$/);
-    if (m) globs.push(m[1]);
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("-")) continue;
+    let rest = trimmed.slice(1).trim();
+    if (
+      (rest.startsWith('"') && rest.endsWith('"')) ||
+      (rest.startsWith("'") && rest.endsWith("'"))
+    ) {
+      rest = rest.slice(1, -1);
+    }
+    if (rest) globs.push(rest);
   }
   return globs;
 }
@@ -66,28 +74,33 @@ function expandGlobs(globs: string[]): string[] {
   return [...dirs];
 }
 
-function loadPackage(dir: string): Loaded | null {
+function loadPackage(dir: string): Loaded | undefined {
   const pkgPath = join(dir, "package.json");
-  if (!existsSync(pkgPath)) return null;
+  if (!existsSync(pkgPath)) return undefined;
   const raw = readFileSync(pkgPath, "utf8");
-  return { dir, pkgPath, raw, pkg: JSON.parse(raw) };
+  const pkg = JSON.parse(raw) as Package;
+  return { dir, pkgPath, raw, pkg };
 }
 
 const VERSION_RE = /^(\d+)\.(\d+)\.(\d+)(?:-alpha\.(\d+))?$/;
-function parseVersion(v: string | undefined): Version | null {
-  const m = v?.match(VERSION_RE);
-  return m
-    ? {
-        major: +m[1],
-        minor: +m[2],
-        patch: +m[3],
-        alpha: m[4] == null ? null : +m[4],
-      }
-    : null;
+function parseVersion(v: string | undefined): Version | undefined {
+  if (v === undefined) return undefined;
+  const m = VERSION_RE.exec(v);
+  if (!m) return undefined;
+  const [, major, minor, patch, alpha] = m;
+  if (major === undefined || minor === undefined || patch === undefined) {
+    return undefined;
+  }
+  return {
+    major: +major,
+    minor: +minor,
+    patch: +patch,
+    alpha: alpha === undefined ? undefined : +alpha,
+  };
 }
 function formatVersion(v: Version): string {
   const base = `${v.major}.${v.minor}.${v.patch}`;
-  return v.alpha == null ? base : `${base}-alpha.${v.alpha}`;
+  return v.alpha === undefined ? base : `${base}-alpha.${v.alpha}`;
 }
 const isAlpha = (pkg: Package) => !!pkg.version?.includes("-alpha.");
 const isPublishable = (pkg: Package) => !pkg.private && !!pkg.version;
@@ -107,11 +120,13 @@ function assertCleanTree() {
 function assertVersionConsistency(pkgs: Loaded[]) {
   const groups = new Map<string, string[]>();
   for (const { pkg } of pkgs) {
-    const parsed = parseVersion(pkg.version);
-    if (!parsed) fail(`${pkg.name} has invalid version "${pkg.version}"`);
-    const key = `${parsed!.major}.${parsed!.minor}.${parsed!.patch}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key)!.push(pkg.name);
+    const parsed =
+      parseVersion(pkg.version) ??
+      fail(`${pkg.name} has invalid version "${pkg.version}"`);
+    const key = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+    const arr = groups.get(key) ?? [];
+    arr.push(pkg.name);
+    groups.set(key, arr);
   }
   if (groups.size > 1) {
     const lines = [...groups.entries()].map(
@@ -123,47 +138,48 @@ function assertVersionConsistency(pkgs: Loaded[]) {
   }
 }
 
-function queryNpmDistTags(name: string): DistTags {
+function queryNpmDistTags(name: string): DistTags | undefined {
   try {
     const out = execSync(`npm view ${name} dist-tags --json 2>/dev/null`, {
       encoding: "utf8",
     }).trim();
-    return out ? JSON.parse(out) : null;
+    return out ? (JSON.parse(out) as DistTags) : undefined;
   } catch {
-    return null;
+    return undefined;
   }
 }
 
 function bumpStable(parsed: Version, kind: Kind): Version {
   if (kind === "major")
-    return { major: parsed.major + 1, minor: 0, patch: 0, alpha: null };
+    return { major: parsed.major + 1, minor: 0, patch: 0, alpha: undefined };
   if (kind === "minor")
     return {
       major: parsed.major,
       minor: parsed.minor + 1,
       patch: 0,
-      alpha: null,
+      alpha: undefined,
     };
   return {
     major: parsed.major,
     minor: parsed.minor,
     patch: parsed.patch + 1,
-    alpha: null,
+    alpha: undefined,
   };
 }
 
 function applyBump(
   parsed: Version,
   mode: Mode,
-  kind: Kind | null,
+  kind: Kind | undefined,
   wasAlpha: boolean,
 ): Version {
   if (mode === "stable") {
-    const next = bumpStable(parsed, kind!);
+    if (!kind) throw new Error("stable bump requires kind");
+    const next = bumpStable(parsed, kind);
     if (wasAlpha) next.alpha = 1;
     return next;
   }
-  if (parsed.alpha == null)
+  if (parsed.alpha === undefined)
     throw new Error("cannot alpha-bump a non-alpha package");
   return { ...parsed, alpha: parsed.alpha + 1 };
 }
@@ -173,7 +189,7 @@ function guardrail(
   publishedVersion: string,
   proposed: Version,
   mode: Mode,
-  kind: Kind | null,
+  kind: Kind | undefined,
   wasAlpha: boolean,
 ): GuardResult {
   const published = parseVersion(publishedVersion);
@@ -198,7 +214,7 @@ type PlanEntry = Loaded & {
   parsed: Version;
   next: Version;
   status: "ok" | "first-publish" | "warning";
-  publishedVersion: string | null;
+  publishedVersion: string | undefined;
 };
 
 (async () => {
@@ -209,7 +225,9 @@ type PlanEntry = Loaded & {
 
   info("• Scanning workspace packages...");
   const dirs = expandGlobs(readWorkspaceGlobs());
-  const loaded = dirs.map(loadPackage).filter((e): e is Loaded => e != null);
+  const loaded = dirs
+    .map(loadPackage)
+    .filter((e): e is Loaded => e !== undefined);
   const publishable = loaded.filter(({ pkg }) => isPublishable(pkg));
   if (publishable.length === 0) fail("no publishable packages found.");
 
@@ -217,7 +235,7 @@ type PlanEntry = Loaded & {
   assertVersionConsistency(publishable);
 
   info("• Querying npm registry...");
-  const distTags: Record<string, DistTags> = {};
+  const distTags: Record<string, DistTags | undefined> = {};
   for (const { pkg } of publishable) {
     distTags[pkg.name] = queryNpmDistTags(pkg.name);
   }
@@ -240,15 +258,14 @@ type PlanEntry = Loaded & {
   );
   info("  (b) Alpha — bumps alpha packages only (alpha.N → alpha.N+1)");
   const modeAns = (await ask("Pick (a/b): ")).trim().toLowerCase();
-  const mode: Mode | null =
+  const mode: Mode =
     modeAns === "a" || modeAns === "stable"
       ? "stable"
       : modeAns === "b" || modeAns === "alpha"
         ? "alpha"
-        : null;
-  if (!mode) fail(`unknown mode "${modeAns}"`);
+        : fail(`unknown mode "${modeAns}"`);
 
-  let kind: Kind | null = null;
+  let kind: Kind | undefined;
   if (mode === "stable") {
     const k = (await ask("  major | minor | patch: ")).trim().toLowerCase();
     if (!["major", "minor", "patch"].includes(k)) fail(`unknown kind "${k}"`);
@@ -271,11 +288,13 @@ type PlanEntry = Loaded & {
   const hardErrors: string[] = [];
   const warnings: string[] = [];
   for (const entry of targets) {
-    const parsed = parseVersion(entry.pkg.version)!;
+    const parsed =
+      parseVersion(entry.pkg.version) ??
+      fail(`${entry.pkg.name}: cannot parse "${entry.pkg.version}"`);
     const wasAlpha = isAlpha(entry.pkg);
-    const next = applyBump(parsed, mode!, kind, wasAlpha);
+    const next = applyBump(parsed, mode, kind, wasAlpha);
     const tag = mode === "alpha" ? "alpha" : wasAlpha ? "alpha" : "latest";
-    const publishedVersion = distTags[entry.pkg.name]?.[tag] ?? null;
+    const publishedVersion = distTags[entry.pkg.name]?.[tag];
 
     let status: PlanEntry["status"] = "ok";
     if (!publishedVersion) {
@@ -286,7 +305,7 @@ type PlanEntry = Loaded & {
         `${entry.pkg.name}: proposed ${formatVersion(next)} is ALREADY on the registry`,
       );
     } else {
-      const g = guardrail(publishedVersion, next, mode!, kind, wasAlpha);
+      const g = guardrail(publishedVersion, next, mode, kind, wasAlpha);
       if (!g.ok) {
         status = "warning";
         warnings.push(`${entry.pkg.name}: ${g.reason}`);
@@ -346,16 +365,23 @@ type PlanEntry = Loaded & {
     const newV = formatVersion(p.next);
     const updated = p.raw.replace(
       /("version"\s*:\s*")[^"]+(")/,
-      (_m, a, b) => `${a}${newV}${b}`,
+      (_m, a: string, b: string) => `${a}${newV}${b}`,
     );
     writeFileSync(p.pkgPath, updated);
   }
 
-  // Release tag: prefer stable (non-alpha) versions. If all bumps are alpha-only, include -alpha.N.
-  const stableEntry = plan.find((p) => p.next.alpha == null);
-  const releaseStr = stableEntry
-    ? `v${stableEntry.next.major}.${stableEntry.next.minor}.${stableEntry.next.patch}`
-    : `v${formatVersion(plan[0].next)}`;
+  // Release tag: prefer stable (non-alpha) versions. If all bumps are alpha-only,
+  // include -alpha.N. Sort by package name for determinism when selecting a fallback.
+  const stableEntry = plan.find((p) => p.next.alpha === undefined);
+  const fallback = [...plan].sort((a, b) =>
+    a.pkg.name.localeCompare(b.pkg.name),
+  )[0];
+  const tagSource =
+    stableEntry ?? fallback ?? fail("internal: no plan entries after bump");
+  const releaseStr =
+    tagSource.next.alpha === undefined
+      ? `v${tagSource.next.major}.${tagSource.next.minor}.${tagSource.next.patch}`
+      : `v${formatVersion(tagSource.next)}`;
 
   info(`\n✓ Bumped ${plan.length} package(s).\n`);
   info("Next steps:");
@@ -369,7 +395,7 @@ type PlanEntry = Loaded & {
   info(
     `   commit as "chore: release ${releaseStr}", open a PR with that title, squash-merge.)\n`,
   );
-})().catch((err) => {
+})().catch((err: unknown) => {
   console.error(err);
   process.exit(1);
 });

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+import {
+  readFileSync,
+  readdirSync,
+  statSync,
+  existsSync,
+  appendFileSync,
+} from "node:fs";
+import { execSync } from "node:child_process";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+type Package = { name: string; version?: string; private?: boolean };
+type Loaded = { dir: string; pkg: Package };
+
+const run = (cmd: string) => {
+  console.log(`$ ${cmd}`);
+  execSync(cmd, { cwd: ROOT, stdio: "inherit" });
+};
+const capture = (cmd: string): string | null => {
+  try {
+    return execSync(cmd, { cwd: ROOT, encoding: "utf8" }).trim();
+  } catch {
+    return null;
+  }
+};
+
+function readWorkspaceGlobs(): string[] {
+  const yaml = readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8");
+  const globs: string[] = [];
+  for (const line of yaml.split("\n")) {
+    const m = line.match(/^\s*-\s*["']?([^"']+?)["']?\s*$/);
+    if (m) globs.push(m[1]);
+  }
+  return globs;
+}
+
+function expandGlobs(globs: string[]): string[] {
+  const dirs = new Set<string>();
+  for (const g of globs) {
+    if (g.endsWith("/*")) {
+      const baseDir = join(ROOT, g.slice(0, -2));
+      if (!existsSync(baseDir)) continue;
+      for (const entry of readdirSync(baseDir)) {
+        const full = join(baseDir, entry);
+        if (statSync(full).isDirectory()) dirs.add(full);
+      }
+    } else {
+      const full = join(ROOT, g);
+      if (existsSync(full) && statSync(full).isDirectory()) dirs.add(full);
+    }
+  }
+  return [...dirs];
+}
+
+const loaded: Loaded[] = expandGlobs(readWorkspaceGlobs())
+  .map((d): Loaded | null => {
+    const p = join(d, "package.json");
+    if (!existsSync(p)) return null;
+    return { dir: d, pkg: JSON.parse(readFileSync(p, "utf8")) as Package };
+  })
+  .filter((e): e is Loaded => !!e && !e.pkg.private && !!e.pkg.version);
+
+if (loaded.length === 0) {
+  console.error("✖ no publishable packages found");
+  process.exit(1);
+}
+
+console.log("Fail-fast npm auth check...");
+run("npm whoami");
+
+const results: { published: string[]; skipped: string[]; failed: string[] } = {
+  published: [],
+  skipped: [],
+  failed: [],
+};
+
+for (const { pkg } of loaded) {
+  const spec = `${pkg.name}@${pkg.version}`;
+  const isAlpha = pkg.version!.includes("-alpha.");
+
+  const existing = capture(`npm view ${spec} version 2>/dev/null`);
+  if (existing === pkg.version) {
+    console.log(`⊙ ${spec} already on registry — skipping`);
+    results.skipped.push(spec);
+    continue;
+  }
+
+  try {
+    const tagFlag = isAlpha ? " --tag alpha" : "";
+    run(
+      `pnpm publish --filter ${pkg.name} --access public --no-git-checks${tagFlag}`,
+    );
+    if (isAlpha) {
+      run(`npm dist-tag add ${spec} latest`);
+    }
+    results.published.push(spec);
+  } catch (err) {
+    results.failed.push(spec);
+    console.error(`✖ publish failed for ${spec}: ${(err as Error).message}`);
+  }
+}
+
+const verifyFailed: string[] = [];
+for (const spec of [...results.published, ...results.skipped]) {
+  const expected = spec.split("@").pop();
+  const actual = capture(`npm view ${spec} version 2>/dev/null`);
+  if (actual !== expected)
+    verifyFailed.push(`${spec} (registry: ${actual ?? "not found"})`);
+}
+
+console.log("\n=== Publish summary ===");
+console.log(`published (${results.published.length}):`);
+for (const s of results.published) console.log(`  + ${s}`);
+console.log(`skipped, already on registry (${results.skipped.length}):`);
+for (const s of results.skipped) console.log(`  ⊙ ${s}`);
+console.log(`failed (${results.failed.length}):`);
+for (const s of results.failed) console.log(`  ✖ ${s}`);
+
+if (verifyFailed.length) {
+  console.error("\n✖ post-publish verification failed:");
+  for (const s of verifyFailed) console.error(`  - ${s}`);
+}
+
+if (results.failed.length || verifyFailed.length) process.exit(1);
+
+// Release tag: prefer a stable (non-alpha) version. If only alpha packages were bumped,
+// use the full alpha version — the tag/changelog filename must match.
+const stable = loaded.find((l) => !l.pkg.version!.includes("-alpha."));
+const releaseVersion = stable ? stable.pkg.version! : loaded[0].pkg.version!;
+
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `release_tag=v${releaseVersion}\n`);
+}
+console.log(`\n✓ release tag: v${releaseVersion}`);

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -19,11 +19,11 @@ const run = (cmd: string) => {
   console.log(`$ ${cmd}`);
   execSync(cmd, { cwd: ROOT, stdio: "inherit" });
 };
-const capture = (cmd: string): string | null => {
+const capture = (cmd: string): string | undefined => {
   try {
     return execSync(cmd, { cwd: ROOT, encoding: "utf8" }).trim();
   } catch {
-    return null;
+    return undefined;
   }
 };
 
@@ -31,8 +31,16 @@ function readWorkspaceGlobs(): string[] {
   const yaml = readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8");
   const globs: string[] = [];
   for (const line of yaml.split("\n")) {
-    const m = line.match(/^\s*-\s*["']?([^"']+?)["']?\s*$/);
-    if (m) globs.push(m[1]);
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("-")) continue;
+    let rest = trimmed.slice(1).trim();
+    if (
+      (rest.startsWith('"') && rest.endsWith('"')) ||
+      (rest.startsWith("'") && rest.endsWith("'"))
+    ) {
+      rest = rest.slice(1, -1);
+    }
+    if (rest) globs.push(rest);
   }
   return globs;
 }
@@ -56,12 +64,14 @@ function expandGlobs(globs: string[]): string[] {
 }
 
 const loaded: Loaded[] = expandGlobs(readWorkspaceGlobs())
-  .map((d): Loaded | null => {
+  .map((d): Loaded | undefined => {
     const p = join(d, "package.json");
-    if (!existsSync(p)) return null;
+    if (!existsSync(p)) return undefined;
     return { dir: d, pkg: JSON.parse(readFileSync(p, "utf8")) as Package };
   })
-  .filter((e): e is Loaded => !!e && !e.pkg.private && !!e.pkg.version);
+  .filter(
+    (e): e is Loaded => e !== undefined && !e.pkg.private && !!e.pkg.version,
+  );
 
 if (loaded.length === 0) {
   console.error("✖ no publishable packages found");
@@ -78,11 +88,13 @@ const results: { published: string[]; skipped: string[]; failed: string[] } = {
 };
 
 for (const { pkg } of loaded) {
-  const spec = `${pkg.name}@${pkg.version}`;
-  const isAlpha = pkg.version!.includes("-alpha.");
+  const version = pkg.version;
+  if (!version) continue;
+  const spec = `${pkg.name}@${version}`;
+  const isAlpha = version.includes("-alpha.");
 
   const existing = capture(`npm view ${spec} version 2>/dev/null`);
-  if (existing === pkg.version) {
+  if (existing === version) {
     console.log(`⊙ ${spec} already on registry — skipping`);
     results.skipped.push(spec);
     continue;
@@ -105,7 +117,8 @@ for (const { pkg } of loaded) {
 
 const verifyFailed: string[] = [];
 for (const spec of [...results.published, ...results.skipped]) {
-  const expected = spec.split("@").pop();
+  const parts = spec.split("@");
+  const expected = parts[parts.length - 1];
   const actual = capture(`npm view ${spec} version 2>/dev/null`);
   if (actual !== expected)
     verifyFailed.push(`${spec} (registry: ${actual ?? "not found"})`);
@@ -126,10 +139,15 @@ if (verifyFailed.length) {
 
 if (results.failed.length || verifyFailed.length) process.exit(1);
 
-// Release tag: prefer a stable (non-alpha) version. If only alpha packages were bumped,
-// use the full alpha version — the tag/changelog filename must match.
-const stable = loaded.find((l) => !l.pkg.version!.includes("-alpha."));
-const releaseVersion = stable ? stable.pkg.version! : loaded[0].pkg.version!;
+// Release tag: prefer a stable (non-alpha) version. If only alpha packages exist,
+// use the full alpha version. Sort by package name for determinism.
+const sorted = [...loaded].sort((a, b) => a.pkg.name.localeCompare(b.pkg.name));
+const stable = sorted.find((l) => !l.pkg.version?.includes("-alpha."));
+const releaseVersion = (stable ?? sorted[0])?.pkg.version;
+if (!releaseVersion) {
+  console.error("✖ cannot derive release tag");
+  process.exit(1);
+}
 
 if (process.env.GITHUB_OUTPUT) {
   appendFileSync(process.env.GITHUB_OUTPUT, `release_tag=v${releaseVersion}\n`);

--- a/scripts/validate-release-pr.ts
+++ b/scripts/validate-release-pr.ts
@@ -6,11 +6,13 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const PR_TITLE = process.env.PR_TITLE ?? "";
-const BASE = process.env.GITHUB_BASE_REF || "main";
+const BASE = process.env.GITHUB_BASE_REF ?? "main";
 
 const TITLE_RE = /^chore: release v(\d+\.\d+\.\d+(?:-alpha\.\d+)?)$/;
 const CHANGELOG_RE = /^changelog\/v(\d+\.\d+\.\d+(?:-alpha\.\d+)?)\.md$/;
-const PKG_RE = /^(packages\/[^/]+|docs|examples)\/package\.json$/;
+const PKG_RE = /^packages\/[^/]+\/package\.json$/;
+const VERSION_LINE_RE = /^[+-]\s*"version"\s*:\s*"[^"]+",?\s*$/;
+const VERSION_FIELD_RE = /"version"\s*:\s*"([^"]+)"/;
 
 const fail = (msg: string): never => {
   console.error(`\n✖ ${msg}\n`);
@@ -19,13 +21,11 @@ const fail = (msg: string): never => {
 
 type DiffEntry = { status: string; path: string };
 
-const titleMatch = PR_TITLE.match(TITLE_RE);
-if (!titleMatch) {
+const titleVersion =
+  TITLE_RE.exec(PR_TITLE)?.[1] ??
   fail(
     `PR title "${PR_TITLE}" must match:  chore: release vX.Y.Z  or  chore: release vX.Y.Z-alpha.N`,
   );
-}
-const titleVersion = titleMatch![1];
 
 const diffRaw = execSync(`git diff --name-status origin/${BASE}...HEAD`, {
   cwd: ROOT,
@@ -38,12 +38,14 @@ if (!diffRaw) {
   );
 }
 
-const entries: DiffEntry[] = diffRaw.split("\n").map((line) => {
-  const [status, ...pathParts] = line.split(/\s+/);
-  return { status, path: pathParts.join(" ") };
-});
+const entries: DiffEntry[] = [];
+for (const line of diffRaw.split("\n")) {
+  const [status, ...pathParts] = line.split("\t");
+  if (!status || pathParts.length === 0) continue;
+  entries.push({ status, path: pathParts.join("\t") });
+}
 
-let changelogFound: string | null = null;
+let changelogFound: string | undefined;
 const packageJsonsChanged: string[] = [];
 const errors: string[] = [];
 
@@ -53,8 +55,7 @@ for (const { status, path } of entries) {
     continue;
   }
 
-  const cm = path.match(CHANGELOG_RE);
-  if (cm) {
+  if (CHANGELOG_RE.exec(path)) {
     if (status !== "A") {
       errors.push(
         `changelog file must be newly added (status=${status}): ${path}`,
@@ -85,7 +86,7 @@ for (const { status, path } of entries) {
     for (const line of pkgDiff.split("\n")) {
       if (!line.startsWith("+") && !line.startsWith("-")) continue;
       if (line.startsWith("+++") || line.startsWith("---")) continue;
-      if (!/^[+-]\s*"version"\s*:\s*"[^"]+",?\s*$/.test(line)) {
+      if (!VERSION_LINE_RE.test(line)) {
         errors.push(`${path}: non-version change detected: ${line.trim()}`);
         break;
       }
@@ -95,7 +96,7 @@ for (const { status, path } of entries) {
   }
 
   errors.push(
-    `unexpected file change: ${path} (status=${status}) — release PRs may only change package.json versions and add one changelog file.`,
+    `unexpected file change: ${path} (status=${status}) — release PRs may only change packages/*/package.json versions and add one changelog file.`,
   );
 }
 
@@ -111,10 +112,10 @@ if (packageJsonsChanged.length === 0) {
 }
 
 if (changelogFound) {
-  const cv = changelogFound.match(CHANGELOG_RE)![1];
-  if (cv !== titleVersion) {
+  const cm = CHANGELOG_RE.exec(changelogFound);
+  if (cm?.[1] && cm[1] !== titleVersion) {
     errors.push(
-      `PR title version v${titleVersion} does not match changelog file v${cv}`,
+      `PR title version v${titleVersion} does not match changelog file v${cm[1]}`,
     );
   }
 }
@@ -123,12 +124,12 @@ if (changelogFound) {
 const bumpedVersions = new Set<string>();
 for (const p of packageJsonsChanged) {
   const content = readFileSync(join(ROOT, p), "utf8");
-  const vm = content.match(/"version"\s*:\s*"([^"]+)"/);
-  if (!vm) {
+  const v = VERSION_FIELD_RE.exec(content)?.[1];
+  if (!v) {
     errors.push(`${p}: could not read version`);
     continue;
   }
-  bumpedVersions.add(vm[1]);
+  bumpedVersions.add(v);
 }
 if (packageJsonsChanged.length && !bumpedVersions.has(titleVersion)) {
   errors.push(

--- a/scripts/validate-release-pr.ts
+++ b/scripts/validate-release-pr.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PR_TITLE = process.env.PR_TITLE ?? "";
+const BASE = process.env.GITHUB_BASE_REF || "main";
+
+const TITLE_RE = /^chore: release v(\d+\.\d+\.\d+(?:-alpha\.\d+)?)$/;
+const CHANGELOG_RE = /^changelog\/v(\d+\.\d+\.\d+(?:-alpha\.\d+)?)\.md$/;
+const PKG_RE = /^(packages\/[^/]+|docs|examples)\/package\.json$/;
+
+const fail = (msg: string): never => {
+  console.error(`\n✖ ${msg}\n`);
+  process.exit(1);
+};
+
+type DiffEntry = { status: string; path: string };
+
+const titleMatch = PR_TITLE.match(TITLE_RE);
+if (!titleMatch) {
+  fail(
+    `PR title "${PR_TITLE}" must match:  chore: release vX.Y.Z  or  chore: release vX.Y.Z-alpha.N`,
+  );
+}
+const titleVersion = titleMatch![1];
+
+const diffRaw = execSync(`git diff --name-status origin/${BASE}...HEAD`, {
+  cwd: ROOT,
+  encoding: "utf8",
+}).trim();
+
+if (!diffRaw) {
+  fail(
+    "no changes vs base — a release PR must bump versions and add a changelog.",
+  );
+}
+
+const entries: DiffEntry[] = diffRaw.split("\n").map((line) => {
+  const [status, ...pathParts] = line.split(/\s+/);
+  return { status, path: pathParts.join(" ") };
+});
+
+let changelogFound: string | null = null;
+const packageJsonsChanged: string[] = [];
+const errors: string[] = [];
+
+for (const { status, path } of entries) {
+  if (path.endsWith("_DISCORD.md")) {
+    errors.push(`Discord file must not be committed: ${path}`);
+    continue;
+  }
+
+  const cm = path.match(CHANGELOG_RE);
+  if (cm) {
+    if (status !== "A") {
+      errors.push(
+        `changelog file must be newly added (status=${status}): ${path}`,
+      );
+      continue;
+    }
+    if (changelogFound) {
+      errors.push(
+        `only one new changelog file allowed; also found ${changelogFound}`,
+      );
+      continue;
+    }
+    changelogFound = path;
+    continue;
+  }
+
+  if (PKG_RE.test(path)) {
+    if (status !== "M") {
+      errors.push(
+        `${path} must be modified (not added/removed); got status=${status}`,
+      );
+      continue;
+    }
+    const pkgDiff = execSync(`git diff origin/${BASE}...HEAD -- "${path}"`, {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+    for (const line of pkgDiff.split("\n")) {
+      if (!line.startsWith("+") && !line.startsWith("-")) continue;
+      if (line.startsWith("+++") || line.startsWith("---")) continue;
+      if (!/^[+-]\s*"version"\s*:\s*"[^"]+",?\s*$/.test(line)) {
+        errors.push(`${path}: non-version change detected: ${line.trim()}`);
+        break;
+      }
+    }
+    packageJsonsChanged.push(path);
+    continue;
+  }
+
+  errors.push(
+    `unexpected file change: ${path} (status=${status}) — release PRs may only change package.json versions and add one changelog file.`,
+  );
+}
+
+if (!changelogFound) {
+  errors.push(
+    `missing changelog file (expected: changelog/v${titleVersion}.md)`,
+  );
+}
+if (packageJsonsChanged.length === 0) {
+  errors.push(
+    "no package.json version bumps found — the PR must bump at least one version.",
+  );
+}
+
+if (changelogFound) {
+  const cv = changelogFound.match(CHANGELOG_RE)![1];
+  if (cv !== titleVersion) {
+    errors.push(
+      `PR title version v${titleVersion} does not match changelog file v${cv}`,
+    );
+  }
+}
+
+// The bumped versions must include the PR-title version as-is (alpha-for-alpha, stable-for-stable).
+const bumpedVersions = new Set<string>();
+for (const p of packageJsonsChanged) {
+  const content = readFileSync(join(ROOT, p), "utf8");
+  const vm = content.match(/"version"\s*:\s*"([^"]+)"/);
+  if (!vm) {
+    errors.push(`${p}: could not read version`);
+    continue;
+  }
+  bumpedVersions.add(vm[1]);
+}
+if (packageJsonsChanged.length && !bumpedVersions.has(titleVersion)) {
+  errors.push(
+    `no package.json bumped to v${titleVersion}; versions in diff are: ${[...bumpedVersions].join(", ")}`,
+  );
+}
+
+if (errors.length) {
+  fail(`release PR validation failed:\n  - ${errors.join("\n  - ")}`);
+}
+
+console.log(`✓ Release PR valid for v${titleVersion}`);
+console.log(`  - ${packageJsonsChanged.length} package.json(s) bumped`);
+console.log(`  - changelog: ${changelogFound}`);


### PR DESCRIPTION
## Summary

Adds a custom end-to-end release workflow for the monorepo. New `pnpm bump` CLI handles unified stable / alpha-only version bumps with npm registry guardrails. A GitHub Actions workflow validates release PRs (title, file scope, version consistency) and, on merge to `main`, publishes to npm, creates the GitHub release, and deploys `docs/` to Vercel — so the site tracks the latest release rather than the latest commit. A `/release` skill orchestrates the whole flow (branch → bump → sanity-check → changelog → approval → PR), with `CONTRIBUTING.md` now pointing contributors to it. Private `docs` and `examples` packages drop their unused `version` field; old ad-hoc `publish-docnode` / `publish-docsync` scripts are removed.

## Test plan

- [ ] Dry-run `pnpm bump` against a scratch branch (stable patch + alpha) and verify registry guardrails
- [ ] Open a mis-named release PR and confirm `validate` job rejects it
- [ ] Merge a real release PR and confirm npm publish, GitHub release, and Vercel prod deploy all succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)