### PR TITLE
Rename DocSync loading state to pending

### DIFF
--- a/docs/content/docs/docsync/client.mdx
+++ b/docs/content/docs/docsync/client.mdx
@@ -158,7 +158,7 @@ const result = useDoc({ type: "notes", id: "doc-123", createIfMissing: true });
   type={{
     status: {
       description: "Current state of the query.",
-      type: '"loading" | "success" | "error"',
+      type: '"pending" | "success" | "error"',
       required: true,
     },
     data: {

--- a/packages/docsync-react/src/index.tsx
+++ b/packages/docsync-react/src/index.tsx
@@ -52,7 +52,7 @@ export function createDocSyncClient<T extends ClientConfig<any, any, any>>(
   }): QueryResult<DocData | undefined>;
   function useDoc(args: GetDocArgs): QueryResult<DocData | undefined> {
     const [result, setResult] = useState<QueryResult<DocData | undefined>>({
-      status: "loading",
+      status: "pending",
     });
     const id = "id" in args ? args.id : undefined;
     const createIfMissing = "createIfMissing" in args && args.createIfMissing;

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -139,7 +139,7 @@ export class DocSyncClient<
    * - `{ type, id, createIfMissing: true }` → Get existing doc or create it if not found.
    *
    * The callback will be invoked with state updates:
-   * 1. `{ status: "loading" }` - Initial state while fetching
+   * 1. `{ status: "pending" }` - Initial state while fetching
    * 2. `{ status: "success", data: { doc, docId } }` - Document loaded successfully
    * 3. `{ status: "error", error }` - Failed to load document
    *
@@ -150,7 +150,7 @@ export class DocSyncClient<
    * const unsubscribe = client.getDoc(
    *   { type: "notes", id: "abc123" },
    *   (result) => {
-   *     if (result.status === "loading") console.log("Loading...");
+   *     if (result.status === "pending") console.log("Pending...");
    *     if (result.status === "success") console.log("Doc:", result.data.doc);
    *     if (result.status === "error") console.error(result.error);
    *   }
@@ -216,7 +216,7 @@ export class DocSyncClient<
     }
 
     // Preparing for the async cases
-    emit({ status: "loading" });
+    emit({ status: "pending" });
 
     // Case: { type, id } or { type, id, createIfMissing } → Load or create (async).
     if (argId) {

--- a/packages/docsync/src/client/types.ts
+++ b/packages/docsync/src/client/types.ts
@@ -12,7 +12,7 @@ import type {
 // ============================================================================
 
 export type QueryResult<D, E = Error> =
-  | { status: "loading"; data?: never; error?: never }
+  | { status: "pending"; data?: never; error?: never }
   | { status: "success"; data: D; error?: never }
   | { status: "error"; data?: never; error: E };
 

--- a/tests/docsync-react/index.browser.test.tsx
+++ b/tests/docsync-react/index.browser.test.tsx
@@ -37,7 +37,7 @@ test("createDocSyncClient", async () => {
     () => useDoc({ type: "test", id: "1" }),
   );
   expectTypeOf(_1.current).toEqualTypeOf<MaybeDocResult>();
-  expect(_1.current.status).toBe("loading");
+  expect(_1.current.status).toBe("pending");
   await expect
     .poll(() => _1.current.status, { interval: 100, timeout: 2000 })
     .toBe("success");
@@ -50,7 +50,7 @@ test("createDocSyncClient", async () => {
     useDoc({ type: "test", id: id2, createIfMissing: true }),
   );
   expectTypeOf(_2.current).toEqualTypeOf<DocResult>();
-  expect(_2.current.status).toBe("loading");
+  expect(_2.current.status).toBe("pending");
   await expect
     .poll(() => _2.current.status, { interval: 100, timeout: 2000 })
     .toBe("success");
@@ -84,7 +84,7 @@ test("createDocSyncClient", async () => {
 
   // Type check: QueryResult<DocData<Doc>> has the expected structure
   expectTypeOf<DocResult>().toEqualTypeOf<
-    | { status: "loading"; data?: never; error?: never }
+    | { status: "pending"; data?: never; error?: never }
     | { status: "success"; data: DocData<Doc>; error?: never }
     | { status: "error"; data?: never; error: Error }
   >();

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -816,7 +816,7 @@ describe("DocSyncClient", () => {
 
     test("QueryResult has expected structure", () => {
       expectTypeOf<DocResult>().toEqualTypeOf<
-        | { status: "loading"; data?: never; error?: never }
+        | { status: "pending"; data?: never; error?: never }
         | { status: "success"; data: DocData<Doc>; error?: never }
         | { status: "error"; data?: never; error: Error }
       >();
@@ -829,14 +829,14 @@ describe("DocSyncClient", () => {
 
   describe("getDoc", () => {
     describe("Get existing document", () => {
-      test("should emit loading status initially", () => {
+      test("should emit pending status initially", () => {
         const client = createClient();
         const callback = createCallback();
 
         client.getDoc({ type: "test", id: "test-id" }, callback);
 
         expect(callback).toHaveBeenCalledWith({
-          status: "loading",
+          status: "pending",
           data: undefined,
           error: undefined,
         });
@@ -882,8 +882,8 @@ describe("DocSyncClient", () => {
         // Request the same doc - cache hit
         client.getDoc({ type: "test", id: createdDoc!.docId }, callback2);
 
-        // First call is loading (sync)
-        expect(callback2.mock.calls[0]?.[0]?.status).toBe("loading");
+        // First call is pending (sync)
+        expect(callback2.mock.calls[0]?.[0]?.status).toBe("pending");
 
         // Wait just one microtask (not setTimeout like tick())
         await Promise.resolve();
@@ -961,26 +961,26 @@ describe("DocSyncClient", () => {
     });
 
     describe("Sync vs async behavior", () => {
-      test("should NOT emit loading when creating new doc without id", () => {
+      test("should NOT emit pending when creating new doc without id", () => {
         const client = createClient();
         const callback = createCallback();
 
         client.getDoc({ type: "test", createIfMissing: true }, callback);
 
-        // First call should be success, not loading
+        // First call should be success, not pending
         expect(callback.mock.calls[0]?.[0]?.status).toBe("success");
         expect(callback).toHaveBeenCalledTimes(1);
       });
 
-      test("should emit loading before success when fetching by id", async () => {
+      test("should emit pending before success when fetching by id", async () => {
         const client = createClient();
         const callback = createCallback();
         const customId = ulid().toLowerCase();
 
         client.getDoc({ type: "test", id: customId }, callback);
 
-        // First call should be loading
-        expect(callback.mock.calls[0]?.[0]?.status).toBe("loading");
+        // First call should be pending
+        expect(callback.mock.calls[0]?.[0]?.status).toBe("pending");
 
         await expect
           .poll(() => callback.mock.calls[1]?.[0]?.status)
@@ -1211,7 +1211,7 @@ describe("DocSyncClient", () => {
       }
     });
 
-    test("should emit loading then error (not just error)", async () => {
+    test("should emit pending then error (not just error)", async () => {
       const errorMessage = "Provider failed";
       const FailingProvider = createFailingProvider(errorMessage);
       const client = createClientWithProvider(FailingProvider);
@@ -1229,8 +1229,8 @@ describe("DocSyncClient", () => {
           callback,
         );
 
-        // First call should be loading
-        expect(callback.mock.calls[0]?.[0]?.status).toBe("loading");
+        // First call should be pending
+        expect(callback.mock.calls[0]?.[0]?.status).toBe("pending");
 
         await expect
           .poll(() => callback.mock.calls[1]?.[0]?.status)


### PR DESCRIPTION
Renames the DocSync query status from `loading` to `pending` across the core client and React hook. Updates the public QueryResult type, emitted getDoc state, hook initial state, tests, and docs to use the new pending terminology. This aligns the naming with React Query and better describes the async state.