### PR TITLE
Simplify selection remapping with document text offsets

### DIFF
--- a/packages/docnode-lexical/src/syncDocNodeToLexical/transformSelection.ts
+++ b/packages/docnode-lexical/src/syncDocNodeToLexical/transformSelection.ts
@@ -14,7 +14,7 @@ import {
 
 type TextReplacement = { start: number; oldEnd: number; newEnd: number };
 
-const ENDPOINT_SEPARATOR = "\n";
+const BLOCK_SEPARATOR = "\n\n";
 
 type SelectionPoint = { key: string; offset: number };
 
@@ -22,26 +22,27 @@ type EndpointBookmark = {
   key: string;
   offset: number;
   text: string;
-  path: number[];
   parentKey: string;
   indexInParent: number;
   previousSiblingKey: string | undefined;
   nextSiblingKey: string | undefined;
-  nextTextKey: string | undefined;
+};
+
+type DocumentTextBookmark = {
+  text: string;
+  anchorOffset: number;
+  focusOffset: number;
 };
 
 type SelectionTransformState = {
   anchor: EndpointBookmark;
   focus: EndpointBookmark;
+  documentText: DocumentTextBookmark | undefined;
 };
 
-type CombinedEndpointText = {
-  oldText: string;
-  endpointOffset: number;
-  otherOffset: number;
-};
+type TextSnapshot = { text: string; spans: TextSpan[] };
 
-type TextMatch = { node: TextNode; startOffset: number };
+type TextSpan = { node: TextNode; start: number; end: number };
 
 export function captureSelectionTransformState():
   | SelectionTransformState
@@ -57,7 +58,11 @@ export function captureSelectionTransformState():
     return;
   }
 
-  return { anchor, focus };
+  return {
+    anchor,
+    focus,
+    documentText: captureDocumentTextBookmark(anchor, focus),
+  };
 }
 
 export function transformSelection(
@@ -67,31 +72,28 @@ export function transformSelection(
     return;
   }
 
-  let nextAnchor = resolveEndpoint(state.anchor, "anchor", state);
-  let nextFocus = resolveEndpoint(state.focus, "focus", state);
+  const textSelection = resolveSelectionFromDocumentText(state);
+  if (textSelection) {
+    setRangeSelection(textSelection.anchor, textSelection.focus);
+    return;
+  }
+
+  const nextAnchor = resolveEndpoint(state.anchor, "anchor", state);
+  const nextFocus = resolveEndpoint(state.focus, "focus", state);
   if (!nextAnchor || !nextFocus) {
-    const recoveredRange = resolveSameTextSelectionTailFromDocument(state);
-    if (!recoveredRange) {
-      return;
-    }
-
-    nextAnchor = recoveredRange.anchor;
-    nextFocus = recoveredRange.focus;
+    return;
   }
 
-  const recoveredRange = resolveCollapsedSameTextSelectionTail(
-    state,
-    nextAnchor,
-    nextFocus,
-  );
-  if (recoveredRange) {
-    nextAnchor = recoveredRange.anchor;
-    nextFocus = recoveredRange.focus;
-  }
+  setRangeSelection(nextAnchor, nextFocus);
+}
 
+function setRangeSelection(
+  anchor: SelectionPoint,
+  focus: SelectionPoint,
+): void {
   const nextSelection = $createRangeSelection();
-  nextSelection.anchor.set(nextAnchor.key, nextAnchor.offset, "text");
-  nextSelection.focus.set(nextFocus.key, nextFocus.offset, "text");
+  nextSelection.anchor.set(anchor.key, anchor.offset, "text");
+  nextSelection.focus.set(focus.key, focus.offset, "text");
   $setSelection(nextSelection);
 }
 
@@ -113,13 +115,150 @@ function captureEndpoint(
     key,
     offset,
     text: node.getTextContent(),
-    path: getPathFromRoot(node),
     parentKey: parent.getKey(),
     indexInParent: node.getIndexWithinParent(),
     previousSiblingKey: node.getPreviousSibling()?.getKey(),
     nextSiblingKey: node.getNextSibling()?.getKey(),
-    nextTextKey: getNextTextNode(node)?.getKey(),
   };
