### PR TITLE
Require stable id for createIfMissing

### DIFF
--- a/docs/content/docs/docnode/lexical.mdx
+++ b/docs/content/docs/docnode/lexical.mdx
@@ -94,9 +94,9 @@ import { DocNodePlugin } from "@docukit/docnode-lexical/react";
 // see the DocSync docs for more info on how to generate these hooks
 import { useDoc, usePresence } from "../docsync/client";
 
-function Editor() {
+function Editor({ id }: { id: string }) {
   // [!code highlight:2]
-  const { doc, docId } = useDoc({ type: "lexical", createIfMissing: true });
+  const { doc, docId } = useDoc({ type: "lexical", id, createIfMissing: true });
   const [presence, setPresence] = usePresence({ docId });
 
   return (

--- a/docs/content/docs/docsync/client.mdx
+++ b/docs/content/docs/docsync/client.mdx
@@ -123,8 +123,6 @@ React hook that subscribes to a document with reactive state updates.
 ```tsx
 const result = useDoc({ type: "notes", id: "doc-123" });
 
-const result = useDoc({ type: "notes", createIfMissing: true });
-
 const result = useDoc({ type: "notes", id: "doc-123", createIfMissing: true });
 ```
 
@@ -139,13 +137,12 @@ const result = useDoc({ type: "notes", id: "doc-123", createIfMissing: true });
       required: true,
     },
     id: {
-      description:
-        "The document ID to load. If omitted with createIfMissing: true, a new ID will be auto-generated.",
+      description: "The document ID to load or create.",
       type: "string",
+      required: true,
     },
     createIfMissing: {
-      description:
-        "If true, creates the document if it doesn't exist. When true without id, generates a new document with auto-generated ID.",
+      description: "If true, creates the document if it doesn't exist.",
       type: "boolean",
       default: "false",
     },

--- a/packages/docsync-react/src/index.tsx
+++ b/packages/docsync-react/src/index.tsx
@@ -43,7 +43,7 @@ export function createDocSyncClient<T extends ClientConfig<any, any, any>>(
   function useDoc(args: {
     type: string;
     createIfMissing: true;
-    id?: string;
+    id: string;
   }): QueryResult<DocData>;
   function useDoc(args: {
     type: string;
@@ -54,17 +54,16 @@ export function createDocSyncClient<T extends ClientConfig<any, any, any>>(
     const [result, setResult] = useState<QueryResult<DocData | undefined>>({
       status: "pending",
     });
-    const id = "id" in args ? args.id : undefined;
+    const id = args.id;
     const createIfMissing = "createIfMissing" in args && args.createIfMissing;
     const type = args.type;
-    const getDocArgs = useMemo<GetDocArgs | undefined>(() => {
-      if (id !== undefined) return { type, id, createIfMissing };
-      if (createIfMissing) return { type, createIfMissing: true };
-      return undefined;
-    }, [id, type, createIfMissing]);
+    const getDocArgs = useMemo<GetDocArgs>(
+      () => ({ type, id, createIfMissing }),
+      [id, type, createIfMissing],
+    );
 
     useEffect(() => {
-      if (!client || !getDocArgs) return;
+      if (!client) return;
       return client.getDoc(getDocArgs, setResult);
     }, [getDocArgs]);
 

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -135,7 +135,6 @@ export class DocSyncClient<
    *
    * The behavior depends on which fields are provided:
    * - `{ type, id }` → Try to get an existing doc. Returns `undefined` if not found.
-   * - `{ type, createIfMissing: true }` → Create a new doc with auto-generated ID (ulid).
    * - `{ type, id, createIfMissing: true }` → Get existing doc or create it if not found.
    *
    * The callback will be invoked with state updates:
@@ -171,111 +170,70 @@ export class DocSyncClient<
     ) => void,
   ): () => void {
     const type = args.type;
-    const argId = "id" in args ? args.id : undefined;
+    const argId = args.id;
     const createIfMissing = "createIfMissing" in args && args.createIfMissing;
     // Internal emit uses wider type; runtime logic ensures correct data per overload
     const emit = onChange as (
       result: QueryResult<DocData<D> | undefined>,
     ) => void;
-    let docId: string | undefined;
+    const docId = argId;
 
-    // Case: { type, createIfMissing: true } → Create new doc with auto-generated ID (sync).
-    if (!argId && createIfMissing) {
-      const { doc, docId: createdDocId } = this._docBinding.create(type);
-      docId = createdDocId;
-      this._docsCache.set(createdDocId, {
-        promisedDoc: Promise.resolve(doc),
+    emit({ status: "pending" });
+
+    // Check cache BEFORE async block to avoid race conditions with getPresence
+    const existingCacheEntry = this._docsCache.get(docId);
+    if (existingCacheEntry) {
+      existingCacheEntry.refCount += 1;
+    } else {
+      // Create cache entry immediately so getPresence can subscribe
+      const promisedDoc = this._loadOrCreateDoc(
+        docId,
+        createIfMissing ? type : undefined,
+      );
+      this._docsCache.set(docId, {
+        promisedDoc,
         refCount: 1,
         type,
         presence: {},
         presenceListeners: new Set(),
       });
-      this._setupChangeListener(doc, createdDocId);
-      emit({ status: "success", data: { doc, docId: createdDocId } });
-
-      this._events.emit("docLoad", {
-        docId: createdDocId,
-        source: "created",
-        refCount: 1,
-      });
-
-      void (async () => {
-        const local = await this._localPromise;
-        if (!local) return;
-        await local.provider.transaction("readwrite", (ctx) =>
-          ctx.saveSerializedDoc({
-            serializedDoc: this._docBinding.serialize(doc),
-            docId: createdDocId,
-            clock: 0,
-          }),
-        );
-      })();
-      // We don't trigger an initial sync here because argId is undefined;
-      // so this is truly a new doc. Initial operations will be pushed to server
-      return () => void this._unloadDoc(createdDocId);
     }
 
-    // Preparing for the async cases
-    emit({ status: "pending" });
-
-    // Case: { type, id } or { type, id, createIfMissing } → Load or create (async).
-    if (argId) {
-      docId = argId;
-      // Check cache BEFORE async block to avoid race conditions with getPresence
-      const existingCacheEntry = this._docsCache.get(docId);
-      if (existingCacheEntry) {
-        existingCacheEntry.refCount += 1;
-      } else {
-        // Create cache entry immediately so getPresence can subscribe
-        const promisedDoc = this._loadOrCreateDoc(
-          docId,
-          createIfMissing ? type : undefined,
-        );
-        this._docsCache.set(docId, {
-          promisedDoc,
-          refCount: 1,
-          type,
-          presence: {},
-          presenceListeners: new Set(),
-        });
-      }
-
-      void (async () => {
-        try {
-          let doc: D | undefined;
-          let source: "cache" | "local" | "created" = "local";
-          const cacheEntry = this._docsCache.get(docId)!;
-          if (existingCacheEntry) {
-            doc = await cacheEntry.promisedDoc;
-            source = "cache";
-          } else {
-            doc = await cacheEntry.promisedDoc;
-            if (doc) {
-              // Register listener only for new docs (not cache hits)
-              this._setupChangeListener(doc, docId);
-              source = createIfMissing ? "created" : "local";
-            }
-          }
-
+    void (async () => {
+      try {
+        let doc: D | undefined;
+        let source: "cache" | "local" | "created" = "local";
+        const cacheEntry = this._docsCache.get(docId)!;
+        if (existingCacheEntry) {
+          doc = await cacheEntry.promisedDoc;
+          source = "cache";
+        } else {
+          doc = await cacheEntry.promisedDoc;
           if (doc) {
-            const refCount = this._docsCache.get(docId)?.refCount ?? 1;
-            this._events.emit("docLoad", { docId, source, refCount });
+            // Register listener only for new docs (not cache hits)
+            this._setupChangeListener(doc, docId);
+            source = createIfMissing ? "created" : "local";
           }
-
-          emit({ status: "success", data: doc ? { doc, docId } : undefined });
-          // Fetch from server to check if document exists there
-          if (doc) {
-            void handleSync(this, docId);
-          }
-        } catch (e) {
-          const error = e instanceof Error ? e : new Error(String(e));
-          emit({ status: "error", error });
         }
-      })();
-    }
+
+        if (doc) {
+          const refCount = this._docsCache.get(docId)?.refCount ?? 1;
+          this._events.emit("docLoad", { docId, source, refCount });
+        }
+
+        emit({ status: "success", data: doc ? { doc, docId } : undefined });
+        // Fetch from server to check if document exists there
+        if (doc) {
+          void handleSync(this, docId);
+        }
+      } catch (e) {
+        const error = e instanceof Error ? e : new Error(String(e));
+        emit({ status: "error", error });
+      }
+    })();
 
     return () => {
-      if (docId) void this._unloadDoc(docId);
+      void this._unloadDoc(docId);
     };
   }
 

--- a/packages/docsync/src/client/types.ts
+++ b/packages/docsync/src/client/types.ts
@@ -19,9 +19,11 @@ export type QueryResult<D, E = Error> =
 /**
  * Arguments for {@link DocSyncClient["getDoc"]}.
  */
-export type GetDocArgs =
-  | { type: string; id: string; createIfMissing?: boolean }
-  | { type: string; createIfMissing: true };
+export type GetDocArgs = {
+  type: string;
+  id: string;
+  createIfMissing?: boolean;
+};
 
 export type DocData<D> = { doc: D; docId: string };
 

--- a/tests/docsync-react/index.browser.test.tsx
+++ b/tests/docsync-react/index.browser.test.tsx
@@ -28,8 +28,20 @@ test("createDocSyncClient", async () => {
   // Type check: useDoc returns QueryResult<Doc>
   expectTypeOf<ReturnType<typeof useDoc>>().toEqualTypeOf<MaybeDocResult>();
 
-  // @ts-expect-error - type is required
-  await renderHook(() => useDoc({ createIfMissing: true, id: "123" }));
+  const typeCheck = (hook: typeof useDoc) => {
+    // @ts-expect-error - type is required
+    hook({ createIfMissing: true, id: "123" });
+
+    // @ts-expect-error - id is required
+    hook({ type: "test" });
+
+    // @ts-expect-error - id is required
+    hook({ type: "test", createIfMissing: false });
+
+    // @ts-expect-error - id is required
+    hook({ type: "test", createIfMissing: true });
+  };
+  expect(typeCheck).toBeDefined();
 
   // with id, without createIfMissing
   // prettier-ignore
@@ -58,21 +70,13 @@ test("createDocSyncClient", async () => {
   expect(_2.current.data?.docId.endsWith("002")).toBe(true);
   expect(_2.current.data?.docId).toBe(_2.current.data?.doc?.root.id);
 
-  // without id, with createIfMissing true
+  // with id, with createIfMissing true
   // prettier-ignore
   const id3 = id.ending("3");
   const { result: _3 } = await renderHook(() =>
     useDoc({ type: "test", id: id3, createIfMissing: true }),
   );
   expectTypeOf(_3.current).toEqualTypeOf<DocResult>();
-
-  // @ts-expect-error - without id, without createIfMissing
-  await renderHook(() => useDoc({ type: "test" }));
-
-  // without id, with createIfMissing false
-  // @ts-expect-error - required id
-  // prettier-ignore
-  await renderHook(() => useDoc({ type: "test", createIfMissing: false }));
 
   // with id, with createIfMissing false
   // prettier-ignore

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -245,7 +245,10 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
 
         // Trigger _localPromise resolution by calling getDoc
-        client.getDoc({ type: "test", createIfMissing: true }, callback);
+        client.getDoc(
+          { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
+          callback,
+        );
 
         await expect.poll(() => constructorSpy.mock.calls.length).toBe(1);
         // BroadcastChannel name should be user-specific: "docsync:{userId}"
@@ -283,7 +286,10 @@ describe("DocSyncClient", () => {
         const client = createClient();
         const callback = createCallback();
 
-        client.getDoc({ type: "test", createIfMissing: true }, callback);
+        client.getDoc(
+          { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
+          callback,
+        );
         await expect.poll(() => client["_bcHelper"]).toBeDefined();
 
         const bcHelper = client["_bcHelper"];
@@ -780,11 +786,6 @@ describe("DocSyncClient", () => {
         expectTypeOf(result).toEqualTypeOf<DocResult>();
       });
 
-      // without id, createIfMissing: true → DocResult
-      client.getDoc({ type: "test", createIfMissing: true }, (result) => {
-        expectTypeOf(result).toEqualTypeOf<DocResult>();
-      });
-
       // with id, createIfMissing: false → MaybeDocResult
       client.getDoc({ type: "test", id, createIfMissing: false }, (result) => {
         expectTypeOf(result).toEqualTypeOf<MaybeDocResult>();
@@ -803,11 +804,14 @@ describe("DocSyncClient", () => {
         // @ts-expect-error - type is required (even with createIfMissing and id)
         client.getDoc({ createIfMissing: true, id: "123" }, callback);
 
-        // @ts-expect-error - without id, createIfMissing must be true
+        // @ts-expect-error - id is required
         client.getDoc({ type: "test" }, callback);
 
-        // @ts-expect-error - without id, createIfMissing: false is invalid
+        // @ts-expect-error - id is required
         client.getDoc({ type: "test", createIfMissing: false }, callback);
+
+        // @ts-expect-error - id is required
+        client.getDoc({ type: "test", createIfMissing: true }, callback);
       };
 
       // Verify the function exists (never called, just for type checking)
@@ -856,9 +860,13 @@ describe("DocSyncClient", () => {
         const client = createClient();
         const callback1 = createCallback();
         const callback2 = createCallback();
+        const docId = ulid().toLowerCase();
 
         // Create a doc first
-        client.getDoc({ type: "test", createIfMissing: true }, callback1);
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback1,
+        );
         await expect.poll(() => getSuccessData(callback1)).toBeDefined();
         const createdDoc = getSuccessData(callback1);
 
@@ -873,11 +881,15 @@ describe("DocSyncClient", () => {
         const client = createClient();
         const callback1 = createCallback();
         const callback2 = createCallback();
+        const docId = ulid().toLowerCase();
 
-        // Create a doc first (sync path)
-        client.getDoc({ type: "test", createIfMissing: true }, callback1);
+        // Create a doc first
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback1,
+        );
+        await expect.poll(() => getSuccessData(callback1)).toBeDefined();
         const createdDoc = getSuccessData(callback1);
-        expect(createdDoc).toBeDefined();
 
         // Request the same doc - cache hit
         client.getDoc({ type: "test", id: createdDoc!.docId }, callback2);
@@ -896,41 +908,17 @@ describe("DocSyncClient", () => {
     });
 
     describe("Create new document", () => {
-      test("should create new document with auto-generated ID when createIfMissing is true", () => {
+      test("should create new document with provided ID when createIfMissing is true", async () => {
         const client = createClient();
         const callback = createCallback();
+        const docId = ulid().toLowerCase();
 
-        client.getDoc({ type: "test", createIfMissing: true }, callback);
-
-        // Should immediately emit success (sync operation)
-        expect(callback).toHaveBeenCalledWith(
-          expect.objectContaining({
-            status: "success",
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            data: expect.objectContaining({
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              doc: expect.anything(),
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              docId: expect.any(String),
-            }),
-          }),
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
         );
-      });
 
-      test("should generate unique IDs for each new document", () => {
-        const client = createClient();
-        const callback1 = createCallback();
-        const callback2 = createCallback();
-
-        client.getDoc({ type: "test", createIfMissing: true }, callback1);
-        client.getDoc({ type: "test", createIfMissing: true }, callback2);
-
-        const id1 = callback1.mock.calls[0]?.[0]?.data?.docId;
-        const id2 = callback2.mock.calls[0]?.[0]?.data?.docId;
-
-        expect(id1).toBeDefined();
-        expect(id2).toBeDefined();
-        expect(id1).not.toBe(id2);
+        await expect.poll(() => getSuccessData(callback)?.docId).toBe(docId);
       });
 
       test("should return unsubscribe function", () => {
@@ -938,7 +926,7 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
 
         const unsubscribe = client.getDoc(
-          { type: "test", createIfMissing: true },
+          { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
           callback,
         );
 
@@ -961,15 +949,18 @@ describe("DocSyncClient", () => {
     });
 
     describe("Sync vs async behavior", () => {
-      test("should NOT emit pending when creating new doc without id", () => {
+      test("should emit pending before success when creating by id", async () => {
         const client = createClient();
         const callback = createCallback();
+        const customId = ulid().toLowerCase();
 
-        client.getDoc({ type: "test", createIfMissing: true }, callback);
+        client.getDoc(
+          { type: "test", id: customId, createIfMissing: true },
+          callback,
+        );
 
-        // First call should be success, not pending
-        expect(callback.mock.calls[0]?.[0]?.status).toBe("success");
-        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback.mock.calls[0]?.[0]?.status).toBe("pending");
+        await expect.poll(() => getSuccessData(callback)?.docId).toBe(customId);
       });
 
       test("should emit pending before success when fetching by id", async () => {
@@ -992,11 +983,13 @@ describe("DocSyncClient", () => {
       test("should remove doc from cache and call dispose when last subscriber unsubscribes", async () => {
         const { client, disposeSpy } = createClientWithDisposeSpy();
         const callback = createCallback();
+        const createdId = ulid().toLowerCase();
 
         const unsubscribe = client.getDoc(
-          { type: "test", createIfMissing: true },
+          { type: "test", id: createdId, createIfMissing: true },
           callback,
         );
+        await expect.poll(() => getSuccessData(callback)).toBeDefined();
         const doc = getSuccessData(callback)!.doc;
         const docId = getSuccessData(callback)!.docId;
         const cache = client["_docsCache"];
@@ -1015,12 +1008,14 @@ describe("DocSyncClient", () => {
         const { client, disposeSpy } = createClientWithDisposeSpy();
         const callback1 = createCallback();
         const callback2 = createCallback();
+        const createdId = ulid().toLowerCase();
 
         // First subscription creates the doc
         const unsubscribe1 = client.getDoc(
-          { type: "test", createIfMissing: true },
+          { type: "test", id: createdId, createIfMissing: true },
           callback1,
         );
+        await expect.poll(() => getSuccessData(callback1)).toBeDefined();
         const doc = getSuccessData(callback1)!.doc;
         const docId = getSuccessData(callback1)!.docId;
 
@@ -1052,9 +1047,14 @@ describe("DocSyncClient", () => {
         const callback1 = createCallback();
         const callback2 = createCallback();
         const callback3 = createCallback();
+        const createdId = ulid().toLowerCase();
 
         // Create doc
-        client.getDoc({ type: "test", createIfMissing: true }, callback1);
+        client.getDoc(
+          { type: "test", id: createdId, createIfMissing: true },
+          callback1,
+        );
+        await expect.poll(() => getSuccessData(callback1)).toBeDefined();
         const docId = getSuccessData(callback1)!.docId;
 
         const cache = client["_docsCache"];
@@ -1073,9 +1073,14 @@ describe("DocSyncClient", () => {
         const client = createClient();
         const callback1 = createCallback();
         const callback2 = createCallback();
+        const createdId = ulid().toLowerCase();
 
         // Create doc
-        client.getDoc({ type: "test", createIfMissing: true }, callback1);
+        client.getDoc(
+          { type: "test", id: createdId, createIfMissing: true },
+          callback1,
+        );
+        await expect.poll(() => getSuccessData(callback1)).toBeDefined();
         const doc1 = getSuccessData(callback1)!.doc;
 
         // Second subscription
@@ -1093,18 +1098,24 @@ describe("DocSyncClient", () => {
       test("should NOT notify callback when document content changes", async () => {
         const client = createClient();
         const callback = createCallback();
+        const createdId = ulid().toLowerCase();
 
         // Create doc
-        client.getDoc({ type: "test", createIfMissing: true }, callback);
+        client.getDoc(
+          { type: "test", id: createdId, createIfMissing: true },
+          callback,
+        );
+        await expect.poll(() => getSuccessData(callback)).toBeDefined();
         const doc = getSuccessData(callback)!.doc;
 
-        // Initial call count (1 for success)
-        expect(callback.mock.calls.length).toBe(1);
+        const initialCallCount = callback.mock.calls.length;
 
         // Trigger a document change
         doc.root.append(doc.createNode(ChildNode));
         // Callback should NOT be called on doc changes (poll until stable)
-        await expect.poll(() => callback.mock.calls.length).toBe(1);
+        await expect
+          .poll(() => callback.mock.calls.length)
+          .toBe(initialCallCount);
       });
     });
 
@@ -1296,8 +1307,13 @@ describe("DocSyncClient", () => {
       try {
         const client = createClient();
         const callback = createCallback();
+        const createdId = ulid().toLowerCase();
 
-        client.getDoc({ type: "test", createIfMissing: true }, callback);
+        client.getDoc(
+          { type: "test", id: createdId, createIfMissing: true },
+          callback,
+        );
+        await expect.poll(() => getSuccessData(callback)).toBeDefined();
         const doc = getSuccessData(callback)!.doc;
         const docId = getSuccessData(callback)!.docId;
 
@@ -1310,7 +1326,6 @@ describe("DocSyncClient", () => {
           type: "OPERATIONS",
           docId,
           source: "local-broadcast",
-          flags: { skipUndo: true },
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           operations: expect.anything(),
         });
@@ -1344,9 +1359,14 @@ describe("DocSyncClient", () => {
       try {
         const client = createClient();
         const callback = createCallback();
+        const createdId = ulid().toLowerCase();
 
         // Create a doc
-        client.getDoc({ type: "test", createIfMissing: true }, callback);
+        client.getDoc(
+          { type: "test", id: createdId, createIfMissing: true },
+          callback,
+        );
+        await expect.poll(() => getSuccessData(callback)).toBeDefined();
         const doc = getSuccessData(callback)!.doc;
         const docId = getSuccessData(callback)!.docId;
 
@@ -1356,7 +1376,11 @@ describe("DocSyncClient", () => {
         // Simulate receiving operations from another tab
         // We need to create valid operations, so we'll create them from another doc
         const tempCallback = createCallback();
-        client.getDoc({ type: "test", createIfMissing: true }, tempCallback);
+        client.getDoc(
+          { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
+          tempCallback,
+        );
+        await expect.poll(() => getSuccessData(tempCallback)).toBeDefined();
         const tempDoc = getSuccessData(tempCallback)!.doc;
         tempDoc.root.append(tempDoc.createNode(ChildNode));
         await expect.poll(() => messageHandler !== null).toBe(true);
@@ -1397,9 +1421,14 @@ describe("DocSyncClient", () => {
       try {
         const client = createClient();
         const callback = createCallback();
+        const createdId = ulid().toLowerCase();
 
         // Create a doc - this will resolve _localPromise and initialize BroadcastChannel
-        client.getDoc({ type: "test", createIfMissing: true }, callback);
+        client.getDoc(
+          { type: "test", id: createdId, createIfMissing: true },
+          callback,
+        );
+        await expect.poll(() => getSuccessData(callback)).toBeDefined();
         const docId = getSuccessData(callback)!.docId;
 
         await expect.poll(() => messageHandler !== undefined).toBe(true);


### PR DESCRIPTION
This removes `getDoc({ type, createIfMissing: true })` without an `id`. The reason is that it was an anti-pattern: in React, it could accidentally create a new document on every render if used the wrong way. It also was not used anywhere in the real examples in this repo.

The right flow is to create or choose a stable ID first, or create a document through a separate path, and then pass that ID to `getDoc` / `useDoc`. It also makes `getDoc` simpler, because before it was doing too many things: not just getting documents, but also inventing IDs and creating new documents.