### PR TITLE
Implement undo manager merge interval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - When I ask a question or describe a problem, start by brainstorming a few potential solutions.
 - Show example code for each and help me compare them.
 - Ask which one we should try together.
+- Do not perform any git-related action unless I explicitly ask for that exact action in the current conversation. This includes staging, unstaging, committing, pushing, branching, switching branches, rebasing, stashing, restoring files, or any other command that mutates git state.
 
 ## Implementation Loop
 

--- a/docs/content/docs/docnode/undo-manager.mdx
+++ b/docs/content/docs/docnode/undo-manager.mdx
@@ -49,15 +49,6 @@ If `undoManager` is omitted, `maxUndoSteps` defaults to `0`.
 Use `skipUndo` for changes that should not become undoable, such as initial content, imports, or remote operations.
 
 ```ts
-doc.forceCommit(
-  () => {
-    seedInitialContent(doc);
-  },
-  { skipUndo: true },
-);
-```
-
-```ts
 doc.forceCommit(() => seedInitialContent(doc), { skipUndo: true });
 doc.applyOperations(remoteOperations, { skipUndo: true });
 ```

--- a/docs/content/docs/docnode/undo-manager.mdx
+++ b/docs/content/docs/docnode/undo-manager.mdx
@@ -5,7 +5,7 @@ description: Undo Manager of the DocNode
 
 import { TypeTable } from "fumadocs-ui/components/type-table";
 
-DocNode provides a built-in undo manager that can be used to undo and redo transactions. It is configured on the document constructor and is disabled by default.
+DocNode includes an undo manager for local transactions. Configure it on the `Doc`; it is disabled by default.
 
 ```ts
 import { Doc } from "@docukit/docnode";
@@ -13,7 +13,7 @@ import { Doc } from "@docukit/docnode";
 const doc = new Doc({
   type: "root",
   extensions: [MyExtension],
-  undoManager: { maxUndoSteps: 100 },
+  undoManager: { maxUndoSteps: 100, mergeInterval: 1000 },
 });
 
 doc.undoManager.undo(); // undo the last transaction
@@ -23,14 +23,9 @@ doc.undoManager.canRedo(); // true if there are redo steps available
 doc.undoManager.isEnabled; // true when maxUndoSteps is greater than 0
 ```
 
-If `undoManager` is omitted, `maxUndoSteps` defaults to `0`, so undo and redo are disabled.
+If `undoManager` is omitted, `maxUndoSteps` defaults to `0`.
 
 ## Options
-
-{/* I wonder if a simple table offers better readability than the TypeTable component. */}
-{/* | Option | Description | Default | */}
-{/* | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | */}
-{/* | maxUndoSteps | The maximum number of undo steps to keep in the undo stack. If the number of undo steps exceeds this limit, the oldest undo step will be removed. | 0 | */}
 
 <TypeTable
   type={{
@@ -40,14 +35,18 @@ If `undoManager` is omitted, `maxUndoSteps` defaults to `0`, so undo and redo ar
       type: "number",
       default: 0,
     },
+    mergeInterval: {
+      description:
+        "The interval in milliseconds used to merge nearby transactions into a single undo step. Set it to 0 to disable merging.",
+      type: "number",
+      default: 1000,
+    },
   }}
 />
 
 ## Skipping Undo History
 
-Some transactions should update the document without becoming undoable. Common examples are initial content, imports, and operations received from another device.
-
-Use `forceCommit(callback, { skipUndo: true })` to isolate a local update and keep it out of the undo stack:
+Use `skipUndo` for changes that should not become undoable, such as initial content, imports, or remote operations.
 
 ```ts
 doc.forceCommit(
@@ -58,10 +57,9 @@ doc.forceCommit(
 );
 ```
 
-When replaying remote operations, pass the same flag to `applyOperations`:
-
 ```ts
-doc.applyOperations(operations, { skipUndo: true });
+doc.forceCommit(() => seedInitialContent(doc), { skipUndo: true });
+doc.applyOperations(remoteOperations, { skipUndo: true });
 ```
 
 <Callout type="info">