+}
+
+function captureDocumentTextBookmark(
+  anchor: EndpointBookmark,
+  focus: EndpointBookmark,
+): DocumentTextBookmark | undefined {
+  const snapshot = getDocumentTextSnapshot();
+  const anchorOffset = getSnapshotOffset(snapshot, anchor.key, anchor.offset);
+  const focusOffset = getSnapshotOffset(snapshot, focus.key, focus.offset);
+  if (anchorOffset === undefined || focusOffset === undefined) {
+    return;
+  }
+
+  return { text: snapshot.text, anchorOffset, focusOffset };
+}
+
+function resolveSelectionFromDocumentText(
+  state: SelectionTransformState,
+): { anchor: SelectionPoint; focus: SelectionPoint } | undefined {
+  const bookmark = state.documentText;
+  if (!bookmark) {
+    return;
+  }
+
+  const snapshot = getDocumentTextSnapshot();
+  const replacement = getTextReplacement(bookmark.text, snapshot.text);
+  const selectionStart = Math.min(bookmark.anchorOffset, bookmark.focusOffset);
+  const selectionEnd = Math.max(bookmark.anchorOffset, bookmark.focusOffset);
+  const anchorOffset = remapSelectionEndpoint({
+    offset: bookmark.anchorOffset,
+    role: "anchor",
+    selectionStart,
+    selectionEnd,
+    replacement,
+  });
+  const focusOffset = remapSelectionEndpoint({
+    offset: bookmark.focusOffset,
+    role: "focus",
+    selectionStart,
+    selectionEnd,
+    replacement,
+  });
+  const isForward = bookmark.anchorOffset <= bookmark.focusOffset;
+  const anchor = pointFromSnapshotOffset(
+    snapshot,
+    anchorOffset,
+    isForward ? "forward" : "backward",
+  );
+  const focus = pointFromSnapshotOffset(
+    snapshot,
+    focusOffset,
+    isForward ? "backward" : "forward",
+  );
+  if (!anchor || !focus) {
+    return;
+  }
+
+  return { anchor, focus };
+}
+
+function getDocumentTextSnapshot(): TextSnapshot {
+  const spans: TextSpan[] = [];
+  const parts: string[] = [];
+  let offset = 0;
+
+  const appendText = (text: string) => {
+    parts.push(text);
+    offset += text.length;
+  };
+
+  const appendNode = (node: LexicalNode) => {
+    if ($isTextNode(node)) {
+      const text = node.getTextContent();
+      spans.push({ node, start: offset, end: offset + text.length });
+      appendText(text);
+      return;
+    }
+
+    if (!$isElementNode(node)) {
+      return;
+    }
+
+    for (const child of node.getChildren()) {
+      appendNode(child);
+    }
+  };
+
+  const children = $getRoot().getChildren();
+  for (const [index, child] of children.entries()) {
+    if (index > 0) {
+      appendText(BLOCK_SEPARATOR);
+    }
+    appendNode(child);
+  }
+
+  return { text: parts.join(""), spans };
+}
+
+function getSnapshotOffset(
+  snapshot: TextSnapshot,
+  key: string,
+  offset: number,
+): number | undefined {
+  for (const span of snapshot.spans) {
+    if (span.node.getKey() !== key) {
+      continue;
+    }
+
+    return span.start + Math.min(offset, span.end - span.start);
+  }
+}
+
+function pointFromSnapshotOffset(
+  snapshot: TextSnapshot,
+  offset: number,
+  affinity: "forward" | "backward",
+): SelectionPoint | undefined {
+  const boundedOffset = Math.max(0, Math.min(offset, snapshot.text.length));
+  let previous: TextSpan | undefined;
+
+  for (const span of snapshot.spans) {
+    if (boundedOffset < span.start) {
+      return affinity === "backward" && previous
+        ? pointAtEndOfSpan(previous)
+        : { key: span.node.getKey(), offset: 0 };
+    }
+
+    if (boundedOffset <= span.end) {
+      return { key: span.node.getKey(), offset: boundedOffset - span.start };
+    }
+
+    previous = span;
+  }
+
+  return previous ? pointAtEndOfSpan(previous) : undefined;
+}
+
+function pointAtEndOfSpan(span: TextSpan): SelectionPoint {
+  return { key: span.node.getKey(), offset: span.end - span.start };
 }
 
 function resolveEndpoint(
@@ -132,20 +271,6 @@ function resolveEndpoint(
     return resolveSurvivingEndpoint(endpoint, role, state, node);
   }
 
-  const bridged = resolveRemovedEndpointFromSurvivingEndpoint(
-    endpoint,
-    role,
-    state,
-  );
-  if (bridged) {
-    return bridged;
-  }
-
-  const recreated = resolveRemovedEndpointByTextPosition(endpoint, role, state);
-  if (recreated) {
-    return recreated;
-  }
-
   return resolveRemovedEndpoint(endpoint);
 }
 
