### PR TITLE
Debounce DocSync local operation flushes

### DIFF
--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -38,6 +38,10 @@ type LocalResolved<S extends {}, O extends {}> = {
   identity: Identity;
 };
 
+type LocalOpsBatchState<O extends {}> = DeferredState<O[]> & {
+  startedAt: number;
+};
+
 type PushStatus = "idle" | "pushing" | "pushing-with-pending";
 type ChangeOrigin = "local" | "network" | "local-broadcast";
 
@@ -66,8 +70,9 @@ export class DocSyncClient<
   protected _changeOrigin: ChangeOrigin = "local";
 
   // Flow control state (batching, debouncing, push queueing)
-  protected _localOpsBatchState = new Map<string, DeferredState<O[]>>();
-  protected _batchDelay = 50;
+  protected _localOpsBatchState = new Map<string, LocalOpsBatchState<O>>();
+  protected _operationsDebounce = 50;
+  protected _operationsMaxDebounce = 1000;
   protected _presenceDebounceState = new Map<string, DeferredState<unknown>>();
   protected _presenceDebounce = 200;
   protected _pushStatusByDocId = new Map<string, PushStatus>();
@@ -81,6 +86,13 @@ export class DocSyncClient<
     const { docBinding, local } = config;
     this._docBinding = docBinding;
     this._clientId = crypto.randomUUID();
