### PR TITLE
Deploy DocSync server to Railway

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,6 +26,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build packages
+        env:
+          SKIP_ENV_VALIDATION: "true"
         run: pnpm build
 
       - name: Check lint, format, and types

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Install dependencies
         run: npm install -g pnpm && pnpm install
       - name: Build docs and workspace dependencies
+        env:
+          NEXT_PUBLIC_DOCSYNC_SERVER_URL: ws://localhost:8081
+          SKIP_ENV_VALIDATION: "true"
         run: pnpm exec turbo build --filter=@docukit/docs
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
       - name: Run Playwright tests
+        env:
+          NEXT_PUBLIC_DOCSYNC_SERVER_URL: ws://localhost:8081
+          SKIP_ENV_VALIDATION: "true"
         run: pnpm exec playwright test
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
+        env:
+          SKIP_ENV_VALIDATION: "true"
         run: pnpm build
 
       - name: Publish to npm
@@ -83,6 +85,12 @@ jobs:
             exit 1
           fi
           gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
+
+      - name: Deploy DocSync server to Railway
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_SERVICE: ${{ vars.RAILWAY_DOCSYNC_SERVICE || 'docukit-docsync' }}
+        run: pnpm dlx @railway/cli up --service "$RAILWAY_SERVICE" --environment production --ci
 
       - name: Deploy docs to Vercel
         working-directory: docs

--- a/docs/collab-server/docsync-server.ts
+++ b/docs/collab-server/docsync-server.ts
@@ -4,9 +4,9 @@ import { lexicalDocNodeConfig } from "@docukit/docnode-lexical";
 import { indexDocConfig } from "../src/components/examples/shared-config.ts";
 import { sqliteProvider } from "./sqlite-provider.ts";
 
-const port = Number(process.env.DOCSYNC_PORT ?? "8081");
+const port = Number(process.env.PORT ?? process.env.DOCSYNC_PORT ?? "8081");
 if (!Number.isInteger(port) || port <= 0) {
-  throw new Error("DOCSYNC_PORT must be a positive integer");
+  throw new Error("PORT/DOCSYNC_PORT must be a positive integer");
 }
 
 new DocSyncServer({

--- a/docs/src/components/examples/utils/createMultiClients.tsx
+++ b/docs/src/components/examples/utils/createMultiClients.tsx
@@ -6,9 +6,7 @@ import {
   createDocSyncClient,
 } from "@docukit/docsync-react/client";
 import type { DocConfig } from "@docukit/docnode";
-
-const DOCSYNC_SERVER_URL =
-  process.env.NEXT_PUBLIC_DOCSYNC_SERVER_URL ?? "ws://localhost:8081";
+import { env } from "@/env";
 
 // Create 3 separate DocSyncClient instances with different deviceIds
 const createClientForUser = (
@@ -23,7 +21,7 @@ const createClientForUser = (
 
   return createDocSyncClient({
     server: {
-      url: DOCSYNC_SERVER_URL,
+      url: env.NEXT_PUBLIC_DOCSYNC_SERVER_URL,
       auth: {
         getToken: () => userId, // Use userId as token
       },

--- a/docs/src/env.ts
+++ b/docs/src/env.ts
@@ -1,6 +1,11 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
+const localDocSyncServerUrl =
+  process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"
+    ? "ws://localhost:8081"
+    : undefined;
+
 export const env = createEnv({
   /**
    * Server-side environment variables schema.
@@ -24,8 +29,13 @@ export const env = createEnv({
    * These are exposed to the browser and must be prefixed with NEXT_PUBLIC_.
    */
   client: {
-    // Add client-side env vars here if needed
-    // NEXT_PUBLIC_EXAMPLE: z.string().min(1),
+    NEXT_PUBLIC_DOCSYNC_SERVER_URL: z
+      .string()
+      .url()
+      .refine(
+        (value) => value.startsWith("ws://") || value.startsWith("wss://"),
+        "Must be a ws:// or wss:// URL",
+      ),
   },
 
   /**
@@ -33,8 +43,8 @@ export const env = createEnv({
    * For Next.js >= 13.4.4, you only need to destructure client variables.
    */
   experimental__runtimeEnv: {
-    // Client vars need to be destructured here
-    // NEXT_PUBLIC_EXAMPLE: process.env.NEXT_PUBLIC_EXAMPLE,
+    NEXT_PUBLIC_DOCSYNC_SERVER_URL:
+      process.env.NEXT_PUBLIC_DOCSYNC_SERVER_URL ?? localDocSyncServerUrl,
   },
 
   /**
@@ -42,7 +52,10 @@ export const env = createEnv({
    * and only client variables on the client. This saves on bundle size.
    * If you want to always validate, set this to true.
    */
-  skipValidation: !!process.env.CI || process.env.NODE_ENV === "development",
+  skipValidation:
+    process.env.SKIP_ENV_VALIDATION === "true" ||
+    process.env.NODE_ENV === "development" ||
+    process.env.NODE_ENV === "test",
 
   /**
    * Makes it so that empty strings are treated as undefined.

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "RAILPACK",
+    "buildCommand": "pnpm exec turbo build --filter='!@docukit/docs'"
+  },
+  "deploy": {
+    "startCommand": "pnpm --filter @docukit/docs docsync-server",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,13 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"],
-      "env": ["GROQ_API_KEY", "SMTP_URL", "CONTACT_EMAIL_TO"]
+      "env": [
+        "GROQ_API_KEY",
+        "SMTP_URL",
+        "CONTACT_EMAIL_TO",
+        "NEXT_PUBLIC_DOCSYNC_SERVER_URL",
+        "SKIP_ENV_VALIDATION"
+      ]
     },
     "dev": { "cache": false, "persistent": true },
     "clean": { "cache": false },


### PR DESCRIPTION
Adds Railway deployment for the DocSync server to the release workflow while keeping the docs site on Vercel. Validates NEXT_PUBLIC_DOCSYNC_SERVER_URL through t3-env and uses it from the examples client. Updates the DocSync server to prefer Railway's PORT env var and keeps generic CI builds from requiring production env values.