### PR TITLE
Add workflow timeouts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   lint-format-types:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
   validate:
     if: "github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'chore: release v')"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -35,6 +36,7 @@ jobs:
   publish:
     if: "github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore: release v')"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     concurrency:


### PR DESCRIPTION
Adds timeout limits to the remaining workflows that did not have them. Check now has a 5 minute timeout, and release validate and publish now each have 10 minute timeouts. Verified with YAML parsing, SKIP_ENV_VALIDATION=true pnpm build, pnpm test:coverage:once, and pnpm fix.