### PR TITLE
Add fetchStatus to DocSync query results

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,2 @@
 pnpm-lock.yaml
-
+.context

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@
 ## TypeScript Rules
 
 - **NEVER add `any` (or `as any`, `as unknown as ...`, etc.) without first stopping, presenting every alternative you can think of, and waiting for explicit approval.** This applies to both implementation code and tests, to both new code and edits to existing code, and to both function signatures (including generic defaults like `<T = any>`) and local values. If TS inference is failing, the right move is to surface the problem and the trade-offs — not to silence it with `any`. Even if the existing code already used `any`, do not preserve it without asking.
+- Never call a function with an explicit type parameter. Let TypeScript infer it. For example, write `createQueryResultReducer(...)`, not `createQueryResultReducer<Data>(...)`.
 
 ## Critical Rules for Agents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,13 @@
 - When I ask a question or describe a problem, start by brainstorming a few potential solutions.
 - Show example code for each and help me compare them.
 - Ask which one we should try together.
-- Do not perform any git-related action unless I explicitly ask for that exact action in the current conversation. This includes staging, unstaging, committing, pushing, branching, switching branches, rebasing, stashing, restoring files, or any other command that mutates git state.
+- Git commands that only read information are allowed, such as `git status`, `git diff`, `git show`, `git log`, and `git branch --show-current`.
+- Do not perform any git action that mutates state unless I explicitly ask for that exact action in the current conversation. This includes staging, unstaging, committing, pushing, branching, switching branches, rebasing, stashing, restoring files, or any other command that mutates git state.
 
 ## Git Safety Rules
 
