### PR TITLE
Make applyOperations forward origin to onChange

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 ## Tests
 
 - Test files should be highly declarative and easy to understand. Extract repetitive utilities, setup, or cleanup functions into utils.ts files.
+- Use `checkUndoManager(...)` to wrap as much `docnode` test logic as is practical.
 - Do your best to ensure that `await tick()` uses the default value of 3ms, or 10ms in some suites. If a longer wait time is required anywhere, it's a sign that there's something that needs optimization.
 - The pattern for exporting private APIs is to use class methods and properties prefixed with `private`. TypeScript allows access to these from outside the class using bracket notation. If you don't recognize the method, you may need to change it to `protected` in your source code. Never export top-level internal modules, nor use assertions to cast an internal property.
   - **IMPORTANT**: When writing tests that need to access internal class properties, ALWAYS change those properties from `private` to `protected` in the source code. Then use bracket notation (e.g., `instance["_property"]`) in tests WITHOUT any type assertions (`as`, `as any`, `as unknown as`). Never use type assertions to access private/internal properties - change them to `protected` instead.

--- a/packages/docnode/src/main.ts
+++ b/packages/docnode/src/main.ts
@@ -941,13 +941,27 @@ export class Doc {
   applyOperations(operations: ops.Operations, origin?: string) {
     const hasOperations =
       operations[0].length > 0 || !isObjectEmpty(operations[1]);
-    if (hasOperations && this._lifeCycleStage === "update") this.forceCommit();
+    if (!hasOperations) {
+      if (
+        this._lifeCycleStage === "change" ||
+        this._lifeCycleStage === "disposed"
+      )
+        throw new Error(
+          `You can't trigger an update inside a ${this._lifeCycleStage} stage`,
+        );
+      if (this._lifeCycleStage === "normalize2") {
+        throw new Error(
+          "Strict mode has caught an error: normalize listeners are not idempotent. I.e, they should not mutate the document on the second pass.",
+        );
+      }
+      return;
+    }
+    if (this._lifeCycleStage === "update") this.forceCommit();
     let didApplyOperations = false;
     this._changeOrigin = origin;
     withTransaction(
       this,
       () => {
-        if (!hasOperations) return;
         ops.onApplyOperations(this, operations);
         didApplyOperations = true;
       },

--- a/packages/docnode/src/main.ts
+++ b/packages/docnode/src/main.ts
@@ -22,7 +22,7 @@ import {
   ULID_REGEX,
   defineNode,
 } from "./utils.js";
-import * as operations from "./operations.js";
+import * as ops from "./operations.js";
 import { nodeIdFactory } from "./idGenerator.js";
 import { decodeTime, ulid } from "ulid";
 
@@ -229,7 +229,7 @@ export class DocNode<T extends NodeDefinition = NodeDefinition> {
         withTransaction(doc, () => {
           if (this === this.doc.root)
             throw new Error("Root node cannot be deleted");
-          operations.onDeleteRange(this.doc, this, laterSibling);
+          ops.onDeleteRange(this.doc, this, laterSibling);
           this.to(laterSibling).forEach((node) => {
             node.descendants({ includeSelf: true }).forEach((node) => {
               void this.doc["_nodeMap"].delete(node.id);
@@ -302,14 +302,7 @@ export class DocNode<T extends NodeDefinition = NodeDefinition> {
           detachRange(this, laterSibling);
 
           // PART 3: Insert the range
-          operations.onMoveRange(
-            doc,
-            this,
-            laterSibling,
-            newParent,
-            newPrev,
-            newNext,
-          );
+          ops.onMoveRange(doc, this, laterSibling, newParent, newPrev, newNext);
 
           this["_set"]("prev", newPrev);
           if (newPrev) newPrev["_set"]("next", this);
@@ -335,12 +328,8 @@ export class DocNode<T extends NodeDefinition = NodeDefinition> {
           const clone = (node: DocNode) => {
             const newNode = new DocNode(doc, node.type);
             for (const key in node["_state"]) {
-              const stringified = operations.stringifyStateKey(node, key);
-              const parsed = operations.parseStateKey(
-                newNode,
-                key,
-                stringified,
-              );
+              const stringified = ops.stringifyStateKey(node, key);
+              const parsed = ops.parseStateKey(newNode, key, stringified);
               (newNode as DocNode<UnsafeDefinition>)["_state"][key] = parsed;
             }
             return newNode;
@@ -532,7 +521,7 @@ export class DocNode<T extends NodeDefinition = NodeDefinition> {
     const resolvedNodeDef = this.doc["_resolvedNodeDefs"].get(this.type);
     const defaultString = resolvedNodeDef?.defaultStrings;
     for (const key in this._state) {
-      const stringifiedState = operations.stringifyStateKey(this, key);
+      const stringifiedState = ops.stringifyStateKey(this, key);
       if (stringifiedState === defaultString?.[key]) continue;
       const stateDefinition = resolvedNodeDef?.state[key];
       const json = stateDefinition?.toJSON
@@ -561,8 +550,9 @@ export class Doc {
     | "normalize2"
     | "change"
     | "disposed" = "idle";
-  protected _operations: operations.Operations = [[], {}];
-  protected _inverseOperations: operations.Operations = [[], {}];
+  protected _operations: ops.Operations = [[], {}];
+  protected _inverseOperations: ops.Operations = [[], {}];
+  protected _changeOrigin: string | undefined;
   protected _diff: Diff = {
     deleted: new Map(),
     inserted: new Set(),
@@ -675,9 +665,9 @@ export class Doc {
               // node or when inserting a node, but not when setting state for a node
               // that is not attached yet
               const isAttached = node.doc["_nodeMap"].has(node.id);
-              if (isAttached) operations.onSetState.inverseOps(node, key);
+              if (isAttached) ops.onSetState.inverseOps(node, key);
               _state[key] = value;
-              if (isAttached) operations.onSetState.operations(node, key);
+              if (isAttached) ops.onSetState.operations(node, key);
 
               // TODO: Subdocs. This is not implemented yet
               // if (valueOrUpdaterFn instanceof Doc) {
@@ -709,7 +699,7 @@ export class Doc {
             // @ts-expect-error - protected property
             const _state = node._state as Record<string, unknown>;
             return maybePrevState
-              ? [true, operations.parseStateKey(node, key, maybePrevState)]
+              ? [true, ops.parseStateKey(node, key, maybePrevState)]
               : [false, _state[key]];
           };
 
@@ -812,7 +802,7 @@ export class Doc {
         position === "before" ||
         (position === "append" && this._nodeMap.has(target.id))
       ) {
-        operations.onInsertRange(this, target, position, nodes);
+        ops.onInsertRange(this, target, position, nodes);
       }
       switch (position) {
         case "append": {
@@ -948,15 +938,24 @@ export class Doc {
     this._normalizeListeners.add(callback);
   }
 
-  applyOperations(_operations: operations.Operations) {
+  applyOperations(operations: ops.Operations, origin?: string) {
+    const hasOperations =
+      operations[0].length > 0 || !isObjectEmpty(operations[1]);
+    if (hasOperations && this._lifeCycleStage === "update") this.forceCommit();
+    let didApplyOperations = false;
+    this._changeOrigin = origin;
     withTransaction(
       this,
       () => {
-        if (!_operations[0].length && isObjectEmpty(_operations[1])) return;
-        operations.onApplyOperations(this, _operations);
+        if (!hasOperations) return;
+        ops.onApplyOperations(this, operations);
+        didApplyOperations = true;
       },
       true,
     );
+    if (didApplyOperations && this._lifeCycleStage === "update") {
+      this.forceCommit();
+    }
   }
 
   /**
@@ -970,9 +969,10 @@ export class Doc {
     this._inverseOperations[0].reverse();
     // End update stage before normalization
     this._lifeCycleStage = "idle";
-    operations.maybeTriggerListeners(this, ignoreEmptyDiff);
+    ops.maybeTriggerListeners(this, ignoreEmptyDiff);
     this._operations = [[], {}];
     this._inverseOperations = [[], {}];
+    this._changeOrigin = undefined;
     this._diff = {
       deleted: new Map(),
       inserted: new Set(),
@@ -986,10 +986,17 @@ export class Doc {
    * Aborts the current transaction and rolls back all changes.
    */
   abort() {
-    const inverseOps: operations.Operations = [...this["_inverseOperations"]];
-    this.applyOperations(inverseOps);
+    const inverseOps: ops.Operations = [...this["_inverseOperations"]];
+    withTransaction(
+      this,
+      () => {
+        ops.onApplyOperations(this, inverseOps);
+      },
+      true,
+    );
     this["_operations"] = [[], {}];
     this["_inverseOperations"] = [[], {}];
+    this["_changeOrigin"] = undefined;
     this["_diff"] = {
       deleted: new Map(),
       inserted: new Set(),

--- a/packages/docnode/src/operations.ts
+++ b/packages/docnode/src/operations.ts
@@ -338,6 +338,7 @@ export const maybeTriggerListeners = (doc: Doc, ignoreEmptyDiff = false) => {
       operations: doc["_operations"],
       inverseOperations: doc["_inverseOperations"],
       diff: doc["_diff"],
+      origin: doc["_changeOrigin"],
     }),
   );
 };

--- a/packages/docnode/src/types.ts
+++ b/packages/docnode/src/types.ts
@@ -235,4 +235,5 @@ export type ChangeEvent = {
   operations: Operations;
   inverseOperations: Operations;
   diff: Diff;
+  origin?: string | undefined;
 };

--- a/packages/docnode/src/undoManager.ts
+++ b/packages/docnode/src/undoManager.ts
@@ -1,13 +1,13 @@
 import { type Doc } from "./main.js";
 import type { Operations } from "./operations.js";
 
+type UndoStackItem = { operations: Operations };
+
 export class UndoManager {
   private readonly _doc: Doc;
   private readonly _maxUndoSteps: number;
-  protected _undoStack: Operations[] = [];
-  protected _redoStack: Operations[] = [];
-  // TODO: How are we going to handle remote changes from other users?
-  // maybe another flag in onChange args like "isRemote"? arbitrary ctx? sessionId?
+  protected _undoStack: UndoStackItem[] = [];
+  protected _redoStack: UndoStackItem[] = [];
   private _txType: "undo" | "redo" | "update" = "update";
   private _lastUpdate?: number; // TODO: threeshold to combine transactions of 500ms
 
@@ -30,17 +30,19 @@ export class UndoManager {
   ) {
     this._doc = doc;
     this._maxUndoSteps = options?.maxUndoSteps ?? 100;
-    this._doc.onChange(({ inverseOperations }) => {
+    this._doc.onChange((event) => {
+      if (event.origin?.startsWith("remote")) return;
+      const item: UndoStackItem = { operations: event.inverseOperations };
       if (this._txType === "update") {
         if (this._maxUndoSteps > this._undoStack.length)
-          this._undoStack.push(inverseOperations);
+          this._undoStack.push(item);
         this._redoStack = [];
         this._lastUpdate = Date.now();
       } else if (this._txType === "undo") {
-        this._redoStack.push(inverseOperations);
+        this._redoStack.push(item);
         this._txType = "update";
       } else {
-        this._undoStack.push(inverseOperations);
+        this._undoStack.push(item);
         this._txType = "update";
       }
     });
@@ -49,19 +51,17 @@ export class UndoManager {
   undo() {
     this._doc.forceCommit();
     this._txType = "undo";
-    const operations = this._undoStack.pop();
-    if (!operations) return;
-    this._doc.applyOperations(operations);
-    this._doc.forceCommit();
+    const item = this._undoStack.pop();
+    if (!item) return;
+    this._doc.applyOperations(item.operations);
   }
 
   redo() {
     this._doc.forceCommit();
     this._txType = "redo";
-    const operations = this._redoStack.pop();
-    if (!operations) return;
-    this._doc.applyOperations(operations);
-    this._doc.forceCommit();
+    const item = this._redoStack.pop();
+    if (!item) return;
+    this._doc.applyOperations(item.operations);
   }
 
   canUndo() {

--- a/packages/docsync/src/bindings/docnode.ts
+++ b/packages/docsync/src/bindings/docnode.ts
@@ -28,11 +28,12 @@ export const DocNodeBinding = (docConfigs: DocConfig[]) => {
       doc.forceCommit();
       return doc;
     },
-    onChange: (doc, cb: (ev: { operations: Operations }) => void) =>
-      doc.onChange(cb),
-    applyOperations: (doc, operations) => {
-      doc.applyOperations(operations);
-      doc.forceCommit();
+    onChange: (
+      doc,
+      cb: (ev: { operations: Operations; origin?: string | undefined }) => void,
+    ) => doc.onChange(cb),
+    applyOperations: (doc, operations, origin) => {
+      doc.applyOperations(operations, origin);
     },
     dispose: (doc) => doc.dispose(),
   });

--- a/packages/docsync/src/client/handlers/clientInitiated/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync.ts
@@ -4,7 +4,7 @@ import type { DocSyncClient } from "../../index.js";
 import { getOwnPresencePatch } from "../../utils/getOwnPresencePatch.js";
 import { request } from "../../utils/request.js";
 
-/** Applies server operations to the cached doc and emits change event (remote). */
+/** Applies server operations to the cached doc. */
 async function applyServerOperations<D extends {}, S extends {}, O extends {}>(
   client: DocSyncClient<D, S, O>,
   args: { docId: string; operations: O[] },
@@ -15,17 +15,9 @@ async function applyServerOperations<D extends {}, S extends {}, O extends {}>(
   const doc = await cacheEntry.promisedDoc;
   if (!doc) return;
 
-  client["_shouldBroadcast"] = false;
   for (const op of args.operations) {
-    client["_docBinding"].applyOperations(doc, op);
+    client["_docBinding"].applyOperations(doc, op, "remote");
   }
-  client["_shouldBroadcast"] = true;
-
-  client["_events"].emit("change", {
-    docId: args.docId,
-    origin: "remote",
-    operations: args.operations,
-  });
 }
 
 /**

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -53,7 +53,6 @@ export class DocSyncClient<
   protected _deviceId: string;
   /** Client-generated id for presence (works offline; sent in auth so server uses same key) */
   protected _clientId: string;
-  private _shouldBroadcast = true;
   protected _bcHelper?: BCHelper<D, S, O>;
   protected _socket: ClientSocket<S, O>;
 
@@ -301,32 +300,33 @@ export class DocSyncClient<
   }
 
   private _setupChangeListener(doc: D, docId: string) {
-    this._docBinding.onChange(doc, ({ operations }) => {
-      if (this._shouldBroadcast) {
-        void this.onLocalOperations({ docId, operations: [operations] });
+    this._docBinding.onChange(doc, ({ operations, origin }) => {
+      const changeOrigin =
+        origin === "remote" || origin === "broadcast" ? origin : "local";
 
-        this._events.emit("change", {
-          docId,
-          origin: "local",
-          operations: [operations],
-        });
+      this._events.emit("change", {
+        docId,
+        origin: changeOrigin,
+        operation: operations,
+      });
 
-        // Defer BC send so Lexical can update selection first; then the presence we
-        // include is the new cursor. Two frames so setPresence (from selection change) has run.
+      if (changeOrigin !== "local") return;
+
+      void this.onLocalOperations({ docId, operations: [operations] });
+
+      // Defer BC send so Lexical can update selection first; then the presence we
+      // include is the new cursor. Two frames so setPresence (from selection change) has run.
+      requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            const presencePatch = getOwnPresencePatch(this, docId);
-            this._bcHelper?.broadcast({
-              type: "OPERATIONS",
-              operations,
-              docId,
-              ...(presencePatch && { presence: presencePatch }),
-            });
+          const presencePatch = getOwnPresencePatch(this, docId);
+          this._bcHelper?.broadcast({
+            type: "OPERATIONS",
+            operations,
+            docId,
+            ...(presencePatch && { presence: presencePatch }),
           });
         });
-      }
-      // Don't automatically reset _shouldBroadcast here!
-      // Let the caller explicitly control when to re-enable broadcasting
+      });
     });
   }
 
@@ -344,25 +344,21 @@ export class DocSyncClient<
 
       if (stored) {
         const doc = this._docBinding.deserialize(stored.serializedDoc);
-        this._shouldBroadcast = false;
         localOperations.forEach((operationsBatch) => {
           operationsBatch.forEach((operations) => {
             this._docBinding.applyOperations(doc, operations);
           });
         });
-        this._shouldBroadcast = true;
         return doc;
       }
 
       // Create new doc if type provided
       if (type) {
         const { doc } = this._docBinding.create(type, docId);
-        this._shouldBroadcast = false;
         if (localOperations.length)
           throw new Error(
             `Doc ${docId} has operations stored locally but no serialized doc found`,
           );
-        this._shouldBroadcast = true;
         // Save the new doc to IDB
         await ctx.saveSerializedDoc({
           serializedDoc: this._docBinding.serialize(doc),

--- a/packages/docsync/src/client/utils/BCHelper.ts
+++ b/packages/docsync/src/client/utils/BCHelper.ts
@@ -52,14 +52,7 @@ export class BCHelper<D extends {}, S extends {}, O extends {} = {}> {
     if (!cacheEntry) return;
     const doc = await cacheEntry.promisedDoc;
     if (!doc) return;
-    client["_shouldBroadcast"] = false;
-    client["_docBinding"].applyOperations(doc, operations);
-    client["_shouldBroadcast"] = true;
-    client["_events"].emit("change", {
-      docId,
-      origin: "broadcast",
-      operations: [operations],
-    });
+    client["_docBinding"].applyOperations(doc, operations, "broadcast");
   }
 
   broadcast(message: BroadcastMessage<O>): void {

--- a/packages/docsync/src/client/utils/events.ts
+++ b/packages/docsync/src/client/utils/events.ts
@@ -9,7 +9,7 @@ export type DisconnectEvent = { reason: string };
 export type ChangeEvent<O = unknown> = {
   docId: string;
   origin: "local" | "broadcast" | "remote";
-  operations: O[];
+  operation: O;
 };
 
 /** Emitted once after sync completes (success or error). */

--- a/packages/docsync/src/shared/types.ts
+++ b/packages/docsync/src/shared/types.ts
@@ -22,8 +22,11 @@ export interface DocBinding<
   create(type: string, id?: string): { doc: D; docId: string };
   deserialize(serializedDoc: S): D;
   serialize(doc: D): S;
-  onChange(doc: D, cb: (ev: { operations: O }) => void): void;
-  applyOperations(doc: D, operations: O): void;
+  onChange(
+    doc: D,
+    cb: (ev: { operations: O; origin?: string | undefined }) => void,
+  ): void;
+  applyOperations(doc: D, operations: O, origin?: string): void;
   dispose(doc: D): void;
 }
 

--- a/tests/docnode/transactions.test.ts
+++ b/tests/docnode/transactions.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
 import {
-  type ChangeEvent,
   Doc,
   type DocNode,
   type Operations,
@@ -401,17 +400,6 @@ describe("applyOperations", () => {
     doc.root.append(...text(doc, "local"));
     doc.forceCommit();
     expect(undoManager.canUndo()).toBe(true);
-  });
-
-  test("update plus applyOperations are committed as two transactions", () => {
-    const remoteOperations = createRemoteInsertOperations("remote");
-    const doc = new Doc({ type: "root", extensions: [TextExtension] });
-    const origins = collectOrigins(doc, () => {
-      doc.root.append(...text(doc, "local"));
-      doc.applyOperations(remoteOperations, "remote");
-    });
-    expect(origins).toStrictEqual([undefined, "remote"]);
-    assertDoc(doc, ["local", "remote"]);
   });
 
   test("applyOperations plus update are committed as two transactions", () => {

--- a/tests/docnode/transactions.test.ts
+++ b/tests/docnode/transactions.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { Doc, type DocNode, UndoManager } from "@docukit/docnode";
+import {
+  type ChangeEvent,
+  Doc,
+  type DocNode,
+  type Operations,
+  UndoManager,
+} from "@docukit/docnode";
 import {
   assertDoc,
   checkUndoManager,
@@ -112,6 +118,31 @@ describe("undoManager", () => {
     assertDoc(doc, []);
     undoManager.redo();
     assertDoc(doc, ["1", "2"]);
+  });
+
+  test("undo immediately after a pending local update still undoes that update", () => {
+    const doc = new Doc({ type: "root", extensions: [TextExtension] });
+    const undoManager = new UndoManager(doc, { maxUndoSteps: 10 });
+    const origins: (string | undefined)[] = [];
+    doc.forceCommit();
+    const unregister = doc.onChange((event) => {
+      origins.push(event.origin);
+    });
+
+    doc.root.append(...text(doc, "a"));
+    doc.forceCommit();
+
+    doc.root.append(...text(doc, "b"));
+    assertDoc(doc, ["a", "b"]);
+
+    undoManager.undo();
+    assertDoc(doc, ["a"]);
+
+    undoManager.redo();
+    assertDoc(doc, ["a", "b"]);
+
+    unregister();
+    expect(origins).toStrictEqual([undefined, undefined, undefined, undefined]);
   });
 
   test("undo/redo - adding and deleting nodes", () => {
@@ -308,8 +339,91 @@ describe("undoManager", () => {
   });
 });
 
-describe.todo("applyOperations", () => {
-  // test.todo("move same item concurrently", () => {
+describe("applyOperations", () => {
+  function createRemoteInsertOperations(value: string): Operations {
+    const source = new Doc({ type: "root", extensions: [TextExtension] });
+    let remoteOperations: Operations | undefined;
+    updateAndListen(
+      source,
+      () => {
+        source.root.append(...text(source, value));
+      },
+      (event) => {
+        remoteOperations = event.operations;
+      },
+    );
+    if (!remoteOperations) throw new Error("Expected remote operations");
+    return remoteOperations;
+  }
+
+  function collectOrigins(
+    doc: Doc,
+    callback: () => void,
+  ): (string | undefined)[] {
+    const origins: (string | undefined)[] = [];
+    doc.forceCommit();
+    const unregister = doc.onChange((event) => {
+      origins.push(event.origin);
+    });
+    callback();
+    doc.forceCommit();
+    unregister();
+    return origins;
+  }
+
+  test("commits atomically and forwards its origin when called inside another update", () => {
+    const remoteOperations = createRemoteInsertOperations("remote");
+
+    const doc = new Doc({ type: "root", extensions: [TextExtension] });
+    const origins = collectOrigins(doc, () => {
+      doc.root.append(...text(doc, "local"));
+      doc.applyOperations(remoteOperations, "remote");
+    });
+
+    expect(origins).toStrictEqual([undefined, "remote"]);
+    assertDoc(doc, ["local", "remote"]);
+  });
+
+  test("UndoManager ignores remote-origin transactions by default", () => {
+    const remoteOperations = createRemoteInsertOperations("remote");
+
+    const doc = new Doc({ type: "root", extensions: [TextExtension] });
+    const undoManager = new UndoManager(doc);
+
+    doc.applyOperations(remoteOperations, "remote");
+    doc.forceCommit();
+    expect(undoManager.canUndo()).toBe(false);
+
+    doc.applyOperations(remoteOperations, "remote:peer-2");
+    doc.forceCommit();
+    expect(undoManager.canUndo()).toBe(false);
+
+    doc.root.append(...text(doc, "local"));
+    doc.forceCommit();
+    expect(undoManager.canUndo()).toBe(true);
+  });
+
+  test("update plus applyOperations are committed as two transactions", () => {
+    const remoteOperations = createRemoteInsertOperations("remote");
+    const doc = new Doc({ type: "root", extensions: [TextExtension] });
+    const origins = collectOrigins(doc, () => {
+      doc.root.append(...text(doc, "local"));
+      doc.applyOperations(remoteOperations, "remote");
+    });
+    expect(origins).toStrictEqual([undefined, "remote"]);
+    assertDoc(doc, ["local", "remote"]);
+  });
+
+  test("applyOperations plus update are committed as two transactions", () => {
+    const remoteOperations = createRemoteInsertOperations("remote");
+    const doc = new Doc({ type: "root", extensions: [TextExtension] });
+    const origins = collectOrigins(doc, () => {
+      doc.applyOperations(remoteOperations, "remote");
+      doc.root.append(...text(doc, "local"));
+    });
+    expect(origins).toStrictEqual(["remote", undefined]);
+    assertDoc(doc, ["remote", "local"]);
+  });
 });
 
 describe("change", () => {

--- a/tests/docnode/utils.ts
+++ b/tests/docnode/utils.ts
@@ -407,20 +407,26 @@ export function checkUndoManager(
   expect(sizeDo).toBe(txCount);
 
   // 2. REPLAY IN A SINGLE UPDATE (doc2)
+  const orderedOperations: Operations[0] = changeEvents.flatMap(
+    (ev) => ev.operations[0],
+  );
+  const statePatch: Operations[1] = {};
+  for (const changeEvent of changeEvents) {
+    for (const nodeId in changeEvent.operations[1]) {
+      statePatch[nodeId] ??= {};
+      Object.assign(statePatch[nodeId], changeEvent.operations[1][nodeId]);
+    }
+  }
   updateAndListen(
     doc2,
     () => {
-      for (const changeEvent of changeEvents) {
-        doc2.applyOperations(changeEvent.operations);
-      }
+      doc2.applyOperations([orderedOperations, statePatch]);
     },
     (changeEvent) => {
       expect(changeEvent.operations.length).toBe(2); // A single op array + state patch
       // The array of operations is equal to the conjunction of all those that were in changeEvents
       // slice(0, -1) because the last operation is the state patch
-      expect(changeEvent.operations[0]).toStrictEqual(
-        changeEvents.map((ev) => ev.operations.slice(0, -1)).flat(2),
-      );
+      expect(changeEvent.operations[0]).toStrictEqual(orderedOperations);
       // Inverse operations can't be compared. The following isn't always true because if a node
       // is inserted in one update and its child is inserted in the next update, inverseOperations
       // will have only one delete op (the parent's) instead of the two I get when doing separate updates.

--- a/tests/docsync/unit/client/events.browser.test.ts
+++ b/tests/docsync/unit/client/events.browser.test.ts
@@ -94,7 +94,7 @@ describe("Client Events", () => {
       client["_events"].emit("change", {
         docId,
         origin: "remote",
-        operations: testOperations,
+        operation: testOperations[0],
       });
       await expect.poll(() => changeOrigin).toBe("remote");
     });

--- a/tests/docsync/unit/server/index.test.ts
+++ b/tests/docsync/unit/server/index.test.ts
@@ -8,6 +8,8 @@ import { DocSyncServer, inMemoryServerProvider } from "@docukit/docsync/server";
 import { DocNodeBinding } from "@docukit/docsync/docnode";
 import { DocSyncClient } from "@docukit/docsync/client";
 import type { ClientProvider } from "@docukit/docsync/client";
+import { Doc, type Operations } from "@docukit/docnode";
+import { testDocConfig } from "../../int/utils.js";
 
 describe("authentication", () => {
   test("rejects without token", async () => {
@@ -247,6 +249,24 @@ function createMockDocSyncClient(port: number, token: string): DocSyncClient {
 }
 
 describe("sync", () => {
+  function createInsertOperation(): Operations {
+    const doc = new Doc(testDocConfig);
+    const childNodeDef = testDocConfig.extensions[0]?.nodes?.[0];
+    if (!childNodeDef) throw new Error("Missing child node definition");
+
+    let capturedOperations: Operations | undefined;
+    const unregister = doc.onChange((event) => {
+      capturedOperations = event.operations;
+    });
+
+    doc.root.append(doc.createNode(childNodeDef));
+    doc.forceCommit();
+    unregister();
+
+    if (!capturedOperations) throw new Error("Expected captured operations");
+    return capturedOperations;
+  }
+
   test("returns incremented clock", async () => {
     const auth = { getToken: () => "valid-user1" };
     await testWrapper({ auth }, async (T) => {
@@ -276,10 +296,11 @@ describe("sync", () => {
 
       // Send 100 operations individually
       for (let i = 0; i < 100; i++) {
+        const operation = createInsertOperation();
         const res = await T.sync({
           type: "test",
           docId,
-          operations: [{ type: "insert", data: `op-${i}` }],
+          operations: [operation],
           clock: i,
         });
 


### PR DESCRIPTION
## Summary
- make `Doc.applyOperations` accept an optional `origin` and forward it through `doc.onChange`
- isolate each `applyOperations` call into its own transaction instead of allowing multiple `applyOperations` calls to collapse into the same transaction
- use that `origin` in `DocSync` to distinguish remote and broadcast-applied changes from local ones

## Motivation
This mirrors how Yjs and Loro expose a transaction/update origin:
- Yjs: `Y.applyUpdate(..., transactionOrigin)` and `ydoc.on("update", (update, origin) => ...)`
  https://docs.yjs.dev/api/document-updates
- Loro: `doc.commit({ origin })`, where `origin` is used locally for event filtering and undo decisions
  https://www.loro.dev/docs/api/js

Before this change, multiple `applyOperations` calls could end up inside the same transaction. After this change, they do not.

That means some scenarios may now emit more transactions than before. This is intentional and necessary, because some features need to know whether a transaction is remote or local. A concrete example is the Undo Manager: remote operations should not be added to the local undo stack.

## Testing
- `pnpm exec vitest run tests/docnode/transactions.test.ts --project node`
- `pnpm --filter @docukit/docnode typecheck`
- `pnpm --filter @docukit/docsync typecheck`
- `pnpm exec vitest run tests/docsync/unit/client/events.browser.test.ts tests/docsync/unit/client/index.browser.test.ts tests/docsync/unit/client2/index.browser.test.ts --project browser`