@@ -85,10 +83,4 @@ const offPop = doc.undoManager.onPop(({ meta }) => {
 });
 ```
 
-`meta` is an opaque `Map` owned by that stack item.
-
-- `onPush(...)`: capture extra state before the step is finalized.
-- `onPop(...)`: restore that state after undo or redo applies.
-
-Both events also receive a type field with either "undo" or "redo".
-This helps avoid attaching metadata at the wrong moment. See our bindings source code for real examples.
+`meta` is an opaque `Map` owned by the stack item. Both callbacks also receive `type`, either `"undo"` or `"redo"`.

--- a/docs/content/docs/docnode/undo-manager.mdx
+++ b/docs/content/docs/docnode/undo-manager.mdx
@@ -13,7 +13,7 @@ import { Doc } from "@docukit/docnode";
 const doc = new Doc({
   type: "root",
   extensions: [MyExtension],
-  undoManager: { maxUndoSteps: 100, mergeInterval: 1000 },
+  undoManager: { maxUndoSteps: 100, mergeInterval: 500 },
 });
 
 doc.undoManager.undo(); // undo the last transaction
@@ -39,7 +39,7 @@ If `undoManager` is omitted, `maxUndoSteps` defaults to `0`.
       description:
         "The interval in milliseconds used to merge nearby transactions into a single undo step. Set it to 0 to disable merging.",
       type: "number",
-      default: 1000,
+      default: 500,
     },
   }}
 />

--- a/packages/docnode-lexical/src/setupUndoManager.ts
+++ b/packages/docnode-lexical/src/setupUndoManager.ts
@@ -94,7 +94,11 @@ export function setupUndoManager(
   );
 
   const offPush = undoManager.onPush(({ meta, type }) => {
-    if (pending?.targetStack === type && pending.selection) {
+    if (
+      pending?.targetStack === type &&
+      pending.selection &&
+      !meta.has(META_SELECTION)
+    ) {
       meta.set(META_SELECTION, pending.selection);
     }
     pending = undefined;

--- a/packages/docnode/src/exports/index.ts
+++ b/packages/docnode/src/exports/index.ts
@@ -18,4 +18,4 @@ export {
 } from "../types.js";
 export { defineNode } from "../utils.js";
 export { boolean, number, string, defineState } from "../stateDefinitions.js";
-export { type Operations } from "../operations.js";
+export { mergeOperations, type Operations } from "../operations.js";

--- a/packages/docnode/src/operations.ts
+++ b/packages/docnode/src/operations.ts
@@ -399,6 +399,21 @@ type StatePatch = { [id: string]: Record<string, string> };
 
 export type Operations = readonly [OrderedOperation[], StatePatch];
 
+export function mergeOperations(...operationsList: Operations[]): Operations {
+  const orderedOperations: OrderedOperation[] = [];
+  const statePatch: StatePatch = {};
+
+  for (const operations of operationsList) {
+    orderedOperations.push(...operations[0]);
+    for (const nodeId in operations[1]) {
+      statePatch[nodeId] ??= {};
+      Object.assign(statePatch[nodeId], operations[1][nodeId]);
+    }
+  }
+
+  return [orderedOperations, statePatch];
+}
+
 // TODO: decide whether this will be added to the API in node.getChildren().toArray()
 function getChildren(node: DocNode) {
   const children: DocNode[] = [];

--- a/packages/docnode/src/types.ts
+++ b/packages/docnode/src/types.ts
@@ -203,7 +203,7 @@ export type UndoManagerConfig = {
   /**
    * The interval in milliseconds to merge transactions into a single undo step.
    * Set to 0 to disable merging.
-   * @default 1000
+   * @default 500
    */
   mergeInterval?: number;
 };

--- a/packages/docnode/src/types.ts
+++ b/packages/docnode/src/types.ts
@@ -200,12 +200,12 @@ export type UndoManagerConfig = {
    * @default 0
    */
   maxUndoSteps?: number;
-  // TODO:
-  // /**
-  //  * The interval in milliseconds to merge transactions into a single undo step.
-  //  * @default 1000
-  //  */
-  // mergeInterval?: number;
+  /**
+   * The interval in milliseconds to merge transactions into a single undo step.
+   * Set to 0 to disable merging.
+   * @default 1000
+   */
+  mergeInterval?: number;
 };
 
 export type DocConfig = {

--- a/packages/docnode/src/undoManager.ts
+++ b/packages/docnode/src/undoManager.ts
@@ -1,5 +1,5 @@
 import { type Doc } from "./main.js";
-import type { Operations } from "./operations.js";
+import { mergeOperations, type Operations } from "./operations.js";
 import type { UndoManagerConfig } from "./types.js";
 
 /** `meta` is opaque — consumers attach arbitrary data (e.g. selection). */
@@ -12,16 +12,18 @@ type Handler = (event: UndoManagerEvent) => void;
 export class UndoManager {
   private readonly _doc: Doc;
   private readonly _maxUndoSteps: number;
+  private readonly _mergeInterval: number;
   protected _undoStack: UndoStackItem[] = [];
   protected _redoStack: UndoStackItem[] = [];
   private _txType: "undo" | "redo" | "update" = "update";
-  private _lastUpdate: number | undefined; // TODO: threeshold to combine transactions of 500ms
+  private _lastUpdate: number | undefined;
   private _pushHandlers = new Set<Handler>();
   private _popHandlers = new Set<Handler>();
 
   constructor(doc: Doc, options?: UndoManagerConfig) {
     this._doc = doc;
     this._maxUndoSteps = options?.maxUndoSteps ?? 0;
+    this._mergeInterval = options?.mergeInterval ?? 1000;
     if (!this.isEnabled) return;
 
     this._doc.onChange((event) => {
@@ -31,14 +33,31 @@ export class UndoManager {
         meta: new Map(),
       };
       if (this._txType === "update") {
-        if (this._maxUndoSteps > this._undoStack.length) {
+        const now = Date.now();
+        const lastItem = this._undoStack.at(-1);
+        if (
+          lastItem &&
+          this._lastUpdate !== undefined &&
+          now - this._lastUpdate < this._mergeInterval
+        ) {
+          lastItem.operations = mergeOperations(
+            item.operations,
+            lastItem.operations,
+          );
+          this._pushHandlers.forEach((h) =>
+            h({ meta: lastItem.meta, type: "undo" }),
+          );
+        } else {
+          if (this._undoStack.length >= this._maxUndoSteps) {
+            this._undoStack.shift();
+          }
           this._undoStack.push(item);
           this._pushHandlers.forEach((h) =>
             h({ meta: item.meta, type: "undo" }),
           );
         }
         this._redoStack = [];
-        this._lastUpdate = Date.now();
+        this._lastUpdate = now;
       } else if (this._txType === "undo") {
         this._redoStack.push(item);
         this._txType = "update";
@@ -60,6 +79,7 @@ export class UndoManager {
     const item = this._undoStack.pop();
     if (!item) return;
     this._txType = "undo";
+    this._lastUpdate = undefined;
     this._doc.applyOperations(item.operations);
     this._popHandlers.forEach((h) => h({ meta: item.meta, type: "undo" }));
   }
@@ -69,6 +89,7 @@ export class UndoManager {
     const item = this._redoStack.pop();
     if (!item) return;
     this._txType = "redo";
+    this._lastUpdate = undefined;
     this._doc.applyOperations(item.operations);
     this._popHandlers.forEach((h) => h({ meta: item.meta, type: "redo" }));
   }

--- a/packages/docnode/src/undoManager.ts
+++ b/packages/docnode/src/undoManager.ts
@@ -23,7 +23,7 @@ export class UndoManager {
   constructor(doc: Doc, options?: UndoManagerConfig) {
     this._doc = doc;
     this._maxUndoSteps = options?.maxUndoSteps ?? 0;
-    this._mergeInterval = options?.mergeInterval ?? 1000;
+    this._mergeInterval = options?.mergeInterval ?? 500;
     if (!this.isEnabled) return;
 
     this._doc.onChange((event) => {

--- a/tests/docnode-lexical/setupUndoManager.test.ts
+++ b/tests/docnode-lexical/setupUndoManager.test.ts
@@ -210,7 +210,7 @@ describe("setupUndoManager doc undo manager", () => {
   });
 
   it("keeps the first selection metadata when updates merge into one undo item", () => {
-    const doc = createLexicalDoc({ mergeInterval: 1000 });
+    const doc = createLexicalDoc({ mergeInterval: 500 });
     const editor = makeEditor();
     const docNode = doc.createNode(LexicalDocNode);
     doc.forceCommit(
@@ -262,7 +262,7 @@ describe("setupUndoManager doc undo manager", () => {
     doc.root.append(doc.createNode(LexicalDocNode));
     doc.forceCommit();
 
-    now = 1500;
+    now = 1400;
     editor.update(
       () => {
         const textNode = $getNodeByKey(textKey);

--- a/tests/docnode-lexical/setupUndoManager.test.ts
+++ b/tests/docnode-lexical/setupUndoManager.test.ts
@@ -6,8 +6,16 @@ import {
 } from "@docukit/docnode-lexical";
 import { createLexicalDoc } from "./utils.js";
 import {
+  $createParagraphNode,
+  $createRangeSelection,
+  $createTextNode,
+  $getNodeByKey,
+  $getRoot,
+  $isTextNode,
+  $setSelection,
   CAN_REDO_COMMAND,
   CAN_UNDO_COMMAND,
+  COLLABORATION_TAG,
   COMMAND_PRIORITY_EDITOR,
   COMMAND_PRIORITY_HIGH,
   COMMAND_PRIORITY_LOW,
@@ -199,6 +207,86 @@ describe("setupUndoManager doc undo manager", () => {
     off();
     offUndoFallback();
     offRedoFallback();
+  });
+
+  it("keeps the first selection metadata when updates merge into one undo item", () => {
+    const doc = createLexicalDoc({ mergeInterval: 1000 });
+    const editor = makeEditor();
+    const docNode = doc.createNode(LexicalDocNode);
+    doc.forceCommit(
+      () => {
+        doc.root.append(docNode);
+      },
+      { skipUndo: true },
+    );
+
+    let textKey = "";
+    editor.update(
+      () => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        const textNode = $createTextNode("abc");
+        textKey = textNode.getKey();
+        paragraph.append(textNode);
+        root.clear();
+        root.append(paragraph);
+
+        const selection = $createRangeSelection();
+        selection.anchor.set(textKey, 0, "text");
+        selection.focus.set(textKey, 0, "text");
+        $setSelection(selection);
+      },
+      { discrete: true, tag: COLLABORATION_TAG },
+    );
+
+    const keyBinding = {
+      lexicalKeyToDocNodeId: new Map([[textKey, docNode.id]]),
+      docNodeIdToLexicalKey: new Map([[docNode.id, textKey]]),
+    };
+    const off = setupUndoManager(editor, doc, keyBinding);
+    let now = 1000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+
+    editor.update(
+      () => {
+        const textNode = $getNodeByKey(textKey);
+        if (!$isTextNode(textNode)) throw new Error("Expected text node");
+        textNode.setTextContent("abcd");
+        const selection = $createRangeSelection();
+        selection.anchor.set(textKey, 1, "text");
+        selection.focus.set(textKey, 1, "text");
+        $setSelection(selection);
+      },
+      { discrete: true },
+    );
+    doc.root.append(doc.createNode(LexicalDocNode));
+    doc.forceCommit();
+
+    now = 1500;
+    editor.update(
+      () => {
+        const textNode = $getNodeByKey(textKey);
+        if (!$isTextNode(textNode)) throw new Error("Expected text node");
+        textNode.setTextContent("abcde");
+        const selection = $createRangeSelection();
+        selection.anchor.set(textKey, 2, "text");
+        selection.focus.set(textKey, 2, "text");
+        $setSelection(selection);
+      },
+      { discrete: true },
+    );
+    doc.root.append(doc.createNode(LexicalDocNode));
+    doc.forceCommit();
+
+    const item = doc.undoManager["_undoStack"][0];
+    expect(doc.undoManager["_undoStack"]).toHaveLength(1);
+    expect(item?.meta.get("selection")).toStrictEqual({
+      anchor: { key: docNode.id, offset: 0 },
+      focus: { key: docNode.id, offset: 0 },
+    });
+
+    dateNow.mockRestore();
+    off();
   });
 
   it("does not register undo handlers when undo manager is disabled", () => {

--- a/tests/docnode-lexical/utils.ts
+++ b/tests/docnode-lexical/utils.ts
@@ -3,11 +3,12 @@ import { createLexicalDocNodeConfig } from "@docukit/docnode-lexical";
 
 export const createLexicalDoc = ({
   enableUndoManager = true,
-}: { enableUndoManager?: boolean } = {}): Doc => {
+  mergeInterval = 0,
+}: { enableUndoManager?: boolean; mergeInterval?: number } = {}): Doc => {
   const doc = Doc.fromJSON(
     createLexicalDocNodeConfig({
       type: "root",
-      undoManager: { maxUndoSteps: enableUndoManager ? 100 : 0 },
+      undoManager: { maxUndoSteps: enableUndoManager ? 100 : 0, mergeInterval },
     }),
     ["01kc52hq510g6y44jhq0wqrjb3", "root", {}],
   );

--- a/tests/docnode/coverage.test.ts
+++ b/tests/docnode/coverage.test.ts
@@ -129,7 +129,7 @@ describe("undoManager.ts coverage", () => {
     expect(undoManager.canRedo()).toBe(false);
   });
 
-  test("empty undo does not turn the next local edit into redo history", () => {
+  test("empty undo and redo do not affect the next local edit", () => {
     const doc = createTextDocWithUndo();
     const undoManager = doc.undoManager;
 
@@ -142,6 +142,20 @@ describe("undoManager.ts coverage", () => {
 
     undoManager.redo();
     assertDoc(doc, ["1"]);
+
+    undoManager.undo();
+    assertDoc(doc, []);
+
+    undoManager.redo();
+    assertDoc(doc, ["1"]);
+
+    undoManager.redo();
+    doc.root.append(...text(doc, "2"));
+    doc.forceCommit();
+
+    expect(undoManager.canUndo()).toBe(true);
+    expect(undoManager.canRedo()).toBe(false);
+    assertDoc(doc, ["1", "2"]);
   });
 
   test("disabled undoManager stays inert after edits", () => {

--- a/tests/docnode/transactions.test.ts
+++ b/tests/docnode/transactions.test.ts
@@ -239,7 +239,7 @@ describe("undoManager", () => {
     const doc = createTextDocWithUndo(2);
     const undoManager = doc.undoManager;
 
-    checkUndoManager(5, doc, () => {
+    checkUndoManager(3, doc, () => {
       doc.root.append(...text(doc, "1"));
       doc.forceCommit();
       doc.root.append(...text(doc, "2"));
@@ -248,16 +248,17 @@ describe("undoManager", () => {
       doc.forceCommit();
 
       expect(undoManager["_undoStack"]).toHaveLength(2);
-
-      undoManager.undo();
-      assertDoc(doc, ["1", "2"]);
-
-      undoManager.undo();
-      assertDoc(doc, ["1"]);
-
-      undoManager.undo();
-      assertDoc(doc, ["1"]);
     });
+
+    // TODO: make checkUndoManager support wrapping undo/redo assertions too.
+    undoManager.undo();
+    assertDoc(doc, ["1", "2"]);
+
+    undoManager.undo();
+    assertDoc(doc, ["1"]);
+
+    undoManager.undo();
+    assertDoc(doc, ["1"]);
   });
 
   test("mergeInterval merges updates separated by a short gap", () => {
@@ -265,7 +266,7 @@ describe("undoManager", () => {
       const doc = createTextDocWithUndo(10, 1000);
       const undoManager = doc.undoManager;
 
-      checkUndoManager(4, doc, () => {
+      checkUndoManager(2, doc, () => {
         setNow(1000);
         doc.root.append(...text(doc, "a"));
         doc.forceCommit();
@@ -274,12 +275,12 @@ describe("undoManager", () => {
         doc.forceCommit();
 
         expect(undoManager["_undoStack"]).toHaveLength(1);
-
-        undoManager.undo();
-        assertDoc(doc, []);
-        undoManager.redo();
-        assertDoc(doc, ["a", "b"]);
       });
+
+      undoManager.undo();
+      assertDoc(doc, []);
+      undoManager.redo();
+      assertDoc(doc, ["a", "b"]);
     });
   });
 
@@ -288,7 +289,7 @@ describe("undoManager", () => {
       const doc = createTextDocWithUndo(10, 1000);
       const undoManager = doc.undoManager;
 
-      checkUndoManager(4, doc, () => {
+      checkUndoManager(2, doc, () => {
         setNow(1000);
         doc.root.append(...text(doc, "a"));
         doc.forceCommit();
@@ -297,12 +298,12 @@ describe("undoManager", () => {
         doc.forceCommit();
 
         expect(undoManager["_undoStack"]).toHaveLength(2);
-
-        undoManager.undo();
-        assertDoc(doc, ["a"]);
-        undoManager.undo();
-        assertDoc(doc, []);
       });
+
+      undoManager.undo();
+      assertDoc(doc, ["a"]);
+      undoManager.undo();
+      assertDoc(doc, []);
     });
   });
 
@@ -311,7 +312,7 @@ describe("undoManager", () => {
       const doc = createTextDocWithUndo(10, 0);
       const undoManager = doc.undoManager;
 
-      checkUndoManager(3, doc, () => {
+      checkUndoManager(2, doc, () => {
         setNow(1000);
         doc.root.append(...text(doc, "a"));
         doc.forceCommit();
@@ -319,10 +320,10 @@ describe("undoManager", () => {
         doc.forceCommit();
 
         expect(undoManager["_undoStack"]).toHaveLength(2);
-
-        undoManager.undo();
-        assertDoc(doc, ["a"]);
       });
+
+      undoManager.undo();
+      assertDoc(doc, ["a"]);
     });
   });
 
@@ -335,10 +336,10 @@ describe("undoManager", () => {
       doc.forceCommit();
 
       expect(undoManager.canUndo()).toBe(false);
-
-      undoManager.undo();
-      assertDoc(doc, ["a"]);
     });
+
+    undoManager.undo();
+    assertDoc(doc, ["a"]);
   });
 
   test("merged state patches undo to the state before the first update", () => {
@@ -347,7 +348,7 @@ describe("undoManager", () => {
       const undoManager = doc.undoManager;
       let node: DocNode<typeof Text> | undefined;
 
-      checkUndoManager(4, doc, () => {
+      checkUndoManager(3, doc, () => {
         setNow(1000);
         doc.forceCommit(() => {
           node = doc.createNode(Text);
@@ -363,10 +364,10 @@ describe("undoManager", () => {
         doc.forceCommit();
 
         expect(undoManager["_undoStack"]).toHaveLength(2);
-
-        undoManager.undo();
-        assertDoc(doc, [""]);
       });
+
+      undoManager.undo();
+      assertDoc(doc, [""]);
     });
   });
 

--- a/tests/docnode/transactions.test.ts
+++ b/tests/docnode/transactions.test.ts
@@ -263,14 +263,14 @@ describe("undoManager", () => {
 
   test("mergeInterval merges updates separated by a short gap", () => {
     withMockedDateNow((setNow) => {
-      const doc = createTextDocWithUndo(10, 1000);
+      const doc = createTextDocWithUndo(10, 500);
       const undoManager = doc.undoManager;
 
       checkUndoManager(2, doc, () => {
         setNow(1000);
         doc.root.append(...text(doc, "a"));
         doc.forceCommit();
-        setNow(1500);
+        setNow(1400);
         doc.root.append(...text(doc, "b"));
         doc.forceCommit();
 
@@ -286,14 +286,14 @@ describe("undoManager", () => {
 
   test("mergeInterval starts a new undo step after a long gap", () => {
     withMockedDateNow((setNow) => {
-      const doc = createTextDocWithUndo(10, 1000);
+      const doc = createTextDocWithUndo(10, 500);
       const undoManager = doc.undoManager;
 
       checkUndoManager(2, doc, () => {
         setNow(1000);
         doc.root.append(...text(doc, "a"));
         doc.forceCommit();
-        setNow(2500);
+        setNow(1600);
         doc.root.append(...text(doc, "b"));
         doc.forceCommit();
 
@@ -344,7 +344,7 @@ describe("undoManager", () => {
 
   test("merged state patches undo to the state before the first update", () => {
     withMockedDateNow((setNow) => {
-      const doc = createTextDocWithUndo(10, 1000);
+      const doc = createTextDocWithUndo(10, 500);
       const undoManager = doc.undoManager;
       let node: DocNode<typeof Text> | undefined;
 
@@ -356,10 +356,10 @@ describe("undoManager", () => {
         }, {});
         if (!node) throw new Error("Expected seed node to be created");
 
-        setNow(2500);
+        setNow(1600);
         node.state.value.set("a");
         doc.forceCommit();
-        setNow(3000);
+        setNow(2000);
         node.state.value.set("b");
         doc.forceCommit();
 

--- a/tests/docnode/transactions.test.ts
+++ b/tests/docnode/transactions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   Doc,
   type DocNode,
+  mergeOperations,
   type Operations,
   type TransactionFlags,
 } from "@docukit/docnode";
@@ -208,6 +209,21 @@ describe("throw errors and abort", () => {
 });
 
 describe("undoManager", () => {
+  function withMockedDateNow(
+    callback: (setNow: (value: number) => void) => void,
+  ) {
+    const originalDateNow = Date.now;
+    let now = 0;
+    Date.now = () => now;
+    try {
+      callback((value) => {
+        now = value;
+      });
+    } finally {
+      Date.now = originalDateNow;
+    }
+  }
+
   test("simplest case", () => {
     const doc = createTextDocWithUndo(1);
     const undoManager = doc.undoManager;
@@ -217,6 +233,170 @@ describe("undoManager", () => {
     assertDoc(doc, []);
     undoManager.redo();
     assertDoc(doc, ["1", "2"]);
+  });
+
+  test("maxUndoSteps keeps the most recent undo steps", () => {
+    const doc = createTextDocWithUndo(2);
+    const undoManager = doc.undoManager;
+
+    checkUndoManager(5, doc, () => {
+      doc.root.append(...text(doc, "1"));
+      doc.forceCommit();
+      doc.root.append(...text(doc, "2"));
+      doc.forceCommit();
+      doc.root.append(...text(doc, "3"));
+      doc.forceCommit();
+
+      expect(undoManager["_undoStack"]).toHaveLength(2);
+
+      undoManager.undo();
+      assertDoc(doc, ["1", "2"]);
+
+      undoManager.undo();
+      assertDoc(doc, ["1"]);
+
+      undoManager.undo();
+      assertDoc(doc, ["1"]);
+    });
+  });
+
+  test("mergeInterval merges updates separated by a short gap", () => {
+    withMockedDateNow((setNow) => {
+      const doc = createTextDocWithUndo(10, 1000);
+      const undoManager = doc.undoManager;
+
+      checkUndoManager(4, doc, () => {
+        setNow(1000);
+        doc.root.append(...text(doc, "a"));
+        doc.forceCommit();
+        setNow(1500);
+        doc.root.append(...text(doc, "b"));
+        doc.forceCommit();
+
+        expect(undoManager["_undoStack"]).toHaveLength(1);
+
+        undoManager.undo();
+        assertDoc(doc, []);
+        undoManager.redo();
+        assertDoc(doc, ["a", "b"]);
+      });
+    });
+  });
+
+  test("mergeInterval starts a new undo step after a long gap", () => {
+    withMockedDateNow((setNow) => {
+      const doc = createTextDocWithUndo(10, 1000);
+      const undoManager = doc.undoManager;
+
+      checkUndoManager(4, doc, () => {
+        setNow(1000);
+        doc.root.append(...text(doc, "a"));
+        doc.forceCommit();
+        setNow(2500);
+        doc.root.append(...text(doc, "b"));
+        doc.forceCommit();
+
+        expect(undoManager["_undoStack"]).toHaveLength(2);
+
+        undoManager.undo();
+        assertDoc(doc, ["a"]);
+        undoManager.undo();
+        assertDoc(doc, []);
+      });
+    });
+  });
+
+  test("mergeInterval 0 disables undo step merging", () => {
+    withMockedDateNow((setNow) => {
+      const doc = createTextDocWithUndo(10, 0);
+      const undoManager = doc.undoManager;
+
+      checkUndoManager(3, doc, () => {
+        setNow(1000);
+        doc.root.append(...text(doc, "a"));
+        doc.forceCommit();
+        doc.root.append(...text(doc, "b"));
+        doc.forceCommit();
+
+        expect(undoManager["_undoStack"]).toHaveLength(2);
+
+        undoManager.undo();
+        assertDoc(doc, ["a"]);
+      });
+    });
+  });
+
+  test("maxUndoSteps 0 disables undo history", () => {
+    const doc = new Doc({ type: "root", extensions: [TextExtension] });
+    const undoManager = doc.undoManager;
+
+    checkUndoManager(1, doc, () => {
+      doc.root.append(...text(doc, "a"));
+      doc.forceCommit();
+
+      expect(undoManager.canUndo()).toBe(false);
+
+      undoManager.undo();
+      assertDoc(doc, ["a"]);
+    });
+  });
+
+  test("merged state patches undo to the state before the first update", () => {
+    withMockedDateNow((setNow) => {
+      const doc = createTextDocWithUndo(10, 1000);
+      const undoManager = doc.undoManager;
+      let node: DocNode<typeof Text> | undefined;
+
+      checkUndoManager(4, doc, () => {
+        setNow(1000);
+        doc.forceCommit(() => {
+          node = doc.createNode(Text);
+          doc.root.append(node);
+        }, {});
+        if (!node) throw new Error("Expected seed node to be created");
+
+        setNow(2500);
+        node.state.value.set("a");
+        doc.forceCommit();
+        setNow(3000);
+        node.state.value.set("b");
+        doc.forceCommit();
+
+        expect(undoManager["_undoStack"]).toHaveLength(2);
+
+        undoManager.undo();
+        assertDoc(doc, [""]);
+      });
+    });
+  });
+
+  test("mergeOperations combines operations without mutating inputs", () => {
+    const first: Operations = [
+      [[1, "a", 0]],
+      { a: { value: "1" }, b: { value: "2" } },
+    ];
+    const second: Operations = [
+      [[2, "b", 0, 0, 0, 0]],
+      { b: { value: "3" }, c: { value: "4" } },
+    ];
+
+    const merged = mergeOperations(first, second);
+
+    expect(merged).toStrictEqual([
+      [
+        [1, "a", 0],
+        [2, "b", 0, 0, 0, 0],
+      ],
+      { a: { value: "1" }, b: { value: "3" }, c: { value: "4" } },
+    ]);
+    expect(first).toStrictEqual([
+      [[1, "a", 0]],
+      { a: { value: "1" }, b: { value: "2" } },
+    ]);
+    expect(second).toStrictEqual([
+      [[2, "b", 0, 0, 0, 0]],
+      { b: { value: "3" }, c: { value: "4" } },
+    ]);
   });
 
   test("undo immediately after a pending local update still undoes that update", () => {

--- a/tests/docnode/utils.ts
+++ b/tests/docnode/utils.ts
@@ -11,6 +11,7 @@ import {
   string,
   type Diff,
   type JsonDoc,
+  mergeOperations,
 } from "@docukit/docnode";
 import { ULID_REGEX } from "valibot";
 import { expect } from "vitest";
@@ -43,11 +44,14 @@ export const text = (doc: Doc, ...values: string[]) =>
     return node;
   });
 
-export function createTextDocWithUndo(maxUndoSteps = 10): Doc {
+export function createTextDocWithUndo(
+  maxUndoSteps = 10,
+  mergeInterval = 0,
+): Doc {
   const doc = new Doc({
     type: "root",
     extensions: [TextExtension],
-    undoManager: { maxUndoSteps },
+    undoManager: { maxUndoSteps, mergeInterval },
   });
   doc.forceCommit();
   return doc;
@@ -295,7 +299,7 @@ export function checkUndoManager(
     {
       type: "root",
       extensions: [{ nodes }],
-      undoManager: { maxUndoSteps: 10000000 },
+      undoManager: { maxUndoSteps: 10000000, mergeInterval: 0 },
     },
     jsonDoc,
   );
@@ -426,26 +430,19 @@ export function checkUndoManager(
   expect(sizeDo).toBe(txCount);
 
   // 2. REPLAY IN A SINGLE UPDATE (doc2)
-  const orderedOperations: Operations[0] = changeEvents.flatMap(
-    (ev) => ev.operations[0],
+  const mergedOperations = mergeOperations(
+    ...changeEvents.map((ev) => ev.operations),
   );
-  const statePatch: Operations[1] = {};
-  for (const changeEvent of changeEvents) {
-    for (const nodeId in changeEvent.operations[1]) {
-      statePatch[nodeId] ??= {};
-      Object.assign(statePatch[nodeId], changeEvent.operations[1][nodeId]);
-    }
-  }
   updateAndListen(
     doc2,
     () => {
-      doc2.applyOperations([orderedOperations, statePatch]);
+      doc2.applyOperations(mergedOperations);
     },
     (changeEvent) => {
       expect(changeEvent.operations.length).toBe(2); // A single op array + state patch
       // The array of operations is equal to the conjunction of all those that were in changeEvents
       // slice(0, -1) because the last operation is the state patch
-      expect(changeEvent.operations[0]).toStrictEqual(orderedOperations);
+      expect(changeEvent.operations[0]).toStrictEqual(mergedOperations[0]);
       // Inverse operations can't be compared. The following isn't always true because if a node
       // is inserted in one update and its child is inserted in the next update, inverseOperations
       // will have only one delete op (the parent's) instead of the two I get when doing separate updates.


### PR DESCRIPTION
## Summary
- Add mergeInterval support to DocNode's undo manager with operation merging
- Export and reuse mergeOperations
- Preserve first Lexical selection metadata for merged undo items
- Update undo manager docs and tests

## Verification
- pnpm fix
- pnpm test:coverage:once
- pnpm run check
- pnpm test:ci
- NEXT_PUBLIC_DOCSYNC_SERVER_URL=ws://localhost:8081 SKIP_ENV_VALIDATION=true pnpm exec playwright test tests/docs/docs.ui.test.ts tests/docsync/ui/editor/undoManager.ui.test.ts