@@ -155,38 +280,12 @@ function resolveSurvivingEndpoint(
   state: SelectionTransformState,
   node: TextNode,
 ): SelectionPoint {
-  const bridged = resolveSurvivingEndpointFromRemovedEndpoint(
-    endpoint,
-    role,
-    state,
-    node,
-  );
-  if (bridged) {
-    return bridged;
-  }
-
   const nextText = node.getTextContent();
   const replacement = getTextReplacement(endpoint.text, nextText);
   const { selectionStart, selectionEnd } = getEndpointSelectionRange(
     endpoint,
     state,
   );
-  const splitSuffix = resolveEndpointMovedToSplitSuffix(
-    endpoint,
-    node,
-    replacement,
-  );
-  if (splitSuffix) {
-    return splitSuffix;
-  }
-
-  if (
-    state.anchor.key === state.focus.key &&
-    replacement.start < selectionStart &&
-    replacement.oldEnd > selectionEnd
-  ) {
-    return { key: node.getKey(), offset: replacement.start };
-  }
 
   return {
     key: node.getKey(),
@@ -198,40 +297,6 @@ function resolveSurvivingEndpoint(
       replacement,
     }),
   };
-}
-
-function resolveEndpointMovedToSplitSuffix(
-  endpoint: EndpointBookmark,
-  node: TextNode,
-  replacement: TextReplacement,
-): SelectionPoint | undefined {
-  if (replacement.start !== replacement.newEnd) {
-    return;
-  }
-  if (replacement.oldEnd !== endpoint.text.length) {
-    return;
-  }
-  if (endpoint.offset <= replacement.start) {
-    return;
-  }
-
-  const movedText = endpoint.text.slice(replacement.start);
-  const nextTextNode = getNextTextNodeMatching(node, (textNode) =>
-    textNode.getTextContent().startsWith(movedText),
-  );
-  if (nextTextNode?.getKey() === endpoint.nextTextKey) {
-    return;
-  }
-  if (!nextTextNode) {
-    return;
-  }
-
-  const nextOffset = endpoint.offset - replacement.start;
-  if (nextOffset > nextTextNode.getTextContentSize()) {
-    return;
-  }
-
-  return { key: nextTextNode.getKey(), offset: nextOffset };
 }
 
 function getEndpointSelectionRange(
@@ -246,122 +311,6 @@ function getEndpointSelectionRange(
     selectionStart: Math.min(state.anchor.offset, state.focus.offset),
     selectionEnd: Math.max(state.anchor.offset, state.focus.offset),
   };
-}
-
-function resolveCollapsedSameTextSelectionTail(
-  state: SelectionTransformState,
-  anchor: SelectionPoint,
-  focus: SelectionPoint,
-): { anchor: SelectionPoint; focus: SelectionPoint } | undefined {
-  if (state.anchor.key !== state.focus.key) {
-    return;
-  }
-  if (state.anchor.offset === state.focus.offset) {
-    return;
-  }
-  if (anchor.key !== focus.key || anchor.offset !== focus.offset) {
-    return;
-  }
-
-  const match =
-    getSelectedTailMatch(anchor, state) ?? getSelectedTailMatch(focus, state);
-  if (!match) {
-    return;
-  }
-
-  const endOffset = match.startOffset + match.text.length;
-  if (state.anchor.offset <= state.focus.offset) {
-    return {
-      anchor: { key: match.node.getKey(), offset: match.startOffset },
-      focus: { key: match.node.getKey(), offset: endOffset },
-    };
-  }
-
-  return {
-    anchor: { key: match.node.getKey(), offset: endOffset },
-    focus: { key: match.node.getKey(), offset: match.startOffset },
-  };
-}
-
-function resolveSameTextSelectionTailFromDocument(
-  state: SelectionTransformState,
-): { anchor: SelectionPoint; focus: SelectionPoint } | undefined {
-  if (state.anchor.key !== state.focus.key) {
-    return;
-  }
-  if (state.anchor.offset === state.focus.offset) {
-    return;
-  }
-
-  const match = getSelectedTailMatchNearPath(state);
-  if (!match) {
-    return;
-  }
-
-  const endOffset = match.startOffset + match.text.length;
-  if (state.anchor.offset <= state.focus.offset) {
-    return {
-      anchor: { key: match.node.getKey(), offset: match.startOffset },
-      focus: { key: match.node.getKey(), offset: endOffset },
-    };
-  }
-
-  return {
-    anchor: { key: match.node.getKey(), offset: endOffset },
-    focus: { key: match.node.getKey(), offset: match.startOffset },
-  };
-}
-
-function getSelectedTailMatch(
-  point: SelectionPoint,
-  state: SelectionTransformState,
-): (TextMatch & { text: string }) | undefined {
-  const node = getAttachedTextNode(point.key);
-  if (!node) {
-    return;
-  }
-
-  const selectionStart = Math.min(state.anchor.offset, state.focus.offset);
-  const selectionEnd = Math.max(state.anchor.offset, state.focus.offset);
-  const selectedText = state.anchor.text.slice(selectionStart, selectionEnd);
-  const nodeText = node.getTextContent();
-  const minimumLength = Math.min(2, selectedText.length);
-  const searchOffset = Math.min(point.offset, nodeText.length);
-
-  for (
-    let prefixLength = 0;
-    prefixLength <= selectedText.length - minimumLength;
-    prefixLength++
-  ) {
-    const text = selectedText.slice(prefixLength);
-    const startOffset = nodeText.lastIndexOf(text, searchOffset);
-    if (startOffset !== -1) {
-      return { node, startOffset, text };
-    }
-  }
-}
-
-function getSelectedTailMatchNearPath(
-  state: SelectionTransformState,
-): (TextMatch & { text: string }) | undefined {
-  const selectionStart = Math.min(state.anchor.offset, state.focus.offset);
-  const selectionEnd = Math.max(state.anchor.offset, state.focus.offset);
-  const selectedText = state.anchor.text.slice(selectionStart, selectionEnd);
-  const minimumLength = Math.min(2, selectedText.length);
-
-  for (
-    let prefixLength = 0;
-    prefixLength <= selectedText.length - minimumLength;
-    prefixLength++
-  ) {
-    const text = selectedText.slice(prefixLength);
-    const match =
-      getTextMatchAtOrBeforePath(state.focus.path, text, state.focus.key) ??
-      getTextMatchAtOrAfterPath(state.focus.path, text, state.focus.key);
-    if (match) {
-      return { ...match, text };
-    }
-  }
 }
 
 function resolveRemovedEndpoint(
@@ -385,176 +334,6 @@ function resolveRemovedEndpoint(
   if (parent) {
     return pointAtChildIndex(parent, endpoint.indexInParent);
   }
-}
-
-function resolveRemovedEndpointByTextPosition(
-  endpoint: EndpointBookmark,
-  role: "anchor" | "focus",
-  state: SelectionTransformState,
-): SelectionPoint | undefined {
-  if (endpoint.text.length === 0) {
-    return;
-  }
-
-  const other = role === "anchor" ? state.focus : state.anchor;
-  const endpointIsAfterOther = comparePaths(other.path, endpoint.path) < 0;
-  const otherNode = getAttachedTextNode(other.key);
-  const searchPath = otherNode ? getPathFromRoot(otherNode) : other.path;
-  const match = endpointIsAfterOther
-    ? getTextMatchAtOrAfterPath(searchPath, endpoint.text, other.key)
-    : getTextMatchAtOrBeforePath(searchPath, endpoint.text, other.key);
-
-  const nextOffset = match ? match.startOffset + endpoint.offset : 0;
-  if (!match || nextOffset > match.node.getTextContentSize()) {
-    return;
-  }
-
-  return { key: match.node.getKey(), offset: nextOffset };
-}
-
-function resolveRemovedEndpointFromSurvivingEndpoint(
-  endpoint: EndpointBookmark,
-  role: "anchor" | "focus",
-  state: SelectionTransformState,
-): SelectionPoint | undefined {
-  const other = role === "anchor" ? state.focus : state.anchor;
-  const otherNode = getAttachedTextNode(other.key);
-  if (!otherNode) {
-    return;
-  }
-
-  const movedAfterOther = resolveRemovedEndpointMovedAfterSurvivingEndpoint(
-    endpoint,
-    other,
-    otherNode,
-  );
-  if (movedAfterOther) {
-    return movedAfterOther;
-  }
-
-  const recreated = resolveRemovedEndpointByTextPosition(endpoint, role, state);
-  if (recreated) {
-    return recreated;
-  }
-
-  return resolveEndpointAgainstCombinedText(endpoint, role, other, otherNode);
-}
-
-function resolveRemovedEndpointMovedAfterSurvivingEndpoint(
-  endpoint: EndpointBookmark,
-  other: EndpointBookmark,
-  otherNode: TextNode,
-): SelectionPoint | undefined {
-  if (endpoint.text.length === 0) {
-    return;
-  }
-  if (comparePaths(other.path, endpoint.path) >= 0) {
-    return;
-  }
-
-  const otherMovedSuffix = getMovedSuffix(other, otherNode);
-  if (other.nextTextKey !== endpoint.key && !otherMovedSuffix) {
-    return;
-  }
-
-  if (otherMovedSuffix) {
-    const nextTextNode = getNextTextNode(otherNode);
-    if (!nextTextNode?.getTextContent().startsWith(otherMovedSuffix)) {
-      return;
-    }
-  }
-
-  const nextTextNode = getNextTextNodeMatching(otherNode, (textNode) =>
-    textNode.getTextContent().startsWith(endpoint.text),
-  );
-  if (!nextTextNode || endpoint.offset > nextTextNode.getTextContentSize()) {
-    return;
-  }
-
-  return { key: nextTextNode.getKey(), offset: endpoint.offset };
-}
-
-function getMovedSuffix(
-  endpoint: EndpointBookmark,
-  node: TextNode,
-): string | undefined {
-  const replacement = getTextReplacement(endpoint.text, node.getTextContent());
-  if (replacement.start !== replacement.newEnd) {
-    return;
-  }
-  if (replacement.oldEnd !== endpoint.text.length) {
-    return;
-  }
-
-  const suffix = endpoint.text.slice(replacement.start);
-  return suffix.length > 0 ? suffix : undefined;
-}
-
-function resolveSurvivingEndpointFromRemovedEndpoint(
-  endpoint: EndpointBookmark,
-  role: "anchor" | "focus",
-  state: SelectionTransformState,
-  node: TextNode,
-): SelectionPoint | undefined {
-  const other = role === "anchor" ? state.focus : state.anchor;
-  if (getAttachedTextNode(other.key)) {
-    return;
-  }
-
-  return resolveEndpointAgainstCombinedText(endpoint, role, other, node);
-}
-
-function resolveEndpointAgainstCombinedText(
-  endpoint: EndpointBookmark,
-  role: "anchor" | "focus",
-  other: EndpointBookmark,
-  node: TextNode,
-): SelectionPoint | undefined {
-  const combined = getCombinedEndpointText(endpoint, other);
-  const replacement = getTextReplacement(
-    combined.oldText,
-    node.getTextContent(),
-  );
-  const selectionStart = Math.min(
-    combined.endpointOffset,
-    combined.otherOffset,
-  );
-  const selectionEnd = Math.max(combined.endpointOffset, combined.otherOffset);
-
-  const nextOffset = remapSelectionEndpointForReplacement({
-    offset: combined.endpointOffset,
-    role,
-    selectionStart,
-    selectionEnd,
-    replacement,
-  });
-  if (nextOffset < 0 || nextOffset > node.getTextContentSize()) {
-    return;
-  }
-
-  return { key: node.getKey(), offset: nextOffset };
-}
-
-function getCombinedEndpointText(
-  endpoint: EndpointBookmark,
-  other: EndpointBookmark,
-): CombinedEndpointText {
-  const endpointIsAfterOther = comparePaths(other.path, endpoint.path) < 0;
-  const separatorLength = ENDPOINT_SEPARATOR.length;
-
-  // The separator only preserves ordering across two formerly separate text
-  // nodes; it is not meant to model rendered paragraph text.
-  return {
-    oldText: endpointIsAfterOther
-      ? `${other.text}${ENDPOINT_SEPARATOR}${endpoint.text}`
-      : `${endpoint.text}${ENDPOINT_SEPARATOR}${other.text}`,
-    endpointOffset: endpointIsAfterOther
-      ? other.text.length + separatorLength + endpoint.offset
-      : endpoint.offset,
-    otherOffset: endpointIsAfterOther
-      ? other.offset
-      : endpoint.text.length + separatorLength + other.offset,
-  };
 }
 
 function pointAtChildIndex(
@@ -628,73 +407,6 @@ function getLastTextDescendant(node: ElementNode): TextNode | undefined {
   }
 }
 
-function getNextTextNode(node: LexicalNode): TextNode | undefined {
-  return getNextTextNodeMatching(node, () => true);
-}
-
-function getNextTextNodeMatching(
-  node: LexicalNode,
-  predicate: (node: TextNode) => boolean,
-): TextNode | undefined {
-  let current: LexicalNode | undefined = node;
-
-  while (current) {
-    const nextSibling = current.getNextSibling();
-    if (nextSibling) {
-      const nextText = firstTextInNodeOrFollowingSiblings(
-        nextSibling,
-        predicate,
-      );
-      if (nextText) {
-        return nextText;
-      }
-    }
-    current = current.getParent() ?? undefined;
-  }
-}
-
-function firstTextInNodeOrFollowingSiblings(
-  node: LexicalNode,
-  predicate: (node: TextNode) => boolean,
-): TextNode | undefined {
-  let current: LexicalNode | undefined = node;
-
-  while (current) {
-    const text = firstTextInNode(current, predicate);
-    if (text) {
-      return text;
-    }
-    current = current.getNextSibling() ?? undefined;
-  }
-}
-
-function firstTextInNode(
-  node: LexicalNode,
-  predicate: (node: TextNode) => boolean,
-): TextNode | undefined {
-  if ($isTextNode(node)) {
-    return predicate(node) ? node : undefined;
-  }
-  if ($isElementNode(node)) {
-    return getFirstTextDescendantMatching(node, predicate);
-  }
-}
-
-function getFirstTextDescendantMatching(
-  node: ElementNode,
-  predicate: (node: TextNode) => boolean,
-): TextNode | undefined {
-  for (const child of node.getChildren()) {
-    if ($isTextNode(child) && predicate(child)) {
-      return child;
-    }
-    if ($isElementNode(child)) {
-      const text = getFirstTextDescendantMatching(child, predicate);
-      if (text) return text;
-    }
-  }
-}
-
 function getAttachedTextNode(key: string): TextNode | undefined {
   const node = $getNodeByKey(key);
   return $isTextNode(node) && node.isAttached() ? node : undefined;
@@ -708,124 +420,6 @@ function getAttachedElementNode(key: string): ElementNode | undefined {
 function getAttachedNode(key: string): LexicalNode | undefined {
   const node = $getNodeByKey(key);
   return node?.isAttached() ? node : undefined;
-}
-
-function getPathFromRoot(node: LexicalNode): number[] {
-  const path = [node.getIndexWithinParent()];
-  const parents = node.getParents();
-
-  for (let index = 0; index < parents.length - 1; index++) {
-    const parent = parents[index];
-    if (parent) {
-      path.unshift(parent.getIndexWithinParent());
-    }
-  }
-
-  return path;
-}
-
-function getTextMatchAtOrAfterPath(
-  path: number[],
-  text: string,
-  excludeKey: string,
-): TextMatch | undefined {
-  return getTextDescendantMatchAtPath(
-    $getRoot(),
-    path,
-    text,
-    "after",
-    excludeKey,
-  );
-}
-
-function getTextMatchAtOrBeforePath(
-  path: number[],
-  text: string,
-  excludeKey: string,
-): TextMatch | undefined {
-  return getTextDescendantMatchAtPath(
-    $getRoot(),
-    path,
-    text,
-    "before",
-    excludeKey,
-  );
-}
-
-function getTextDescendantMatchAtPath(
-  node: LexicalNode,
-  path: number[],
-  text: string,
-  direction: "after" | "before",
-  excludeKey: string,
-): TextMatch | undefined {
-  if ($isTextNode(node)) {
-    const comparison = comparePaths(getPathFromRoot(node), path);
-    const isCandidate =
-      direction === "after" ? comparison >= 0 : comparison <= 0;
-    if (!isCandidate || node.getKey() === excludeKey) {
-      return;
-    }
-
-    const nodeText = node.getTextContent();
-    const startOffset =
-      direction === "after"
-        ? nodeText.indexOf(text)
-        : nodeText.lastIndexOf(text);
-    return startOffset === -1 ? undefined : { node, startOffset };
-  }
-
-  if (!$isElementNode(node)) {
-    return;
-  }
-
-  const children = node.getChildren();
-  if (direction === "after") {
-    for (const child of children) {
-      const textNode = getTextDescendantMatchAtPath(
-        child,
-        path,
-        text,
-        direction,
-        excludeKey,
-      );
-      if (textNode) {
-        return textNode;
-      }
-    }
-    return;
-  }
-
-  for (let index = children.length - 1; index >= 0; index--) {
-    const child = children[index];
-    if (!child) {
-      continue;
-    }
-
-    const textNode = getTextDescendantMatchAtPath(
-      child,
-      path,
-      text,
-      direction,
-      excludeKey,
-    );
-    if (textNode) {
-      return textNode;
-    }
-  }
-}
-
-function comparePaths(left: number[], right: number[]): number {
-  const length = Math.min(left.length, right.length);
-
-  for (let index = 0; index < length; index++) {
-    const delta = left[index]! - right[index]!;
-    if (delta !== 0) {
-      return delta;
-    }
-  }
-
-  return left.length - right.length;
 }
 
 function getTextReplacement(oldText: string, newText: string): TextReplacement {
@@ -865,6 +459,10 @@ function remapSelectionEndpoint({
   selectionEnd: number;
   replacement: TextReplacement;
 }): number {
+  if (replacement.start < selectionStart && replacement.oldEnd > selectionEnd) {
+    return replacement.start;
+  }
+
   const delta =
     replacement.newEnd -
     replacement.start -
@@ -893,21 +491,4 @@ function remapSelectionEndpoint({
   return replacement.oldEnd > selectionEnd
     ? replacement.start
     : replacement.newEnd;
-}
-
-function remapSelectionEndpointForReplacement(args: {
-  offset: number;
-  role: "anchor" | "focus";
-  selectionStart: number;
-  selectionEnd: number;
-  replacement: TextReplacement;
-}): number {
-  if (
-    args.replacement.start < args.selectionStart &&
-    args.replacement.oldEnd > args.selectionEnd
-  ) {
-    return args.replacement.start;
-  }
-
-  return remapSelectionEndpoint(args);
 }


### PR DESCRIPTION
## Summary
- Replace the special-case removed-node/split-suffix selection remapping with a document-text offset remap.
- Capture the editor text and selection offsets before remote DocNode operations, then diff old/new text and map offsets back to Lexical text nodes.
- Keep a small structural fallback for cases where text mapping cannot produce points.

## Why
This is an experimental alternative to the current PR 23 implementation. The goal is to reduce the number of edge-case heuristics while keeping the same cross-paragraph, split/merge, bold-node, and overlap behavior.

## Validation
- pnpm --filter @docukit/docnode-lexical typecheck
- pnpm exec playwright test tests/docsync/ui/editor/transformSelection/transformSelection.ui.test.ts --project=chromium --workers=1 --reporter=list --retries=0 --timeout=60000 (55 passed)
- pnpm fix
- pnpm test:coverage:once (426 passed, 1 skipped, 4 todo)

## Note
- pnpm test:once still hits the existing docnode ID regex flaky case when compact IDs grow beyond a one-character time prefix. Per request, this PR does not modify that test.