### PR TITLE
Tidy DocSync dev logs

### DIFF
--- a/docs/collab-server/sqlite-provider.ts
+++ b/docs/collab-server/sqlite-provider.ts
@@ -1,11 +1,10 @@
-import { statSync } from "node:fs";
 import { and, desc, eq, gt, sql } from "drizzle-orm";
 import type { JsonDoc, Operations } from "@docukit/docnode";
 import type {
   ServerProvider,
   ServerProviderContext,
 } from "@docukit/docsync-react/server";
-import { db, sqlite, sqlitePath } from "./sqlite-db.ts";
+import { db, sqlite } from "./sqlite-db.ts";
 import * as schema from "./sqlite-schema.ts";
 
 const defaultDocTtlMs = 7 * 24 * 60 * 60 * 1000;
@@ -19,39 +18,8 @@ function parseOperations(value: string): Operations[] {
   return JSON.parse(value) as Operations[];
 }
 
-function getSqliteFileSizeKb() {
-  try {
-    const dbBytes = statSync(sqlitePath).size;
-    const walBytes = statSync(`${sqlitePath}-wal`).size;
-    const shmBytes = statSync(`${sqlitePath}-shm`).size;
-    return Math.round(((dbBytes + walBytes + shmBytes) / 1024) * 100) / 100;
-  } catch {
-    return undefined;
-  }
-}
-
-function getStats() {
-  const docsCount =
-    db
-      .select({ count: sql<number>`count(*)` })
-      .from(schema.documents)
-      .get()?.count ?? 0;
-  const operationsCount =
-    db
-      .select({ count: sql<number>`count(*)` })
-      .from(schema.operations)
-      .get()?.count ?? 0;
-
-  return {
-    docs: docsCount,
-    operationBatches: operationsCount,
-    sqliteKb: getSqliteFileSizeKb(),
-  };
-}
-
 function cleanupExpiredDocs(ttlMs: number) {
   const cutoff = Date.now() - ttlMs;
-  const before = getStats();
   const lastActivityByDocId = new Map<string, number>();
 
   const documentRows = db
@@ -94,14 +62,6 @@ function cleanupExpiredDocs(ttlMs: number) {
     sqlite.pragma("wal_checkpoint(TRUNCATE)");
     sqlite.exec("vacuum");
   }
-
-  const after = getStats();
-  if (
-    before.docs !== after.docs ||
-    before.operationBatches !== after.operationBatches
-  ) {
-    console.log("[docsync:sqlite] cleanup", { before, after });
-  }
 }
 
 export function sqliteProvider({
@@ -125,7 +85,6 @@ export function sqliteProvider({
   setInterval(() => {
     void runExclusive(() => {
       cleanupExpiredDocs(ttlMs);
-      console.log("[docsync:sqlite] stats", getStats());
     });
   }, cleanupIntervalMs);
 

--- a/packages/docsync/src/server/index.ts
+++ b/packages/docsync/src/server/index.ts
@@ -14,6 +14,7 @@ import { handleDisconnect } from "./handlers/disconnect.js";
 import { handlePresence } from "./handlers/presence.js";
 import { handleSync } from "./handlers/sync.js";
 import { handleUnsubscribeDoc } from "./handlers/unsubscribe.js";
+import { startupLog } from "./utils/startupLog.js";
 
 type AuthenticatedContext<TContext = {}> = {
   userId: string;
@@ -49,11 +50,14 @@ export class DocSyncServer<
   private _syncRequestEventListeners = new Set<SyncRequestEventListener>();
 
   constructor(config: ServerConfig<TContext, D, S, O>) {
-    this._io = new Server(config.port ?? 8080, {
+    const port = config.port ?? 8080;
+
+    this._io = new Server(port, {
       cors: { origin: "*" },
       // Performance: Only WebSocket transport, no polling
       transports: ["websocket"],
     });
+    console.log(startupLog(port));
 
     this._docBinding = config.docBinding;
     this._provider = config.provider;

--- a/packages/docsync/src/server/utils/startupLog.ts
+++ b/packages/docsync/src/server/utils/startupLog.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ansi = {
+  blue: (text: string) => `\x1b[34m${text}\x1b[0m`,
+  cyan: (text: string) => `\x1b[36m${text}\x1b[0m`,
+  green: (text: string) => `\x1b[32m${text}\x1b[0m`,
+};
+
+function isPackageJson(value: unknown): value is { version: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "version" in value &&
+    typeof value.version === "string"
+  );
+}
+
+function readDocSyncVersion(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  const packageJsonPaths = [
+    resolve(moduleDir, "../../../package.json"),
+    resolve(moduleDir, "../../../../package.json"),
+  ];
+
+  for (const packageJsonPath of packageJsonPaths) {
+    try {
+      const packageJson: unknown = JSON.parse(
+        readFileSync(packageJsonPath, "utf8"),
+      );
+      if (isPackageJson(packageJson)) return packageJson.version;
+    } catch {
+      // Source and dist builds place this module at different depths.
+    }
+  }
+
+  return "unknown";
+}
+
+export function startupLog(port: number): string {
+  return [
+    "",
+    `  ${ansi.blue(`DocSync v${readDocSyncVersion()}`)}`,
+    "",
+    `  ${ansi.green("➜")}  Local:   ${ansi.cyan(`http://localhost:${port}/`)}`,
+    "",
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary
- add Vite-style DocSync server startup log with only the local URL
- remove recurring SQLite provider stats/cleanup logs from the docs server

## Verification
- pnpm --filter @docukit/docsync build