-- Never run `git add`, `git commit`, `git push`, or any other git command unless I explicitly ask for that exact git action in the current conversation.
+- Read-only git commands are allowed when they help inspect work, review staged files, compare changes, or understand history.
+- Never run `git add`, `git commit`, `git push`, or any other git command that mutates git state unless I explicitly ask for that exact git action in the current conversation.
 - Updating a PR, editing documentation, fixing code, or running tests does not imply permission to stage, commit, push, branch, rebase, stash, restore, checkout, or mutate git state.
 - If a change is ready but I did not explicitly ask for a git action, leave it unstaged.
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -208,6 +208,7 @@ export const rootEslintConfig = tseslint.config(
   {
     ignores: [
       "**/dist",
+      "**/.context",
       "**/.next",
       "**/node_modules",
       "**/.test-results",

--- a/packages/docsync-react/src/index.tsx
+++ b/packages/docsync-react/src/index.tsx
@@ -53,6 +53,7 @@ export function createDocSyncClient<T extends ClientConfig<any, any, any>>(
   function useDoc(args: GetDocArgs): QueryResult<DocData | undefined> {
     const [result, setResult] = useState<QueryResult<DocData | undefined>>({
       status: "pending",
+      fetchStatus: "fetching",
     });
     const id = "id" in args ? args.id : undefined;
     const createIfMissing = "createIfMissing" in args && args.createIfMissing;

--- a/packages/docsync/src/client/handlers/clientInitiated/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync.ts
@@ -39,6 +39,11 @@ function _replaceDocInCache<D extends {}, S extends {}, O extends {}>(
     promisedDoc: Promise.resolve(newDoc),
     refCount: cacheEntry.refCount,
     type: cacheEntry.type,
+    ...(cacheEntry.localLoadMode && {
+      localLoadMode: cacheEntry.localLoadMode,
+    }),
+    queryResult: cacheEntry.queryResult,
+    queryListeners: cacheEntry.queryListeners,
     presence: cacheEntry.presence,
     presenceListeners: cacheEntry.presenceListeners,
   });
@@ -181,5 +186,7 @@ export const handleSync = async <D extends {}, S extends {}, O extends {}>(
   pushStatusByDocId.set(docId, "idle");
   if (shouldRetry) {
     void handleSync(client, docId);
+    return;
   }
+  client["_markDocQueryIdle"](docId);
 };

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -45,6 +45,18 @@ type LocalOpsBatchState<O extends {}> = DeferredState<O[]> & {
 
 type PushStatus = "idle" | "pushing" | "pushing-with-pending";
 type ChangeOrigin = "local" | "network" | "local-broadcast";
+type LocalLoadMode = "load" | "loadOrCreate";
+type QueryListener = (result: QueryResult<DocData<{}> | undefined>) => void;
+type DocCacheEntry<D> = {
+  promisedDoc: Promise<D | undefined>;
+  refCount: number;
+  type: string;
+  localLoadMode?: LocalLoadMode;
+  queryResult: QueryResult<DocData<D> | undefined>;
+  queryListeners: Set<QueryListener>;
+  presence: Presence;
+  presenceListeners: Set<(presence: Presence) => void>;
+};
 
 export class DocSyncClient<
   D extends {} = {},
@@ -52,16 +64,7 @@ export class DocSyncClient<
   O extends {} = {},
 > {
   protected _docBinding: DocBinding<D, S, O>;
-  protected _docsCache = new Map<
-    string,
-    {
-      promisedDoc: Promise<D | undefined>;
-      refCount: number;
-      type: string;
-      presence: Presence;
-      presenceListeners: Set<(presence: Presence) => void>;
-    }
-  >();
+  protected _docsCache = new Map<string, DocCacheEntry<D>>();
   protected _localPromise: Promise<LocalResolved<S, O>>;
   protected _deviceId: string;
   /** Client-generated id for presence (works offline; sent in auth so server uses same key) */
@@ -170,71 +173,132 @@ export class DocSyncClient<
     ) => void,
   ): () => void {
     const type = args.type;
-    const argId = args.id;
-    const createIfMissing = "createIfMissing" in args && args.createIfMissing;
-    // Internal emit uses wider type; runtime logic ensures correct data per overload
-    const emit = onChange as (
-      result: QueryResult<DocData<D> | undefined>,
-    ) => void;
-    const docId = argId;
+    const docId = args.id;
+    const createIfMissing =
+      "createIfMissing" in args && args.createIfMissing === true;
+    const localLoadMode = createIfMissing ? "loadOrCreate" : "load";
+    const listener = onChange as QueryListener;
+    const initialFetchStatus = this._socket.connected ? "fetching" : "paused";
 
-    emit({ status: "pending" });
-
-    // Check cache BEFORE async block to avoid race conditions with getPresence
     const existingCacheEntry = this._docsCache.get(docId);
     if (existingCacheEntry) {
       existingCacheEntry.refCount += 1;
+      existingCacheEntry.queryListeners.add(listener);
+      listener(existingCacheEntry.queryResult);
+
+      const hasDoc =
+        existingCacheEntry.queryResult.status === "success" &&
+        existingCacheEntry.queryResult.data !== undefined;
+
+      if (
+        createIfMissing &&
+        existingCacheEntry.localLoadMode !== "loadOrCreate" &&
+        !hasDoc
+      ) {
+        existingCacheEntry.localLoadMode = "loadOrCreate";
+        const promisedDoc = this._loadOrCreateDoc(docId, type);
+        existingCacheEntry.promisedDoc = promisedDoc;
+        this._observePromisedDoc(docId, promisedDoc, "loadOrCreate");
+      }
     } else {
       // Create cache entry immediately so getPresence can subscribe
       const promisedDoc = this._loadOrCreateDoc(
         docId,
         createIfMissing ? type : undefined,
       );
+      const queryResult: QueryResult<DocData<D> | undefined> = {
+        status: "pending",
+        fetchStatus: initialFetchStatus,
+      };
       this._docsCache.set(docId, {
         promisedDoc,
         refCount: 1,
         type,
+        localLoadMode,
+        queryResult,
+        queryListeners: new Set([listener]),
         presence: {},
         presenceListeners: new Set(),
       });
+      listener(queryResult);
+      this._observePromisedDoc(docId, promisedDoc, localLoadMode);
     }
 
+    return () => {
+      this._docsCache.get(docId)?.queryListeners.delete(listener);
+      void this._unloadDoc(docId);
+    };
+  }
+
+  protected _emitQueryResult(
+    docId: string,
+    result: QueryResult<DocData<D> | undefined>,
+  ): void {
+    const cacheEntry = this._docsCache.get(docId);
+    if (!cacheEntry) return;
+
+    cacheEntry.queryResult = result;
+    for (const listener of cacheEntry.queryListeners) {
+      listener(result);
+    }
+  }
+
+  protected _markDocQueryIdle(docId: string): void {
+    const cacheEntry = this._docsCache.get(docId);
+    if (!cacheEntry) return;
+    if (cacheEntry.queryResult.fetchStatus === "idle") return;
+
+    this._emitQueryResult(docId, {
+      ...cacheEntry.queryResult,
+      fetchStatus: "idle",
+    });
+  }
+
+  private _observePromisedDoc(
+    docId: string,
+    promisedDoc: Promise<D | undefined>,
+    localLoadMode: LocalLoadMode,
+  ): void {
     void (async () => {
       try {
-        let doc: D | undefined;
-        let source: "cache" | "local" | "created" = "local";
-        const cacheEntry = this._docsCache.get(docId)!;
-        if (existingCacheEntry) {
-          doc = await cacheEntry.promisedDoc;
-          source = "cache";
-        } else {
-          doc = await cacheEntry.promisedDoc;
-          if (doc) {
-            // Register listener only for new docs (not cache hits)
-            this._setupChangeListener(doc, docId);
-            source = createIfMissing ? "created" : "local";
-          }
-        }
+        const doc = await promisedDoc;
+        const cacheEntry = this._docsCache.get(docId);
+        if (!cacheEntry) return;
+        if (cacheEntry.promisedDoc !== promisedDoc) return;
+        delete cacheEntry.localLoadMode;
 
         if (doc) {
-          const refCount = this._docsCache.get(docId)?.refCount ?? 1;
-          this._events.emit("docLoad", { docId, source, refCount });
+          this._setupChangeListener(doc, docId);
+          this._events.emit("docLoad", {
+            docId,
+            source: localLoadMode === "loadOrCreate" ? "created" : "local",
+            refCount: cacheEntry.refCount,
+          });
         }
 
-        emit({ status: "success", data: doc ? { doc, docId } : undefined });
-        // Fetch from server to check if document exists there
+        this._emitQueryResult(docId, {
+          status: "success",
+          fetchStatus: doc ? cacheEntry.queryResult.fetchStatus : "idle",
+          data: doc ? { doc, docId } : undefined,
+        });
+
         if (doc) {
           void handleSync(this, docId);
         }
       } catch (e) {
+        const cacheEntry = this._docsCache.get(docId);
+        if (!cacheEntry) return;
+        if (cacheEntry.promisedDoc !== promisedDoc) return;
+        delete cacheEntry.localLoadMode;
+
         const error = e instanceof Error ? e : new Error(String(e));
-        emit({ status: "error", error });
+        this._emitQueryResult(docId, {
+          ...cacheEntry.queryResult,
+          status: "error",
+          error,
+        });
       }
     })();
-
-    return () => {
-      void this._unloadDoc(docId);
-    };
   }
 
   /**

--- a/packages/docsync/src/client/types.ts
+++ b/packages/docsync/src/client/types.ts
@@ -11,6 +11,8 @@ import type {
 // Query / Doc
 // ============================================================================
 
+export type FetchStatus = "fetching" | "paused" | "idle";
+
 export type QueryResult<D, E = Error> =
   | { status: "pending"; data?: never; error?: never }
   | { status: "success"; data: D; error?: never }

--- a/packages/docsync/src/client/types.ts
+++ b/packages/docsync/src/client/types.ts
@@ -14,9 +14,14 @@ import type {
 export type FetchStatus = "fetching" | "paused" | "idle";
 
 export type QueryResult<D, E = Error> =
-  | { status: "pending"; data?: never; error?: never }
-  | { status: "success"; data: D; error?: never }
-  | { status: "error"; data?: never; error: E };
+  | { status: "pending"; fetchStatus: FetchStatus; data?: never; error?: never }
+  | { status: "success"; fetchStatus: FetchStatus; data: D; error?: never }
+  | {
+      status: "error";
+      fetchStatus: FetchStatus;
+      data?: D | undefined;
+      error: E;
+    };
 
 /**
  * Arguments for {@link DocSyncClient["getDoc"]}.

--- a/packages/docsync/src/client/utils/getOwnPresencePatch.ts
+++ b/packages/docsync/src/client/utils/getOwnPresencePatch.ts
@@ -1,7 +1,8 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { DocSyncClient } from "../index.js";
 
-export function getOwnPresencePatch(
-  client: DocSyncClient,
+export function getOwnPresencePatch<D extends {}, S extends {}, O extends {}>(
+  client: DocSyncClient<D, S, O>,
   docId: string,
 ): Record<string, unknown> | undefined {
   const state = client["_presenceDebounceState"].get(docId);

--- a/packages/docsync/src/client/utils/queryResultReducer.ts
+++ b/packages/docsync/src/client/utils/queryResultReducer.ts
@@ -1,0 +1,89 @@
+import type { FetchStatus, QueryResult } from "../types.js";
+import { createReducer } from "./reducer.js";
+
+function withFetchStatus<D>(
+  state: QueryResult<D>,
+  fetchStatus: FetchStatus,
+): QueryResult<D> {
+  if (state.fetchStatus === fetchStatus) return state;
+  return { ...state, fetchStatus };
+}
+
+function success<D>(data: D, fetchStatus: FetchStatus): QueryResult<D> {
+  return { status: "success", fetchStatus, data };
+}
+
+function error<D>(
+  state: QueryResult<D>,
+  fetchStatus: FetchStatus,
+  errorValue: Error,
+): QueryResult<D> {
+  return { ...state, status: "error", fetchStatus, error: errorValue };
+}
+
+/**
+ * @internal - Do not use this function!
+ */
+export function createQueryResultReducer<D>(config: {
+  initialFetchStatus: FetchStatus;
+  createIfMissing: boolean;
+}) {
+  const initialState: QueryResult<D> = {
+    status: "pending",
+    fetchStatus: config.initialFetchStatus,
+  };
+
+  const actions = {
+    // localDocNotFound is not an action, because does not change the state
+    localDocFound: (state: QueryResult<D>, payload: { data: D }) =>
+      success(payload.data, state.fetchStatus),
+
+    localQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
+      error(state, state.fetchStatus, payload.error),
+
+    connected: (state: QueryResult<D>, _payload: undefined) => {
+      if (state.fetchStatus !== "paused") return state;
+      return withFetchStatus(state, "fetching");
+    },
+
+    disconnected: (state: QueryResult<D>, _payload: undefined) => {
+      if (state.fetchStatus !== "fetching") return state;
+      return withFetchStatus(state, "paused");
+    },
+
+    networkDocFound: (_state: QueryResult<D>, payload: { data: D }) =>
+      success(payload.data, "idle"),
+
+    networkDocNotFound: (
+      state: QueryResult<D>,
+      _payload: undefined,
+    ): QueryResult<D> => {
+      if (state.status === "success") return success(state.data, "idle");
+      if (state.status === "error" && state.data !== undefined) {
+        return success(state.data, "idle");
+      }
+      if (config.createIfMissing) {
+        return { status: "pending", fetchStatus: "idle" };
+      }
+      return success(undefined as D, "idle");
+    },
+
+    networkQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
+      error(state, "idle", payload.error),
+  };
+
+  return createReducer<QueryResult<D>, typeof actions>({
+    initialState,
+    actions,
+    beforeAction: (state, action) => {
+      const terminalNetworkAction =
+        action.type === "networkDocFound" ||
+        action.type === "networkDocNotFound" ||
+        action.type === "networkQueryError";
+
+      if (terminalNetworkAction && state.fetchStatus === "idle") {
+        throw new Error(`Cannot apply ${action.type} when fetchStatus is idle`);
+      }
+    },
+  });
+}

--- a/packages/docsync/src/client/utils/queryResultReducer.ts
+++ b/packages/docsync/src/client/utils/queryResultReducer.ts
@@ -25,56 +25,49 @@ function error<D>(
  * @internal - Do not use this function!
  */
 export function createQueryResultReducer<D>(config: {
-  initialFetchStatus: FetchStatus;
+  initialState: QueryResult<D>;
   createIfMissing: boolean;
 }) {
-  const initialState: QueryResult<D> = {
-    status: "pending",
-    fetchStatus: config.initialFetchStatus,
-  };
+  return createReducer({
+    initialState: config.initialState,
+    actions: {
+      // localDocNotFound is not an action, because does not change the state
+      localDocFound: (state: QueryResult<D>, payload: { data: D }) =>
+        success(payload.data, state.fetchStatus),
 
-  const actions = {
-    // localDocNotFound is not an action, because does not change the state
-    localDocFound: (state: QueryResult<D>, payload: { data: D }) =>
-      success(payload.data, state.fetchStatus),
+      localQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
+        error(state, state.fetchStatus, payload.error),
 
-    localQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
-      error(state, state.fetchStatus, payload.error),
+      connected: (state: QueryResult<D>, _payload: undefined) => {
+        if (state.fetchStatus !== "paused") return state;
+        return withFetchStatus(state, "fetching");
+      },
 
-    connected: (state: QueryResult<D>, _payload: undefined) => {
-      if (state.fetchStatus !== "paused") return state;
-      return withFetchStatus(state, "fetching");
+      disconnected: (state: QueryResult<D>, _payload: undefined) => {
+        if (state.fetchStatus !== "fetching") return state;
+        return withFetchStatus(state, "paused");
+      },
+
+      networkDocFound: (_state: QueryResult<D>, payload: { data: D }) =>
+        success(payload.data, "idle"),
+
+      networkDocNotFound: (
+        state: QueryResult<D>,
+        _payload: undefined,
+      ): QueryResult<D> => {
+        if (state.status === "success") return success(state.data, "idle");
+        if (state.status === "error" && state.data !== undefined) {
+          return success(state.data, "idle");
+        }
+        if (config.createIfMissing) {
+          return { status: "pending", fetchStatus: "idle" };
+        }
+        return success(undefined as D, "idle");
+      },
+
+      networkQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
+        error(state, "idle", payload.error),
     },
-
-    disconnected: (state: QueryResult<D>, _payload: undefined) => {
-      if (state.fetchStatus !== "fetching") return state;
-      return withFetchStatus(state, "paused");
-    },
-
-    networkDocFound: (_state: QueryResult<D>, payload: { data: D }) =>
-      success(payload.data, "idle"),
-
-    networkDocNotFound: (
-      state: QueryResult<D>,
-      _payload: undefined,
-    ): QueryResult<D> => {
-      if (state.status === "success") return success(state.data, "idle");
-      if (state.status === "error" && state.data !== undefined) {
-        return success(state.data, "idle");
-      }
-      if (config.createIfMissing) {
-        return { status: "pending", fetchStatus: "idle" };
-      }
-      return success(undefined as D, "idle");
-    },
-
-    networkQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
-      error(state, "idle", payload.error),
-  };
-
-  return createReducer<QueryResult<D>, typeof actions>({
-    initialState,
-    actions,
     beforeAction: (state, action) => {
       const terminalNetworkAction =
         action.type === "networkDocFound" ||

--- a/packages/docsync/src/client/utils/queryResultReducer.ts
+++ b/packages/docsync/src/client/utils/queryResultReducer.ts
@@ -26,7 +26,6 @@ function error<D>(
  */
 export function createQueryResultReducer<D>(config: {
   initialState: QueryResult<D>;
-  createIfMissing: boolean;
 }) {
   return createReducer({
     initialState: config.initialState,
@@ -53,13 +52,13 @@ export function createQueryResultReducer<D>(config: {
 
       networkDocNotFound: (
         state: QueryResult<D>,
-        _payload: undefined,
+        payload: { createIfMissing: boolean },
       ): QueryResult<D> => {
         if (state.status === "success") return success(state.data, "idle");
         if (state.status === "error" && state.data !== undefined) {
           return success(state.data, "idle");
         }
-        if (config.createIfMissing) {
+        if (payload.createIfMissing) {
           return { status: "pending", fetchStatus: "idle" };
         }
         return success(undefined as D, "idle");

--- a/packages/docsync/src/client/utils/reducer.ts
+++ b/packages/docsync/src/client/utils/reducer.ts
@@ -13,6 +13,9 @@ type Dispatchers<State, Actions extends ActionMap<State>> = {
   ) => State;
 };
 
+/**
+ * @internal - Do not use this function!
+ */
 export function createReducer<State, Actions extends ActionMap<State>>(config: {
   initialState: State;
   actions: Actions;

--- a/packages/docsync/src/client/utils/reducer.ts
+++ b/packages/docsync/src/client/utils/reducer.ts
@@ -1,0 +1,48 @@
+type ActionMap<State> = Record<string, (state: State, payload: never) => State>;
+
+type PayloadOf<Handler> = Handler extends (
+  state: never,
+  payload: infer Payload,
+) => unknown
+  ? Payload
+  : never;
+
+type Dispatchers<State, Actions extends ActionMap<State>> = {
+  [Name in keyof Actions & string]: (
+    payload: PayloadOf<Actions[Name]>,
+  ) => State;
+};
+
+export function createReducer<State, Actions extends ActionMap<State>>(config: {
+  initialState: State;
+  actions: Actions;
+  beforeAction?: (
+    state: State,
+    action: {
+      [Name in keyof Actions & string]: {
+        type: Name;
+        payload: PayloadOf<Actions[Name]>;
+      };
+    }[keyof Actions & string],
+  ) => void;
+}): { action: Dispatchers<State, Actions>; getState: () => State } {
+  let state = config.initialState;
+  const action = {} as Dispatchers<State, Actions>;
+
+  for (const name of Object.keys(config.actions) as Array<
+    keyof Actions & string
+  >) {
+    const reducer = config.actions[name] as (
+      state: State,
+      payload: PayloadOf<Actions[typeof name]>,
+    ) => State;
+
+    action[name] = ((payload: PayloadOf<Actions[typeof name]>) => {
+      config.beforeAction?.(state, { type: name, payload });
+      state = reducer(state, payload);
+      return state;
+    }) as Dispatchers<State, Actions>[typeof name];
+  }
+
+  return { action, getState: () => state };
+}

--- a/packages/docsync/src/exports/client.ts
+++ b/packages/docsync/src/exports/client.ts
@@ -14,6 +14,7 @@ export type {
 export type {
   ClientConfig,
   ClientProvider,
+  FetchStatus,
   GetDocArgs,
   DocData,
   Identity,

--- a/packages/docsync/src/exports/client.ts
+++ b/packages/docsync/src/exports/client.ts
@@ -1,6 +1,8 @@
 export { createDocBinding } from "../bindings/index.js";
 export { DocSyncClient } from "../client/index.js";
 export { indexedDBProvider } from "../client/providers/indexeddb.js";
+export { createReducer as _INTERNAL_createReducer } from "../client/utils/reducer.js";
+export { createQueryResultReducer as _INTERNAL_createQueryResultReducer } from "../client/utils/queryResultReducer.js";
 export type { DocBinding, Presence } from "../shared/types.js";
 export type {
   ChangeEvent,

--- a/tests/docsync-react/index.browser.test.tsx
+++ b/tests/docsync-react/index.browser.test.tsx
@@ -45,6 +45,7 @@ test("createDocSyncClient", async () => {
     // @ts-expect-error - id is required
     hook({ type: "test", createIfMissing: false });
 
+    // @ts-expect-error - id is required
     hook({ type: "test", createIfMissing: true });
   };
   expect(typeCheck).toBeDefined();

--- a/tests/docsync-react/index.browser.test.tsx
+++ b/tests/docsync-react/index.browser.test.tsx
@@ -9,11 +9,18 @@ import type { DocData, QueryResult } from "@docukit/docsync/client";
 import { renderHook } from "vitest-browser-react";
 import { docConfig, id } from "./utils.js";
 
+declare global {
+  var __TEST_SERVER_PORT__: number | undefined;
+}
+
+const testServerUrl = () =>
+  `ws://localhost:${globalThis.__TEST_SERVER_PORT__ ?? 8082}`;
+
 test("createDocSyncClient", async () => {
   const { useDoc } = createDocSyncClient({
     server: {
-      url: "ws://localhost:8081",
-      auth: { getToken: () => "1234567890" as string },
+      url: testServerUrl(),
+      auth: { getToken: () => "test-token-John" },
     },
     local: {
       provider: indexedDBProvider,
@@ -38,9 +45,12 @@ test("createDocSyncClient", async () => {
   );
   expectTypeOf(_1.current).toEqualTypeOf<MaybeDocResult>();
   expect(_1.current.status).toBe("pending");
+  expect(_1.current.fetchStatus).toBeDefined();
+  const initialResult = _1.current;
   await expect
     .poll(() => _1.current.status, { interval: 100, timeout: 2000 })
     .toBe("success");
+  expect(_1.current).not.toBe(initialResult);
   expect(_1.current.data?.doc).toBeUndefined();
 
   // with id, with createIfMissing true
@@ -84,17 +94,32 @@ test("createDocSyncClient", async () => {
 
   // Type check: QueryResult<DocData<Doc>> has the expected structure
   expectTypeOf<DocResult>().toEqualTypeOf<
-    | { status: "pending"; data?: never; error?: never }
-    | { status: "success"; data: DocData<Doc>; error?: never }
-    | { status: "error"; data?: never; error: Error }
+    | {
+        status: "pending";
+        fetchStatus: "fetching" | "paused" | "idle";
+        data?: never;
+        error?: never;
+      }
+    | {
+        status: "success";
+        fetchStatus: "fetching" | "paused" | "idle";
+        data: DocData<Doc>;
+        error?: never;
+      }
+    | {
+        status: "error";
+        fetchStatus: "fetching" | "paused" | "idle";
+        data?: DocData<Doc> | undefined;
+        error: Error;
+      }
   >();
-});
+}, 5000);
 
 test("client keeps own presence for debounced outgoing sync", async () => {
   const { useDoc, usePresence, client } = createDocSyncClient({
     server: {
-      url: "ws://localhost:8081",
-      auth: { getToken: () => "1234567890" as string },
+      url: testServerUrl(),
+      auth: { getToken: () => "test-token-John" },
     },
     local: {
       provider: indexedDBProvider,

--- a/tests/docsync-react/index.browser.test.tsx
+++ b/tests/docsync-react/index.browser.test.tsx
@@ -45,7 +45,6 @@ test("createDocSyncClient", async () => {
     // @ts-expect-error - id is required
     hook({ type: "test", createIfMissing: false });
 
-    // @ts-expect-error - id is required
     hook({ type: "test", createIfMissing: true });
   };
   expect(typeCheck).toBeDefined();

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -816,9 +816,24 @@ describe("DocSyncClient", () => {
 
     test("QueryResult has expected structure", () => {
       expectTypeOf<DocResult>().toEqualTypeOf<
-        | { status: "pending"; data?: never; error?: never }
-        | { status: "success"; data: DocData<Doc>; error?: never }
-        | { status: "error"; data?: never; error: Error }
+        | {
+            status: "pending";
+            fetchStatus: "fetching" | "paused" | "idle";
+            data?: never;
+            error?: never;
+          }
+        | {
+            status: "success";
+            fetchStatus: "fetching" | "paused" | "idle";
+            data: DocData<Doc>;
+            error?: never;
+          }
+        | {
+            status: "error";
+            fetchStatus: "fetching" | "paused" | "idle";
+            data?: DocData<Doc> | undefined;
+            error: Error;
+          }
       >();
     });
   });
@@ -837,8 +852,7 @@ describe("DocSyncClient", () => {
 
         expect(callback).toHaveBeenCalledWith({
           status: "pending",
-          data: undefined,
-          error: undefined,
+          fetchStatus: "fetching",
         });
       });
 
@@ -849,7 +863,7 @@ describe("DocSyncClient", () => {
         client.getDoc({ type: "test", id: "non-existent-id" }, callback);
         await expect
           .poll(() => callback.mock.calls.at(-1)?.[0])
-          .toEqual({ status: "success", data: undefined, error: undefined });
+          .toEqual({ status: "success", fetchStatus: "idle", data: undefined });
       });
 
       test("should return cached document when requested multiple times", async () => {
@@ -957,6 +971,84 @@ describe("DocSyncClient", () => {
           callback,
         );
         await expect.poll(() => getSuccessData(callback)?.docId).toBe(customId);
+      });
+
+      test("should emit local success while network fetch is still active", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const customId = ulid().toLowerCase();
+
+        client.getDoc(
+          { type: "test", id: customId, createIfMissing: true },
+          callback,
+        );
+
+        await expect
+          .poll(() =>
+            callback.mock.calls.some(
+              ([result]) =>
+                result.status === "success" &&
+                result.fetchStatus === "fetching",
+            ),
+          )
+          .toBe(true);
+      });
+
+      test("should emit local success as paused when disconnected", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const cachedCallback = createCallback();
+
+        client.getDoc({ type: "test", createIfMissing: true }, callback);
+        const created = getSuccessData(callback);
+        expect(created).toBeDefined();
+
+        Object.defineProperty(client["_socket"], "connected", {
+          configurable: true,
+          value: false,
+        });
+        client.getDoc({ type: "test", id: created!.docId }, cachedCallback);
+
+        await expect
+          .poll(() =>
+            cachedCallback.mock.calls.some(
+              ([result]) =>
+                result.status === "success" && result.fetchStatus === "paused",
+            ),
+          )
+          .toBe(true);
+      });
+
+      test("should emit a new result object when network settles after local success", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const customId = ulid().toLowerCase();
+
+        client.getDoc(
+          { type: "test", id: customId, createIfMissing: true },
+          callback,
+        );
+
+        await expect
+          .poll(
+            () =>
+              callback.mock.calls.find(
+                ([result]) =>
+                  result.status === "success" &&
+                  result.fetchStatus === "fetching",
+              )?.[0],
+          )
+          .toBeDefined();
+        const localResult = callback.mock.calls.find(
+          ([result]) =>
+            result.status === "success" && result.fetchStatus === "fetching",
+        )?.[0];
+
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        expect(callback.mock.calls.at(-1)?.[0]).not.toBe(localResult);
       });
     });
 

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -883,7 +883,7 @@ describe("DocSyncClient", () => {
         expect(cachedDoc?.doc).toBe(createdDoc!.doc);
       });
 
-      test("should resolve cache hit on next microtask (no setTimeout needed)", async () => {
+      test("should emit cached query state immediately", () => {
         const client = createClient();
         const callback1 = createCallback();
         const callback2 = createCallback();
@@ -896,15 +896,8 @@ describe("DocSyncClient", () => {
         // Request the same doc - cache hit
         client.getDoc({ type: "test", id: createdDoc!.docId }, callback2);
 
-        // First call is pending (sync)
-        expect(callback2.mock.calls[0]?.[0]?.status).toBe("pending");
-
-        // Wait just one microtask (not setTimeout like tick())
-        await Promise.resolve();
-
-        // Should already have success from cache
-        expect(callback2.mock.calls.length).toBe(2);
-        expect(callback2.mock.calls[1]?.[0]?.status).toBe("success");
+        expect(callback2.mock.calls.length).toBe(1);
+        expect(callback2.mock.calls[0]?.[0]?.status).toBe("success");
         expect(getSuccessData(callback2)?.doc).toBe(createdDoc!.doc);
       });
     });
@@ -973,6 +966,34 @@ describe("DocSyncClient", () => {
         await expect.poll(() => getSuccessData(callback)?.docId).toBe(customId);
       });
 
+      test("createIfMissing true should promote an existing shared query", async () => {
+        const client = createClient();
+        const callback1 = createCallback();
+        const callback2 = createCallback();
+        const customId = ulid().toLowerCase();
+
+        client.getDoc({ type: "test", id: customId }, callback1);
+        client.getDoc(
+          { type: "test", id: customId, createIfMissing: true },
+          callback2,
+        );
+
+        await expect
+          .poll(() => getSuccessData(callback1)?.docId)
+          .toBe(customId);
+        await expect
+          .poll(() => getSuccessData(callback2)?.docId)
+          .toBe(customId);
+
+        const doc1 = getSuccessData(callback1)?.doc;
+        const doc2 = getSuccessData(callback2)?.doc;
+        expect(doc1).toBe(doc2);
+
+        const cacheEntry = client["_docsCache"].get(customId);
+        expect(cacheEntry?.refCount).toBe(2);
+        expect(cacheEntry?.createIfMissing).toBe(true);
+      });
+
       test("should emit local success while network fetch is still active", async () => {
         const client = createClient();
         const callback = createCallback();
@@ -997,21 +1018,20 @@ describe("DocSyncClient", () => {
       test("should emit local success as paused when disconnected", async () => {
         const client = createClient();
         const callback = createCallback();
-        const cachedCallback = createCallback();
-
-        client.getDoc({ type: "test", createIfMissing: true }, callback);
-        const created = getSuccessData(callback);
-        expect(created).toBeDefined();
+        const customId = ulid().toLowerCase();
 
         Object.defineProperty(client["_socket"], "connected", {
           configurable: true,
           value: false,
         });
-        client.getDoc({ type: "test", id: created!.docId }, cachedCallback);
+        client.getDoc(
+          { type: "test", id: customId, createIfMissing: true },
+          callback,
+        );
 
         await expect
           .poll(() =>
-            cachedCallback.mock.calls.some(
+            callback.mock.calls.some(
               ([result]) =>
                 result.status === "success" && result.fetchStatus === "paused",
             ),

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -187,10 +187,17 @@ describe("DocSyncClient", () => {
   };
 
   const cacheDebounceTestDoc = (client: DebounceTestClient, docId: string) => {
+    const doc = { docId };
     client["_docsCache"].set(docId, {
-      promisedDoc: Promise.resolve({ docId }),
+      promisedDoc: Promise.resolve(doc),
       refCount: 1,
       type: "test",
+      queryResult: {
+        status: "success",
+        fetchStatus: "idle",
+        data: { doc, docId },
+      },
+      queryListeners: new Set(),
       presence: {},
       presenceListeners: new Set(),
     });
@@ -891,7 +898,7 @@ describe("DocSyncClient", () => {
         expect(cachedDoc?.doc).toBe(createdDoc!.doc);
       });
 
-      test("should emit cached query state immediately", () => {
+      test("should emit cached query state immediately", async () => {
         const client = createClient();
         const callback1 = createCallback();
         const callback2 = createCallback();
@@ -979,7 +986,6 @@ describe("DocSyncClient", () => {
 
         const cacheEntry = client["_docsCache"].get(customId);
         expect(cacheEntry?.refCount).toBe(2);
-        expect(cacheEntry?.createIfMissing).toBe(true);
       });
 
       test("should emit local success while network fetch is still active", async () => {

--- a/tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts
+++ b/tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { actionCases, stateCases } from "./utils.js";
+
+const combinations = stateCases.flatMap((stateCase) =>
+  actionCases.map((actionCase) => ({ stateCase, actionCase })),
+);
+
+describe("createQueryResultReducer", () => {
+  test("declares every state and action combination", () => {
+    expect(combinations).toHaveLength(stateCases.length * actionCases.length);
+  });
+
+  test.each(combinations)(
+    "$stateCase.name + $actionCase.name",
+    ({ stateCase, actionCase }) => {
+      const invalidReason = actionCase.invalid?.(stateCase.state);
+
+      if (invalidReason) {
+        expect(() => actionCase.run(stateCase.state)).toThrow(invalidReason);
+        return;
+      }
+
+      expect(actionCase.run(stateCase.state)).toStrictEqual(
+        actionCase.expected(stateCase.state),
+      );
+    },
+  );
+});

--- a/tests/docsync/unit/client/queryResultReducer/utils.ts
+++ b/tests/docsync/unit/client/queryResultReducer/utils.ts
@@ -20,13 +20,8 @@ const fetchStatuses = ["fetching", "paused", "idle"] satisfies FetchStatus[];
 const localError = new Error("local failed");
 const networkError = new Error("network failed");
 
-function reducerFor(state: State, createIfMissing = false) {
-  const reducer = createQueryResultReducer<Data>({
-    initialFetchStatus: state.fetchStatus === "paused" ? "paused" : "fetching",
-    createIfMissing,
-  });
-  Object.assign(reducer.getState(), state);
-  return reducer;
+function reducerFor(state: State) {
+  return createQueryResultReducer<Data>({ initialState: state });
 }
 
 function success(data: Data, fetchStatus: FetchStatus): State {
@@ -134,14 +129,15 @@ export const actionCases: ActionCase[] = [
   },
   {
     name: "networkDocNotFound optional data",
-    run: (state) => reducerFor(state).action.networkDocNotFound(undefined),
+    run: (state) =>
+      reducerFor(state).action.networkDocNotFound({ createIfMissing: false }),
     expected: (state) => networkDocNotFoundExpected(state, false),
     invalid: invalidNetworkAction,
   },
   {
     name: "networkDocNotFound required data",
     run: (state) =>
-      reducerFor(state, true).action.networkDocNotFound(undefined),
+      reducerFor(state).action.networkDocNotFound({ createIfMissing: true }),
     expected: (state) => networkDocNotFoundExpected(state, true),
     invalid: invalidNetworkAction,
   },

--- a/tests/docsync/unit/client/queryResultReducer/utils.ts
+++ b/tests/docsync/unit/client/queryResultReducer/utils.ts
@@ -1,0 +1,155 @@
+import {
+  _INTERNAL_createQueryResultReducer as createQueryResultReducer,
+  type FetchStatus,
+  type QueryResult,
+} from "@docukit/docsync/client";
+
+type Data = string | undefined;
+type State = QueryResult<Data>;
+
+type StateCase = { name: string; state: State };
+
+type ActionCase = {
+  name: string;
+  run: (state: State) => State;
+  expected: (state: State) => State;
+  invalid?: (state: State) => string | undefined;
+};
+
+const fetchStatuses = ["fetching", "paused", "idle"] satisfies FetchStatus[];
+const localError = new Error("local failed");
+const networkError = new Error("network failed");
+
+function reducerFor(state: State, createIfMissing = false) {
+  const reducer = createQueryResultReducer<Data>({
+    initialFetchStatus: state.fetchStatus === "paused" ? "paused" : "fetching",
+    createIfMissing,
+  });
+  Object.assign(reducer.getState(), state);
+  return reducer;
+}
+
+function success(data: Data, fetchStatus: FetchStatus): State {
+  return { status: "success", fetchStatus, data };
+}
+
+function pending(fetchStatus: FetchStatus): State {
+  return { status: "pending", fetchStatus };
+}
+
+function errorWithoutData(fetchStatus: FetchStatus): State {
+  return { status: "error", fetchStatus, error: localError };
+}
+
+function errorWithData(fetchStatus: FetchStatus): State {
+  return { status: "error", fetchStatus, data: "local", error: localError };
+}
+
+function errorState(
+  state: State,
+  fetchStatus: FetchStatus,
+  error: Error,
+): State {
+  return { ...state, status: "error", fetchStatus, error };
+}
+
+function withFetchStatus(state: State, fetchStatus: FetchStatus): State {
+  if (state.fetchStatus === fetchStatus) return state;
+  if (state.status === "pending") return { status: "pending", fetchStatus };
+  if (state.status === "success") return success(state.data, fetchStatus);
+  return errorState(state, fetchStatus, state.error);
+}
+
+function invalidNetworkAction(state: State): string | undefined {
+  if (state.fetchStatus !== "idle") return undefined;
+  return "when fetchStatus is idle";
+}
+
+function networkDocNotFoundExpected(
+  state: State,
+  createIfMissing: boolean,
+): State {
+  if ("data" in state) return success(state.data, "idle");
+  if (createIfMissing) return { status: "pending", fetchStatus: "idle" };
+  return success(undefined, "idle");
+}
+
+export const stateCases: StateCase[] = [
+  ...fetchStatuses.map((fetchStatus) => ({
+    name: `pending ${fetchStatus}`,
+    state: pending(fetchStatus),
+  })),
+  ...fetchStatuses.map((fetchStatus) => ({
+    name: `success with data ${fetchStatus}`,
+    state: success("local", fetchStatus),
+  })),
+  ...fetchStatuses.map((fetchStatus) => ({
+    name: `success with undefined ${fetchStatus}`,
+    state: success(undefined, fetchStatus),
+  })),
+  ...fetchStatuses.map((fetchStatus) => ({
+    name: `error without data ${fetchStatus}`,
+    state: errorWithoutData(fetchStatus),
+  })),
+  ...fetchStatuses.map((fetchStatus) => ({
+    name: `error with data ${fetchStatus}`,
+    state: errorWithData(fetchStatus),
+  })),
+];
+
+export const actionCases: ActionCase[] = [
+  {
+    name: "localDocFound",
+    run: (state) => reducerFor(state).action.localDocFound({ data: "found" }),
+    expected: (state) => success("found", state.fetchStatus),
+  },
+  {
+    name: "localQueryError",
+    run: (state) =>
+      reducerFor(state).action.localQueryError({ error: localError }),
+    expected: (state) => errorState(state, state.fetchStatus, localError),
+  },
+  {
+    name: "connected",
+    run: (state) => reducerFor(state).action.connected(undefined),
+    expected: (state) =>
+      state.fetchStatus === "paused"
+        ? withFetchStatus(state, "fetching")
+        : state,
+  },
+  {
+    name: "disconnected",
+    run: (state) => reducerFor(state).action.disconnected(undefined),
+    expected: (state) =>
+      state.fetchStatus === "fetching"
+        ? withFetchStatus(state, "paused")
+        : state,
+  },
+  {
+    name: "networkDocFound",
+    run: (state) =>
+      reducerFor(state).action.networkDocFound({ data: "network" }),
+    expected: () => success("network", "idle"),
+    invalid: invalidNetworkAction,
+  },
+  {
+    name: "networkDocNotFound optional data",
+    run: (state) => reducerFor(state).action.networkDocNotFound(undefined),
+    expected: (state) => networkDocNotFoundExpected(state, false),
+    invalid: invalidNetworkAction,
+  },
+  {
+    name: "networkDocNotFound required data",
+    run: (state) =>
+      reducerFor(state, true).action.networkDocNotFound(undefined),
+    expected: (state) => networkDocNotFoundExpected(state, true),
+    invalid: invalidNetworkAction,
+  },
+  {
+    name: "networkQueryError",
+    run: (state) =>
+      reducerFor(state).action.networkQueryError({ error: networkError }),
+    expected: (state) => errorState(state, "idle", networkError),
+    invalid: invalidNetworkAction,
+  },
+];

--- a/tests/docsync/unit/client/reducer.test.ts
+++ b/tests/docsync/unit/client/reducer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+import { createReducer } from "../../../../packages/docsync/src/client/utils/reducer.js";
+
+type State = { count: number };
+
+describe("createReducer", () => {
+  test("runs typed actions and stores the latest state", () => {
+    const beforeActions: Array<{
+      state: State;
+      action: { type: "add"; payload: { amount: number } };
+    }> = [];
+
+    const reducer = createReducer({
+      initialState: { count: 0 },
+      actions: {
+        add: (state, payload: { amount: number }) => ({
+          count: state.count + payload.amount,
+        }),
+      },
+      beforeAction: (state, action) => {
+        beforeActions.push({ state, action });
+      },
+    });
+
+    expect(reducer.action.add({ amount: 2 })).toStrictEqual({ count: 2 });
+    expect(reducer.getState()).toStrictEqual({ count: 2 });
+    expect(beforeActions).toStrictEqual([
+      { state: { count: 0 }, action: { type: "add", payload: { amount: 2 } } },
+    ]);
+  });
+});

--- a/tests/docsync/unit/client/reducer.test.ts
+++ b/tests/docsync/unit/client/reducer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { createReducer } from "../../../../packages/docsync/src/client/utils/reducer.js";
+import { _INTERNAL_createReducer as createReducer } from "@docukit/docsync/client";
 
 type State = { count: number };
 

--- a/tests/docsync/unit/client2/index.browser.test.ts
+++ b/tests/docsync/unit/client2/index.browser.test.ts
@@ -228,8 +228,10 @@ describe("Client 2", () => {
         "sync",
         expect.objectContaining({ docId, operations: [ops({ test: "data" })] }),
       );
+      await expect
+        .poll(() => client["_pushStatusByDocId"].get(docId))
+        .toBe("idle");
       expect(await getOperationsCount(client, docId)).toBe(0);
-      expect(client["_pushStatusByDocId"].get(docId)).toBe("idle");
     });
 
     test("should handle client sends operations + server returns operations", async () => {
@@ -255,8 +257,10 @@ describe("Client 2", () => {
         "sync",
         expect.objectContaining({ docId, operations: [ops({ client: "op" })] }),
       );
+      await expect
+        .poll(() => client["_pushStatusByDocId"].get(docId))
+        .toBe("idle");
       expect(await getOperationsCount(client, docId)).toBe(0);
-      expect(client["_pushStatusByDocId"].get(docId)).toBe("idle");
     });
 
     test("should handle client sends no operations + server returns no operations (pull with no updates)", async () => {
@@ -283,7 +287,9 @@ describe("Client 2", () => {
         "sync",
         expect.objectContaining({ docId, operations: [] }),
       );
-      expect(client["_pushStatusByDocId"].get(docId)).toBe("idle");
+      await expect
+        .poll(() => client["_pushStatusByDocId"].get(docId))
+        .toBe("idle");
     });
 
     test("should handle client sends no operations + server returns operations (pull with updates)", async () => {
@@ -332,6 +338,9 @@ describe("Client 2", () => {
         "sync",
         expect.objectContaining({ docId, operations: [] }),
       );
+      await expect
+        .poll(() => client["_pushStatusByDocId"].get(docId))
+        .toBe("idle");
 
       // Verify server operations were applied to stored document
       const storedDoc = await provider.transaction("readonly", async (ctx) => {
@@ -345,7 +354,6 @@ describe("Client 2", () => {
       storedDoc.root.children().forEach(() => storedChildren++);
       // Should have the 2 server children
       expect(storedChildren).toBe(2);
-      expect(client["_pushStatusByDocId"].get(docId)).toBe("idle");
     });
   });
 

--- a/tests/docsync/unit/client2/utils.ts
+++ b/tests/docsync/unit/client2/utils.ts
@@ -186,6 +186,12 @@ export const triggerSync = (
       promisedDoc: Promise.resolve(doc),
       refCount: 1,
       type: "test",
+      queryResult: {
+        status: "success",
+        fetchStatus: "idle",
+        data: { doc, docId },
+      },
+      queryListeners: new Set(),
       presence: {},
       presenceListeners: new Set(),
     });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,9 +23,13 @@ const project = (name: string, browser: boolean): TestProjectConfiguration => ({
     testTimeout: 2000, // (includes Playwright launch time?)
     hookTimeout: 2000,
     ...(browser
-      ? { include: ["**/*.browser.test.ts", "**/*.browser.test.tsx"] }
+      ? {
+          include: ["**/*.browser.test.ts", "**/*.browser.test.tsx"],
+          exclude: ["**/.context/**", "**/node_modules/**", "**/dist/**"],
+        }
       : {
           exclude: [
+            "**/.context/**",
             "**/*.browser.test.ts",
             "**/*.browser.test.tsx",
             "**/*.ui.test.ts",
@@ -61,6 +65,7 @@ export default defineConfig({
       reportsDirectory: ".test-results/vitest",
       reporter: ["text", "html"],
       exclude: [
+        "**/.context/**",
         "**/node_modules/**",
         "**/tests/**",
         "**/*.d.ts",


### PR DESCRIPTION
## Summary
- Adds `fetchStatus` to DocSync `QueryResult` so query outcome and network activity are modeled separately.
- Adds small internal reducers for query state transitions and tests all reducer state/action combinations.
- Shares cached doc query state across subscribers, including `createIfMissing` promotion and final `idle` emission after sync settles.
- Updates React hook/type tests and ignores `.context` in tooling.

## Verification
- `pnpm --filter @docukit/docsync build`
- `pnpm --filter @docukit/docsync-react build`
- `pnpm fix`
- `pnpm test:once tests/docsync/unit/client/index.browser.test.ts tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts tests/docsync/unit/client/reducer.test.ts tests/docsync-react/index.browser.test.tsx`
- `pnpm test:coverage:once`

`docnode/src` remains at 100% statements/functions/lines coverage.