+    const { timing } = config;
+    this._operationsDebounce = Math.max(0, timing?.operationsDebounce ?? 50);
+    this._operationsMaxDebounce = Math.max(
+      0,
+      timing?.operationsMaxDebounce ?? 1000,
+    );
+    this._presenceDebounce = Math.max(0, timing?.presenceDebounce ?? 200);
 
     // Initialize local provider (if configured)
     this._localPromise = (async () => {
@@ -435,10 +447,11 @@ export class DocSyncClient<
   onLocalOperations({ docId, operations }: { docId: string; operations: O[] }) {
     // Get or create the batch state for this document
     let state = this._localOpsBatchState.get(docId);
+    const now = Date.now();
 
     if (!state) {
       // Create new state with empty queue
-      state = { data: [] };
+      state = { data: [], startedAt: now };
       this._localOpsBatchState.set(docId, state);
     }
 
@@ -447,29 +460,44 @@ export class DocSyncClient<
       state.data.push(...operations);
     }
 
-    // If there is already a pending timeout, we just wait
     if (state.timeout !== undefined) {
+      clearTimeout(state.timeout);
+      delete state.timeout;
+    }
+
+    if (
+      this._operationsDebounce === 0 ||
+      now - state.startedAt >= this._operationsMaxDebounce
+    ) {
+      void this._flushLocalOperations(docId);
       return;
     }
 
-    // Otherwise, schedule the batch save
-    state.timeout = setTimeout(() => {
-      void (async () => {
-        const currentState = this._localOpsBatchState.get(docId);
-        if (!currentState) return;
+    state.timeout = setTimeout(
+      () => {
+        void this._flushLocalOperations(docId);
+      },
+      Math.min(
+        this._operationsDebounce,
+        this._operationsMaxDebounce - (now - state.startedAt),
+      ),
+    );
+  }
 
-        const opsToSave = currentState.data;
-        this._localOpsBatchState.delete(docId);
+  protected async _flushLocalOperations(docId: string): Promise<void> {
+    const currentState = this._localOpsBatchState.get(docId);
+    if (!currentState) return;
 
-        if (opsToSave && opsToSave.length > 0) {
-          const local = await this._localPromise;
-          await local?.provider.transaction("readwrite", (ctx) =>
-            ctx.saveOperations({ docId, operations: opsToSave }),
-          );
-          void handleSync(this, docId);
-        }
-      })();
-    }, this._batchDelay);
+    const opsToSave = currentState.data;
+    this._localOpsBatchState.delete(docId);
+
+    if (opsToSave.length > 0) {
+      const local = await this._localPromise;
+      await local?.provider.transaction("readwrite", (ctx) =>
+        ctx.saveOperations({ docId, operations: opsToSave }),
+      );
+      void handleSync(this, docId);
+    }
   }
 
   protected async _deleteDoc(docId: string): Promise<boolean> {

--- a/packages/docsync/src/client/types.ts
+++ b/packages/docsync/src/client/types.ts
@@ -43,6 +43,11 @@ export type ClientConfig<
 > = {
   docBinding: DocBinding<D, S, O>;
   server: { url: string; auth: { getToken: () => MaybePromise<string> } };
+  timing?: {
+    operationsDebounce?: number;
+    operationsMaxDebounce?: number;
+    presenceDebounce?: number;
+  };
   local: {
     provider: (identity: Identity) => ClientProvider<NoInfer<S>, NoInfer<O>>;
     getIdentity: () => MaybePromise<Identity>;

--- a/tests/docsync/int/index.browser.test.ts
+++ b/tests/docsync/int/index.browser.test.ts
@@ -306,9 +306,10 @@ describe("Local-First", () => {
       expect(childrenArray1.length).toBe(101);
       await reference.assertIDBDoc({ doc: childrenArray1, ops: [] });
       expect(reference.reqSpy.mock.calls.length).toBeLessThan(4);
+      const requestsAfterFirstBatch = reference.reqSpy.mock.calls.length;
 
       // without batching delay
-      reference.client["_batchDelay"] = 0;
+      reference.client["_operationsDebounce"] = 0;
 
       const childrenArray2 = [];
 
@@ -322,7 +323,9 @@ describe("Local-First", () => {
         doc: [...childrenArray1, ...childrenArray2],
         ops: [],
       });
-      expect(reference.reqSpy.mock.calls.length).toBeLessThan(4);
+      expect(
+        reference.reqSpy.mock.calls.length - requestsAfterFirstBatch,
+      ).toBeLessThan(4);
     });
   });
 });

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -3,6 +3,7 @@ import {
   DocSyncClient,
   indexedDBProvider,
   type ClientConfig,
+  type ClientProvider,
   type DocData,
   type DocBinding,
   type Identity,
@@ -38,6 +39,88 @@ vi.mock("socket.io-client", () => ({
 // ============================================================================
 
 describe("DocSyncClient", () => {
+  type DebounceTestDoc = { docId: string };
+  type DebounceTestSerializedDoc = { docId: string };
+  type DebounceTestOperation = { value: string };
+  type SaveOperations = (arg: {
+    docId: string;
+    operations: DebounceTestOperation[];
+  }) => Promise<void>;
+
+  const createDebounceTestClient = ({
+    saveOperations,
+    timing,
+  }: {
+    saveOperations: SaveOperations;
+    timing?: {
+      operationsDebounce?: number;
+      operationsMaxDebounce?: number;
+      presenceDebounce?: number;
+    };
+  }) => {
+    const docBinding: DocBinding<
+      DebounceTestDoc,
+      DebounceTestSerializedDoc,
+      DebounceTestOperation
+    > = {
+      create: (_type, id) => {
+        const docId = id ?? ulid().toLowerCase();
+        return { doc: { docId }, docId };
+      },
+      deserialize: (serializedDoc) => ({ docId: serializedDoc.docId }),
+      serialize: (doc) => ({ docId: doc.docId }),
+      onChange: () => undefined,
+      applyOperations: () => undefined,
+      dispose: () => undefined,
+    };
+
+    const provider: ClientProvider<
+      DebounceTestSerializedDoc,
+      DebounceTestOperation
+    > = {
+      transaction: (_mode, callback) =>
+        callback({
+          getSerializedDoc: ({ docId }) =>
+            Promise.resolve({ serializedDoc: { docId }, clock: 0 }),
+          getOperations: () => Promise.resolve([]),
+          deleteOperations: () => Promise.resolve(undefined),
+          saveOperations,
+          saveSerializedDoc: () => Promise.resolve(undefined),
+        }),
+    };
+
+    const config: ClientConfig<
+      DebounceTestDoc,
+      DebounceTestSerializedDoc,
+      DebounceTestOperation
+    > = {
+      server: {
+        url: "ws://localhost:8081",
+        auth: { getToken: () => "test-token" },
+      },
+      docBinding,
+      local: {
+        provider: () => provider,
+        getIdentity: () => ({
+          userId: `debounce-test-${ulid().toLowerCase()}`,
+          secret: "test-secret",
+        }),
+      },
+    };
+
+    if (timing !== undefined) {
+      config.timing = timing;
+    }
+
+    return new DocSyncClient(config);
+  };
+
+  const flushMicrotasks = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
   // ──────────────────────────────────────────────────────────────────────────
   // Constructor tests
   // ──────────────────────────────────────────────────────────────────────────
@@ -244,6 +327,117 @@ describe("DocSyncClient", () => {
         docId,
         presence: { [client["_clientId"]]: { anchor: 2 } },
       });
+    });
+  });
+
+  describe("local operations debounce", () => {
+    test("uses timing configuration for operation and presence debounces", async () => {
+      const saveOperations = vi.fn<SaveOperations>(() =>
+        Promise.resolve(undefined),
+      );
+      const client = createDebounceTestClient({
+        saveOperations,
+        timing: {
+          operationsDebounce: 75,
+          operationsMaxDebounce: 500,
+          presenceDebounce: 25,
+        },
+      });
+      await client["_localPromise"];
+
+      expect(client["_operationsDebounce"]).toBe(75);
+      expect(client["_operationsMaxDebounce"]).toBe(500);
+      expect(client["_presenceDebounce"]).toBe(25);
+      client.disconnect();
+    });
+
+    test("debounces local operation persistence from the latest operation", async () => {
+      vi.useFakeTimers();
+
+      try {
+        const saveOperations = vi.fn<SaveOperations>(() =>
+          Promise.resolve(undefined),
+        );
+        const client = createDebounceTestClient({
+          saveOperations,
+          timing: { operationsDebounce: 50, operationsMaxDebounce: 1000 },
+        });
+        await client["_localPromise"];
+
+        client.onLocalOperations({
+          docId: "doc-1",
+          operations: [{ value: "A" }],
+        });
+        await vi.advanceTimersByTimeAsync(49);
+        expect(saveOperations).not.toHaveBeenCalled();
+
+        client.onLocalOperations({
+          docId: "doc-1",
+          operations: [{ value: "B" }],
+        });
+        await vi.advanceTimersByTimeAsync(49);
+        await flushMicrotasks();
+        expect(saveOperations).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        await flushMicrotasks();
+
+        expect(saveOperations).toHaveBeenCalledOnce();
+        expect(saveOperations).toHaveBeenCalledWith({
+          docId: "doc-1",
+          operations: [{ value: "A" }, { value: "B" }],
+        });
+        client.disconnect();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test("flushes local operations when maxDebounce is reached", async () => {
+      vi.useFakeTimers();
+
+      try {
+        const saveOperations = vi.fn<SaveOperations>(() =>
+          Promise.resolve(undefined),
+        );
+        const client = createDebounceTestClient({
+          saveOperations,
+          timing: { operationsDebounce: 50, operationsMaxDebounce: 100 },
+        });
+        await client["_localPromise"];
+
+        client.onLocalOperations({
+          docId: "doc-1",
+          operations: [{ value: "A" }],
+        });
+        await vi.advanceTimersByTimeAsync(40);
+
+        client.onLocalOperations({
+          docId: "doc-1",
+          operations: [{ value: "B" }],
+        });
+        await vi.advanceTimersByTimeAsync(40);
+
+        client.onLocalOperations({
+          docId: "doc-1",
+          operations: [{ value: "C" }],
+        });
+        await vi.advanceTimersByTimeAsync(19);
+        await flushMicrotasks();
+        expect(saveOperations).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        await flushMicrotasks();
+
+        expect(saveOperations).toHaveBeenCalledOnce();
+        expect(saveOperations).toHaveBeenCalledWith({
+          docId: "doc-1",
+          operations: [{ value: "A" }, { value: "B" }, { value: "C" }],
+        });
+        client.disconnect();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
Replaces the DocSync client's local operation batching window with a true debounce that resets on each local operation and flushes at operationsMaxDebounce. Adds a timing config group for operationsDebounce, operationsMaxDebounce, and presenceDebounce, and wires presenceDebounce into the existing presence debounce. Updates unit and integration coverage for the debounce behavior and request batching expectations. Verified with pnpm fix and pnpm test:coverage:once.