### PR TITLE
Add default Lexical presence user

### DIFF
--- a/docs/content/docs/docnode/lexical.mdx
+++ b/docs/content/docs/docnode/lexical.mdx
@@ -17,6 +17,10 @@ npm i @docukit/docnode @docukit/docnode-lexical
 how you should sync that Doc across different clients. We recommend using DocSync as explained
 in the next section.
 
+Presence is opt-in. If you do not pass `setPresence`, `DocNodePlugin` will not send local presence.
+When you do pass `setPresence`, `user` is optional. Missing user fields are filled with
+`name: "Anonymous"` and a random curated color.
+
 ```tsx tab="React"
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { DocNodePlugin } from "@docukit/docnode-lexical/react";
@@ -29,7 +33,7 @@ function Editor({ doc, presence, setPresence }) {
         doc={doc}
         presence={presence}
         setPresence={setPresence}
-        user={{ name: "John Doe", color: "#ff0000" }}
+        user={{ name: "John Doe", color: "#ff0000" }} // optional color override
       />
       {/* ... The rest of your Lexical Plugins ... */}
       {/* ... Don't include <HistoryPlugin /> here ... */}
@@ -75,8 +79,8 @@ const doc = new Doc(
     },
     user: {
       description:
-        "User information to attach to presence data. When provided, the plugin automatically enriches presence updates with the user's name and color.",
-      type: "{ name: string; color: string } | undefined",
+        'User information to attach to presence data. If omitted, presence uses name: "Anonymous" and a random curated color. If you pass only name, color is deterministic from that name. If you pass only color, name is "Anonymous".',
+      type: "{ name?: string; color?: string } | undefined",
       required: false,
     },
   }}
@@ -101,7 +105,7 @@ function Editor() {
         doc={doc}
         presence={presence}
         setPresence={setPresence}
-        user={{ name: "John Doe", color: "#ff0000" }}
+        user={{ name: "John Doe" }}
       />
       {/* ... The rest of your Lexical Plugins ... */}
     </LexicalComposer>

--- a/docs/src/components/examples/editor/EditorExample.tsx
+++ b/docs/src/components/examples/editor/EditorExample.tsx
@@ -2,8 +2,10 @@
 
 import type React from "react";
 import { useEffect, useState } from "react";
-import { createLexicalDocNodeConfig } from "@docukit/docnode-lexical";
-import type { Presence } from "@docukit/docnode-lexical/react";
+import {
+  createLexicalDocNodeConfig,
+  type Presence,
+} from "@docukit/docnode-lexical";
 import {
   AlignCenter,
   AlignLeft,

--- a/docs/src/components/examples/editor/EditorPanel.tsx
+++ b/docs/src/components/examples/editor/EditorPanel.tsx
@@ -10,13 +10,11 @@ import ToolbarPlugin from "./ToolbarPlugin";
 import { $getRoot, type RootNode } from "lexical";
 import {
   SKIP_UNDO_TAG,
-  type PresenceSelection,
-} from "@docukit/docnode-lexical";
-import {
-  DocNodePlugin,
   type Presence,
+  type PresenceSelection,
   type PresenceUser,
-} from "@docukit/docnode-lexical/react";
+} from "@docukit/docnode-lexical";
+import { DocNodePlugin } from "@docukit/docnode-lexical/react";
 import { type Doc } from "@docukit/docnode";
 import { useEffect } from "react";
 

--- a/packages/docnode-lexical/src/bindings/react.tsx
+++ b/packages/docnode-lexical/src/bindings/react.tsx
@@ -5,10 +5,8 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import type { Doc } from "@docukit/docnode";
 import { syncLexicalWithDoc } from "../index.js";
 import { updatePresence } from "../presence/index.js";
-import type { PresenceSelection } from "../types.js";
+import type { PresenceSelection, PresenceUser } from "../types.js";
 import type { Presence } from "../presence/types.js";
-
-export type PresenceUser = { name: string; color: string };
 
 export type DocNodePluginProps = {
   doc: Doc;
@@ -18,8 +16,7 @@ export type DocNodePluginProps = {
     | undefined;
   /**
    * User information to attach to presence data.
-   * When provided, the plugin will automatically enrich presence updates
-   * with the user's name and color.
+   * Missing name falls back to "Anonymous"; missing color uses the name or a random curated color.
    */
   user?: PresenceUser | undefined;
 };

--- a/packages/docnode-lexical/src/exports/index.ts
+++ b/packages/docnode-lexical/src/exports/index.ts
@@ -10,6 +10,7 @@ export { setupUndoManager as _INTERNAL_setupUndoManager } from "../setupUndoMana
 export type {
   syncLexicalWithDocPresenceOptions,
   KeyBinding,
+  PresenceUser,
   PresenceSelection,
 } from "../types.js";
 export type {

--- a/packages/docnode-lexical/src/exports/react.tsx
+++ b/packages/docnode-lexical/src/exports/react.tsx
@@ -1,7 +1,1 @@
-export {
-  DocNodePlugin,
-  type DocNodePluginProps,
-  type PresenceUser,
-} from "../bindings/react.js";
-export type { PresenceSelection } from "../types.js";
-export type { Presence } from "../presence/types.js";
+export { DocNodePlugin, type DocNodePluginProps } from "../bindings/react.js";

--- a/packages/docnode-lexical/src/presence/index.ts
+++ b/packages/docnode-lexical/src/presence/index.ts
@@ -17,6 +17,7 @@ import type {
   syncLexicalWithDocPresenceOptions,
 } from "../types.js";
 import { destroyCursor } from "./cursorRendering.js";
+import { resolvePresenceUser } from "./resolvePresenceUser.js";
 import { syncSelectionToPresence } from "./syncSelectionToPresence.js";
 import { syncPresenceToSelection } from "./syncPresenceToSelection.js";
 import type { Presence, PresenceBinding, PresenceHandle } from "./types.js";
@@ -58,14 +59,14 @@ export function syncPresence(
 ): (() => void) | undefined {
   const { setPresence: rawSetPresence, user } = presenceOptions ?? {};
   if (!rawSetPresence) return undefined;
+  const presenceUser = resolvePresenceUser(user);
 
   let lastSelection: PresenceSelection | undefined;
 
   const setPresence = (selection: PresenceSelection | undefined) => {
-    const nextSelection =
-      selection && user?.name != null && user?.color != null
-        ? { ...selection, name: user.name, color: user.color }
-        : selection;
+    const nextSelection = selection
+      ? { ...selection, name: presenceUser.name, color: presenceUser.color }
+      : selection;
 
     if (areSelectionsEqual(lastSelection, nextSelection)) return;
     lastSelection = nextSelection;

--- a/packages/docnode-lexical/src/presence/resolvePresenceUser.ts
+++ b/packages/docnode-lexical/src/presence/resolvePresenceUser.ts
@@ -1,0 +1,52 @@
+import type { PresenceUser } from "../types.js";
+
+const DEFAULT_PRESENCE_NAME = "Anonymous";
+const DEFAULT_PRESENCE_COLORS = [
+  "#2563eb",
+  "#16a34a",
+  "#db2777",
+  "#9333ea",
+  "#ea580c",
+  "#0891b2",
+  "#4f46e5",
+  "#dc2626",
+  "#0d9488",
+  "#7c3aed",
+  "#ca8a04",
+  "#0284c7",
+];
+
+function createDefaultPresenceColor(): string {
+  return (
+    DEFAULT_PRESENCE_COLORS[
+      Math.floor(Math.random() * DEFAULT_PRESENCE_COLORS.length)
+    ] ?? "#2563eb"
+  );
+}
+
+function createPresenceColorFromName(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+
+  return (
+    DEFAULT_PRESENCE_COLORS[Math.abs(hash) % DEFAULT_PRESENCE_COLORS.length] ??
+    "#2563eb"
+  );
+}
+
+export function resolvePresenceUser(user: PresenceUser | undefined): {
+  name: string;
+  color: string;
+} {
+  const name = user?.name ?? DEFAULT_PRESENCE_NAME;
+  return {
+    name,
+    color:
+      user?.color ??
+      (user?.name == null
+        ? createDefaultPresenceColor()
+        : createPresenceColorFromName(user.name)),
+  };
+}

--- a/packages/docnode-lexical/src/types.ts
+++ b/packages/docnode-lexical/src/types.ts
@@ -12,6 +12,12 @@ export type PresenceSelection = {
   color?: string;
 };
 
+/** User information attached to local presence. Missing fields use library defaults. */
+export type PresenceUser = {
+  name?: string | undefined;
+  color?: string | undefined;
+};
+
 /**
  * Optional presence options for syncLexicalWithDoc.
  * Pass as third argument when you want to sync selection to presence and/or render remote cursors.
@@ -21,6 +27,6 @@ export type syncLexicalWithDocPresenceOptions = {
   setPresence?:
     | ((selection: PresenceSelection | undefined) => void)
     | undefined;
-  /** When provided, outgoing presence is enriched with name and color. */
-  user?: { name: string; color: string } | undefined;
+  /** Outgoing presence user info. Missing name falls back to "Anonymous"; missing color uses the name or a random curated color. */
+  user?: PresenceUser | undefined;
 };

--- a/tests/docnode-lexical/presence.browser.test.ts
+++ b/tests/docnode-lexical/presence.browser.test.ts
@@ -1,0 +1,136 @@
+import {
+  $createParagraphNode,
+  $createRangeSelection,
+  $createTextNode,
+  $getRoot,
+  $setSelection,
+  FOCUS_COMMAND,
+  createEditor,
+  type LexicalEditor,
+} from "lexical";
+import { describe, expect, test, vi } from "vitest";
+import {
+  syncPresence,
+  type KeyBinding,
+  type PresenceSelection,
+  type PresenceUser,
+} from "@docukit/docnode-lexical";
+
+const DEFAULT_COLORS = [
+  "#2563eb",
+  "#16a34a",
+  "#db2777",
+  "#9333ea",
+  "#ea580c",
+  "#0891b2",
+  "#4f46e5",
+  "#dc2626",
+  "#0d9488",
+  "#7c3aed",
+  "#ca8a04",
+  "#0284c7",
+];
+
+function createPresenceEditor(): {
+  editor: LexicalEditor;
+  keyBinding: KeyBinding;
+} {
+  const editor = createEditor({
+    namespace: "PresenceTest",
+    onError: (error) => {
+      throw error;
+    },
+  });
+
+  let textKey = "";
+  editor.update(
+    () => {
+      const root = $getRoot();
+      const paragraph = $createParagraphNode();
+      const text = $createTextNode("hello");
+      textKey = text.getKey();
+      paragraph.append(text);
+      root.clear();
+      root.append(paragraph);
+
+      const selection = $createRangeSelection();
+      selection.anchor.set(textKey, 1, "text");
+      selection.focus.set(textKey, 4, "text");
+      $setSelection(selection);
+    },
+    { discrete: true },
+  );
+
+  return {
+    editor,
+    keyBinding: {
+      lexicalKeyToDocNodeId: new Map([[textKey, "docnode-text"]]),
+      docNodeIdToLexicalKey: new Map([["docnode-text", textKey]]),
+    },
+  };
+}
+
+function readPresence(user?: PresenceUser): PresenceSelection | undefined {
+  const { editor, keyBinding } = createPresenceEditor();
+  let presence: PresenceSelection | undefined;
+  const cleanup = syncPresence(editor, keyBinding, {
+    setPresence: (selection) => {
+      presence = selection;
+    },
+    user,
+  });
+
+  editor.dispatchCommand(FOCUS_COMMAND, new FocusEvent("focus"));
+  cleanup?.();
+
+  return presence;
+}
+
+describe("presence defaults", () => {
+  test("does not enable presence when setPresence is omitted", () => {
+    const { editor, keyBinding } = createPresenceEditor();
+    const cleanup = syncPresence(editor, keyBinding);
+
+    expect(cleanup).toBeUndefined();
+  });
+
+  test("uses Anonymous and a random curated color by default", () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const presence = readPresence();
+
+    expect(presence).toMatchObject({
+      anchor: { key: "docnode-text", offset: 1 },
+      focus: { key: "docnode-text", offset: 4 },
+      name: "Anonymous",
+    });
+    expect(DEFAULT_COLORS).toContain(presence?.color);
+    expect(random).toHaveBeenCalled();
+    random.mockRestore();
+  });
+
+  test("keeps a provided name and fills in a deterministic color", () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(0);
+    const firstPresence = readPresence({ name: "Ada" });
+
+    random.mockReturnValue(0.9);
+    const secondPresence = readPresence({ name: "Ada" });
+
+    expect(firstPresence).toMatchObject({
+      anchor: { key: "docnode-text", offset: 1 },
+      focus: { key: "docnode-text", offset: 4 },
+      name: "Ada",
+    });
+    expect(DEFAULT_COLORS).toContain(firstPresence?.color);
+    expect(secondPresence?.color).toBe(firstPresence?.color);
+    random.mockRestore();
+  });
+
+  test("keeps a provided color and fills in the default name", () => {
+    expect(readPresence({ color: "#123456" })).toStrictEqual({
+      anchor: { key: "docnode-text", offset: 1 },
+      color: "#123456",
+      focus: { key: "docnode-text", offset: 4 },
+      name: "Anonymous",
+    });
+  });
+});


### PR DESCRIPTION
Adds default presence user resolution for docnode-lexical so local presence gets an Anonymous name and curated color when user info is missing. Name-only users now get deterministic colors, while anonymous fallback colors remain random. Keeps React exports focused on React-only APIs and moves core presence types to the main package entrypoint. Updates docs/examples and adds browser coverage for default, name-only, color-only, and opt-out presence behavior.