### PR TITLE
chore(docsync): tighten object type bounds

### DIFF
--- a/packages/docsync/src/bindings/index.ts
+++ b/packages/docsync/src/bindings/index.ts
@@ -1,8 +1,10 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
-
 import type { DocBinding } from "../shared/types.js";
 
-export const createDocBinding = <D extends {}, S extends {}, O extends {} = {}>(
+export const createDocBinding = <
+  D extends object,
+  S extends object,
+  O extends object = object,
+>(
   docBinding: DocBinding<D, S, O>,
 ): DocBinding<D, S, O> => {
   return docBinding;

--- a/packages/docsync/src/client/handlers/clientInitiated/presence.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/presence.ts
@@ -1,10 +1,13 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { PresenceRequest } from "../../../shared/types.js";
 import type { DocSyncClient } from "../../index.js";
 import { request } from "../../utils/request.js";
 
 /** Set presence for a document: debounce outgoing updates, then emit to active channels. */
-export function handlePresence<D extends {}, S extends {}, O extends {}>(
+export function handlePresence<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
   client: DocSyncClient<D, S, O>,
   args: { docId: string; presence: unknown },
 ): void {
@@ -45,7 +48,11 @@ export function handlePresence<D extends {}, S extends {}, O extends {}>(
   client["_presenceDebounceState"].set(docId, state);
 }
 
-export function flushPresenceDebounce<D extends {}, S extends {}, O extends {}>(
+export function flushPresenceDebounce<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
   client: DocSyncClient<D, S, O>,
   docId: string,
   args?: { timeoutBeforeChange: ReturnType<typeof setTimeout> | undefined },
@@ -60,9 +67,9 @@ export function flushPresenceDebounce<D extends {}, S extends {}, O extends {}>(
 }
 
 export function emitCurrentServerPresence<
-  D extends {},
-  S extends {},
-  O extends {},
+  D extends object,
+  S extends object,
+  O extends object,
 >(client: DocSyncClient<D, S, O>, docId: string): void {
   if (!client["_collabDocIds"].has(docId)) return;
 
@@ -73,7 +80,7 @@ export function emitCurrentServerPresence<
   emitServerPresence(client, { docId, presence: state.data });
 }
 
-function emitPresence<D extends {}, S extends {}, O extends {}>(
+function emitPresence<D extends object, S extends object, O extends object>(
   client: DocSyncClient<D, S, O>,
   args: { docId: string; presence: unknown },
 ): void {
@@ -85,7 +92,11 @@ function emitPresence<D extends {}, S extends {}, O extends {}>(
   emitServerPresence(client, { docId, presence });
 }
 
-function emitServerPresence<D extends {}, S extends {}, O extends {}>(
+function emitServerPresence<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
   client: DocSyncClient<D, S, O>,
   args: { docId: string; presence: unknown },
 ): void {

--- a/packages/docsync/src/client/handlers/clientInitiated/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync.ts
@@ -1,11 +1,14 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { SyncRequest, SyncResponse } from "../../../shared/types.js";
 import type { DocSyncClient } from "../../index.js";
 import { getOwnPresencePatch } from "../../utils/getOwnPresencePatch.js";
 import { request } from "../../utils/request.js";
 
 /** Applies server operations to the cached doc. */
-async function applyServerOperations<D extends {}, S extends {}, O extends {}>(
+async function applyServerOperations<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
   client: DocSyncClient<D, S, O>,
   args: { docId: string; operations: O[] },
 ): Promise<void> {
@@ -24,7 +27,11 @@ async function applyServerOperations<D extends {}, S extends {}, O extends {}>(
  * TODO: Replaces the cached document (e.g. when server responds with a squashed doc).
  * Keeps refCount, presence, and presenceListeners unchanged.
  */
-function _replaceDocInCache<D extends {}, S extends {}, O extends {}>(
+function _replaceDocInCache<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
   client: DocSyncClient<D, S, O>,
   args: { docId: string; doc?: D; serializedDoc?: S },
 ): void {
@@ -53,7 +60,11 @@ function _replaceDocInCache<D extends {}, S extends {}, O extends {}>(
  * Sync (push) a document to the server. Queues if already pushing (sets
  * pushing-with-pending), otherwise sets pushing and runs the sync.
  */
-export const handleSync = async <D extends {}, S extends {}, O extends {}>(
+export const handleSync = async <
+  D extends object,
+  S extends object,
+  O extends object,
+>(
   client: DocSyncClient<D, S, O>,
   docId: string,
 ): Promise<void> => {

--- a/packages/docsync/src/client/handlers/connection/connect.ts
+++ b/packages/docsync/src/client/handlers/connection/connect.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { DocSyncClient } from "../../index.js";
 import { handleSync } from "../clientInitiated/sync.js";
 
 export function handleConnect<
-  D extends {} = {},
-  S extends {} = {},
-  O extends {} = {},
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
 >({ client }: { client: DocSyncClient<D, S, O> }): void {
   client["_socket"].on("connect", () => {
     client["_events"].emit("connect");

--- a/packages/docsync/src/client/handlers/connection/disconnect.ts
+++ b/packages/docsync/src/client/handlers/connection/disconnect.ts
@@ -1,10 +1,9 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { DocSyncClient } from "../../index.js";
 
 export function handleDisconnect<
-  D extends {} = {},
-  S extends {} = {},
-  O extends {} = {},
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
 >({ client }: { client: DocSyncClient<D, S, O> }): void {
   client["_socket"].on("disconnect", (reason) => {
     client["_pushStatusByDocId"].clear();

--- a/packages/docsync/src/client/handlers/serverInitiated/collaboration.ts
+++ b/packages/docsync/src/client/handlers/serverInitiated/collaboration.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { DocSyncClient } from "../../index.js";
 import { emitCurrentServerPresence } from "../clientInitiated/presence.js";
 
 export function handleCollaboration<
-  D extends {} = {},
-  S extends {} = {},
-  O extends {} = {},
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
 >({ client }: { client: DocSyncClient<D, S, O> }): void {
   client["_socket"].on("collaboration", ({ docId, hasCollaborators }) => {
     if (hasCollaborators) {

--- a/packages/docsync/src/client/handlers/serverInitiated/dirty.ts
+++ b/packages/docsync/src/client/handlers/serverInitiated/dirty.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { DocSyncClient } from "../../index.js";
 import { handleSync } from "../clientInitiated/sync.js";
 
 export function handleDirty<
-  D extends {} = {},
-  S extends {} = {},
-  O extends {} = {},
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
 >({ client }: { client: DocSyncClient<D, S, O> }): void {
   client["_socket"].on("dirty", (payload) => {
     void handleSync(client, payload.docId);

--- a/packages/docsync/src/client/handlers/serverInitiated/presence.ts
+++ b/packages/docsync/src/client/handlers/serverInitiated/presence.ts
@@ -1,12 +1,11 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { DocSyncClient } from "../../index.js";
 import { applyPresencePatch } from "../../utils/applyPresencePatch.js";
 
 /** Registers the socket listener for incoming presence updates from the server. */
 export function handlePresence<
-  D extends {} = {},
-  S extends {} = {},
-  O extends {} = {},
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
 >({ client }: { client: DocSyncClient<D, S, O> }): void {
   client["_socket"].on("presence", (payload) => {
     const cacheEntry = client["_docsCache"].get(payload.docId);

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import { io } from "socket.io-client";
 import type {
   DocBinding,
@@ -34,19 +33,19 @@ import { getDeviceId } from "./utils/getDeviceId.js";
 import { getOwnPresencePatch } from "./utils/getOwnPresencePatch.js";
 
 // TODO: review this type!
-type LocalResolved<S extends {}, O extends {}> = {
+type LocalResolved<S extends object, O extends object> = {
   provider: ClientProvider<S, O>;
   identity: Identity;
 };
 
-type LocalOpsBatchState<O extends {}> = DeferredState<O[]> & {
+type LocalOpsBatchState<O extends object> = DeferredState<O[]> & {
   startedAt: number;
 };
 
 type PushStatus = "idle" | "pushing" | "pushing-with-pending";
 type ChangeOrigin = "local" | "network" | "local-broadcast";
 type LocalLoadMode = "load" | "loadOrCreate";
-type QueryListener = (result: QueryResult<DocData<{}> | undefined>) => void;
+type QueryListener = (result: QueryResult<DocData<object> | undefined>) => void;
 type DocCacheEntry<D> = {
   promisedDoc: Promise<D | undefined>;
   refCount: number;
@@ -59,9 +58,9 @@ type DocCacheEntry<D> = {
 };
 
 export class DocSyncClient<
-  D extends {} = {},
-  S extends {} = {},
-  O extends {} = {},
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
 > {
   protected _docBinding: DocBinding<D, S, O>;
   protected _docsCache = new Map<string, DocCacheEntry<D>>();

--- a/packages/docsync/src/client/types.ts
+++ b/packages/docsync/src/client/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type {
   ClientToServerEvents,
   DocBinding,
@@ -46,9 +45,9 @@ export type DeferredState<T> = {
 export type Identity = { userId: string; secret: string };
 
 export type ClientConfig<
-  D extends {} = {},
-  S extends {} = {},
-  O extends {} = {},
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
 > = {
   docBinding: DocBinding<D, S, O>;
   server: { url: string; auth: { getToken: () => MaybePromise<string> } };
@@ -88,7 +87,7 @@ export type ClientConfig<
  * Context passed to client transaction callbacks.
  * All operations share the same underlying transaction.
  */
-export type ClientProviderContext<S extends {}, O extends {}> = {
+export type ClientProviderContext<S extends object, O extends object> = {
   getSerializedDoc(arg: {
     docId: string;
   }): Promise<{ serializedDoc: S; clock: number } | undefined>;
@@ -102,7 +101,7 @@ export type ClientProviderContext<S extends {}, O extends {}> = {
  * Storage provider for the client.
  * All operations must be performed within a transaction.
  */
-export type ClientProvider<S extends {}, O extends {}> = {
+export type ClientProvider<S extends object, O extends object> = {
   transaction<T>(
     mode: "readonly" | "readwrite",
     callback: (ctx: ClientProviderContext<S, O>) => Promise<T>,

--- a/packages/docsync/src/client/utils/BCHelper.ts
+++ b/packages/docsync/src/client/utils/BCHelper.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
-
 import type { DocSyncClient } from "../index.js";
 import { applyPresencePatch } from "./applyPresencePatch.js";
 
@@ -16,7 +14,11 @@ type BroadcastMessage<O> =
     }
   | { type: "PRESENCE"; docId: string; presence: Record<string, unknown> };
 
-export class BCHelper<D extends {}, S extends {}, O extends {} = {}> {
+export class BCHelper<
+  D extends object,
+  S extends object,
+  O extends object = object,
+> {
   private _channel: BroadcastChannel;
   private _closed = false;
 

--- a/packages/docsync/src/client/utils/getOwnPresencePatch.ts
+++ b/packages/docsync/src/client/utils/getOwnPresencePatch.ts
@@ -1,7 +1,10 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { DocSyncClient } from "../index.js";
 
-export function getOwnPresencePatch<D extends {}, S extends {}, O extends {}>(
+export function getOwnPresencePatch<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
   client: DocSyncClient<D, S, O>,
   docId: string,
 ): Record<string, unknown> | undefined {

--- a/packages/docsync/src/server/handlers/deleteDoc.ts
+++ b/packages/docsync/src/server/handlers/deleteDoc.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type {
   DeleteDocRequest,
   DeleteDocResponse,
@@ -11,14 +10,19 @@ export type DeleteDocHandler = (
   cb: (res: DeleteDocResponse) => void,
 ) => void | Promise<void>;
 
-export const handleDeleteDoc = <TContext = {}>({
+export const handleDeleteDoc = <
+  TContext = unknown,
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
+>({
   server,
   socket,
   userId,
   context,
 }: {
-  server: DocSyncServer<TContext>;
-  socket: ServerConnectionSocket<{}, {}>;
+  server: DocSyncServer<TContext, D, S, O>;
+  socket: ServerConnectionSocket<TContext, S, O>;
   userId: string;
   context: TContext;
 }): void => {

--- a/packages/docsync/src/server/handlers/disconnect.ts
+++ b/packages/docsync/src/server/handlers/disconnect.ts
@@ -1,18 +1,22 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { ServerConnectionSocket } from "../types.js";
 import type { DocSyncServer } from "../index.js";
 import { applyPresenceUpdate } from "../utils/applyPresenceUpdate.js";
 import { broadcastCollaborationState } from "../utils/broadcastCollaborationState.js";
 
-export function handleDisconnect({
+export function handleDisconnect<
+  TContext = unknown,
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
+>({
   server,
   socket,
   userId,
   deviceId,
   clientId,
 }: {
-  server: DocSyncServer;
-  socket: ServerConnectionSocket<{}, {}>;
+  server: DocSyncServer<TContext, D, S, O>;
+  socket: ServerConnectionSocket<TContext, S, O>;
   userId: string;
   deviceId: string;
   clientId: string;

--- a/packages/docsync/src/server/handlers/presence.ts
+++ b/packages/docsync/src/server/handlers/presence.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { PresenceRequest, PresenceResponse } from "../../shared/types.js";
 import type { ServerConnectionSocket } from "../types.js";
 import type { DocSyncServer } from "../index.js";
@@ -9,15 +8,20 @@ export type PresenceHandler = (
   cb: (res: PresenceResponse) => void,
 ) => void | Promise<void>;
 
-export function handlePresence<TContext = unknown>({
+export function handlePresence<
+  TContext = unknown,
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
+>({
   server,
   socket,
   userId,
   clientId,
   context,
 }: {
-  server: DocSyncServer<TContext>;
-  socket: ServerConnectionSocket<{}, {}>;
+  server: DocSyncServer<TContext, D, S, O>;
+  socket: ServerConnectionSocket<TContext, S, O>;
   userId: string;
   clientId: string;
   context: TContext;

--- a/packages/docsync/src/server/handlers/sync.ts
+++ b/packages/docsync/src/server/handlers/sync.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { SyncRequest, SyncResponse } from "../../shared/types.js";
 import type { ServerConnectionSocket } from "../types.js";
 import type { DocSyncServer } from "../index.js";
@@ -12,10 +11,10 @@ export type SyncHandler<S = unknown, O = unknown> = (
 ) => void | Promise<void>;
 
 export function handleSync<
-  TContext = {},
-  D extends {} = {},
-  S extends {} = {},
-  O extends {} = {},
+  TContext = unknown,
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
 >({
   server,
   socket,
@@ -24,7 +23,7 @@ export function handleSync<
   context,
 }: {
   server: DocSyncServer<TContext, D, S, O>;
-  socket: ServerConnectionSocket<S, O>;
+  socket: ServerConnectionSocket<TContext, S, O>;
   userId: string;
   deviceId: string;
   context: TContext;

--- a/packages/docsync/src/server/handlers/unsubscribe.ts
+++ b/packages/docsync/src/server/handlers/unsubscribe.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type {
   UnsubscribeDocRequest,
   UnsubscribeDocResponse,
@@ -13,13 +12,18 @@ export type UnsubscribeDocHandler = (
   cb: (res: UnsubscribeDocResponse) => void,
 ) => void | Promise<void>;
 
-export function handleUnsubscribeDoc({
+export function handleUnsubscribeDoc<
+  TContext = unknown,
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
+>({
   server,
   socket,
   clientId,
 }: {
-  server: DocSyncServer;
-  socket: ServerConnectionSocket<{}, {}>;
+  server: DocSyncServer<TContext, D, S, O>;
+  socket: ServerConnectionSocket<TContext, S, O>;
   clientId: string;
 }): void {
   const socketToDocsMap = server["_socketToDocsMap"];

--- a/packages/docsync/src/server/index.ts
+++ b/packages/docsync/src/server/index.ts
@@ -1,7 +1,12 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import { Server } from "socket.io";
-import type { DocBinding, Presence } from "../shared/types.js";
 import type {
+  ClientToServerEvents,
+  DocBinding,
+  Presence,
+  ServerToClientEvents,
+} from "../shared/types.js";
+import type {
+  AuthenticatedSocketData,
   ClientConnectEventListener,
   ClientDisconnectEventListener,
   ServerConfig,
@@ -16,21 +21,13 @@ import { handleSync } from "./handlers/sync.js";
 import { handleUnsubscribeDoc } from "./handlers/unsubscribe.js";
 import { startupLog } from "./utils/startupLog.js";
 
-type AuthenticatedContext<TContext = {}> = {
-  userId: string;
-  deviceId: string;
-  /** Client-generated id for presence (set from auth or socket.id in connection flow) */
-  clientId: string;
-  context: TContext;
-};
-
 export class DocSyncServer<
-  TContext = {},
-  D extends {} = {},
-  S extends {} = {},
-  O extends {} = {},
+  TContext = unknown,
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
 > {
-  private _io: ServerSocket<S, O>;
+  private _io: ServerSocket<TContext, S, O>;
   private _docBinding: DocBinding<D, S, O>;
   private _provider: ServerProvider<S, O>;
   private _authenticate: ServerConfig<TContext, D, S, O>["authenticate"];
@@ -52,7 +49,12 @@ export class DocSyncServer<
   constructor(config: ServerConfig<TContext, D, S, O>) {
     const port = config.port ?? 8080;
 
-    this._io = new Server(port, {
+    this._io = new Server<
+      ClientToServerEvents<S, O>,
+      ServerToClientEvents,
+      Record<string, never>,
+      AuthenticatedSocketData<TContext>
+    >(port, {
       cors: { origin: "*" },
       // Performance: Only WebSocket transport, no polling
       transports: ["websocket"],
@@ -99,7 +101,7 @@ export class DocSyncServer<
             deviceId,
             clientId,
             context: authResult.context ?? ({} as TContext),
-          } satisfies AuthenticatedContext<TContext>;
+          } satisfies AuthenticatedSocketData<TContext>;
 
           next();
         })
@@ -124,8 +126,7 @@ export class DocSyncServer<
     );
 
     this._io.on("connection", (socket) => {
-      const { userId, deviceId, clientId, context } =
-        socket.data as AuthenticatedContext;
+      const { userId, deviceId, clientId, context } = socket.data;
 
       // Emit client connect event
       this._emit(this._clientConnectEventListeners, {
@@ -135,7 +136,7 @@ export class DocSyncServer<
         context,
       });
 
-      const server = this as DocSyncServer;
+      const server = this;
       handleDisconnect({ server, socket, userId, deviceId, clientId });
       // prettier-ignore
       handleSync({ server, socket, userId, deviceId, context });

--- a/packages/docsync/src/server/types.ts
+++ b/packages/docsync/src/server/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type {
   ClientToServerEvents,
   DocBinding,
@@ -7,6 +6,7 @@ import type {
   ServerToClientEvents,
   SerializedDocPayload,
 } from "../shared/types.js";
+import type { Server, Socket } from "socket.io";
 
 // ============================================================================
 // Server Events
@@ -75,7 +75,12 @@ export type SyncRequestEventListener<O = unknown, S = unknown> = (
  * @typeParam TContext - Application-defined context shape returned by authenticate
  *                       and passed to authorize. Defaults to empty object.
  */
-export type ServerConfig<TContext, D extends {}, S extends {}, O extends {}> = {
+export type ServerConfig<
+  TContext,
+  D extends object,
+  S extends object,
+  O extends object,
+> = {
   docBinding: DocBinding<D, S, O>;
   port?: number;
   provider: ServerProvider<NoInfer<S>, NoInfer<O>>;
@@ -101,7 +106,7 @@ export type ServerConfig<TContext, D extends {}, S extends {}, O extends {}> = {
  * All operations share the same underlying transaction.
  */
 // prettier-ignore
-export type ServerProviderContext<S extends {}, O extends {}> = {
+export type ServerProviderContext<S extends object, O extends object> = {
   getSerializedDoc(arg: { docId: string }): Promise<{ serializedDoc: S; clock: number } | undefined>;
   getOperations(arg: { docId: string; clock: number }): Promise<O[][]>;
   deleteOperations(arg: { docId: string; count: number }): Promise<void>;
@@ -113,7 +118,7 @@ export type ServerProviderContext<S extends {}, O extends {}> = {
  * Storage provider for the server.
  * All operations must be performed within a transaction.
  */
-export type ServerProvider<S extends {}, O extends {}> = {
+export type ServerProvider<S extends object, O extends object> = {
   transaction<T>(
     mode: "readonly" | "readwrite",
     callback: (ctx: ServerProviderContext<S, O>) => Promise<T>,
@@ -124,15 +129,33 @@ export type ServerProvider<S extends {}, O extends {}> = {
 // Socket (server)
 // ============================================================================
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- type-only reference to socket.io
-export type ServerSocket<S, O> = import("socket.io").Server<
+export type AuthenticatedSocketData<TContext = unknown> = {
+  userId: string;
+  deviceId: string;
+  /** Client-generated id for presence (set from auth or socket.id in connection flow) */
+  clientId: string;
+  context: TContext;
+};
+
+export type ServerSocket<
+  TContext = unknown,
+  S extends object = object,
+  O extends object = object,
+> = Server<
   ClientToServerEvents<S, O>,
-  ServerToClientEvents
+  ServerToClientEvents,
+  Record<string, never>,
+  AuthenticatedSocketData<TContext>
 >;
 
 /** Per-connection socket on the server (has .id, .join, .emit, .on, etc.). */
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- type-only reference to socket.io
-export type ServerConnectionSocket<S, O> = import("socket.io").Socket<
+export type ServerConnectionSocket<
+  TContext = unknown,
+  S extends object = object,
+  O extends object = object,
+> = Socket<
   ClientToServerEvents<S, O>,
-  ServerToClientEvents
+  ServerToClientEvents,
+  Record<string, never>,
+  AuthenticatedSocketData<TContext>
 >;

--- a/packages/docsync/src/server/utils/applyPresenceUpdate.ts
+++ b/packages/docsync/src/server/utils/applyPresenceUpdate.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { Presence } from "../../shared/types.js";
 import type { ServerConnectionSocket } from "../types.js";
 
@@ -6,9 +5,13 @@ import type { ServerConnectionSocket } from "../types.js";
  * Updates server presence state for a document and broadcasts the change
  * to other clients in the doc room. Handlers import and call this directly.
  */
-export function applyPresenceUpdate(
+export function applyPresenceUpdate<
+  TContext,
+  S extends object,
+  O extends object,
+>(
   presenceByDoc: Map<string, Presence>,
-  socket: ServerConnectionSocket<{}, {}>,
+  socket: ServerConnectionSocket<TContext, S, O>,
   clientId: string,
   args: { docId: string; presence: unknown },
 ): void {

--- a/packages/docsync/src/server/utils/broadcastCollaborationState.ts
+++ b/packages/docsync/src/server/utils/broadcastCollaborationState.ts
@@ -1,11 +1,10 @@
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { DocSyncServer } from "../index.js";
 
 export function broadcastCollaborationState<
   TContext,
-  D extends {},
-  S extends {},
-  O extends {},
+  D extends object,
+  S extends object,
+  O extends object,
 >(server: DocSyncServer<TContext, D, S, O>, docId: string): void {
   const io = server["_io"];
   const room = io.sockets.adapter.rooms.get(`doc:${docId}`);
@@ -16,7 +15,7 @@ export function broadcastCollaborationState<
   for (const socketId of room) {
     const targetSocket = io.sockets.sockets.get(socketId);
     if (!targetSocket) continue;
-    const { userId } = targetSocket.data as { userId: string };
+    const { userId } = targetSocket.data;
     socketIds.push(socketId);
     userIds.add(userId);
   }

--- a/packages/docsync/src/shared/types.ts
+++ b/packages/docsync/src/shared/types.ts
@@ -5,7 +5,6 @@ import type { PresenceHandler } from "../server/handlers/presence.js";
 import type { SyncHandler } from "../server/handlers/sync.js";
 import type { UnsubscribeDocHandler } from "../server/handlers/unsubscribe.js";
 
-/* eslint-disable @typescript-eslint/no-empty-object-type */
 /**
  * DocSync Type Definitions
  *
@@ -14,9 +13,9 @@ import type { UnsubscribeDocHandler } from "../server/handlers/unsubscribe.js";
 
 // TO-DECIDE: should params in fn's be objects?
 export interface DocBinding<
-  D extends {} = {},
-  S extends {} = {},
-  O extends {} = {},
+  D extends object = object,
+  S extends object = object,
+  O extends object = object,
 > {
   // method syntax is required to avoid type errors
   create(type: string, id?: string): { doc: D; docId: string };


### PR DESCRIPTION
## Summary
- replace empty-object generic bounds with object in packages/docsync
- type server socket data with authenticated context
- remove no-empty-object-type disables from DocSync types and handlers

## Verification
- pnpm fix
- pnpm test:once tests/docsync/unit/client/index.browser.test.ts tests/docsync/unit/client/events.browser.test.ts tests/docsync/int/auth.browser.test.ts tests/docsync/int/index.browser.test.ts tests/docsync/unit/server/index.test.ts tests/docsync/unit/server/events.test.ts
- pnpm test:coverage:once

Note: docs build required local dummy env vars to generate Next/Fumadocs types before full checks.