### PR TITLE
chore: release v0.4.0

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -80,10 +80,6 @@ Attribute each bullet to a PR number (squash-merge titles often end with `(#123)
 ```
 # <tag> — YYYY-MM-DD
 
-## Highlights
-
-- **[Major release headline.]** [Why users should care.] (#123) Optional docs: [Doc title](https://docukit.dev/...)
-
 ## Breaking changes
 
 - [Short description.] **Migration:** [what the consumer changes]. (#123)
@@ -109,24 +105,19 @@ Rules:
 
 - If no breaking changes were found, write `_No breaking changes in this release._` under that section. **Do not omit the section** — explicit emptiness lets a reviewer catch a false negative.
 - Keep bullets user-facing. "Renamed `foo` → `bar`" — not "refactored internal foo helpers".
-- Open with a market-facing **Highlights** section. Put the most important story first, not the biggest diff. Make the top bullets attractive and clear for readers who will only skim.
-- Order bullets by user impact, not by commit order.
-- Link to documentation when it helps users adopt or understand the change.
-- Group related breaking changes by product area and shared migration so the section stays readable, but do not omit any real breaking change.
+- Group bullets that share a migration.
 - Omit empty Features/Fixes/Docs/Internal sections silently — only Breaking is mandatory.
 
 Use today's date from the environment.
 
 ### Discord sibling — `changelog/<tag>_DISCORD.md`
 
-Same story, transformed for Discord:
+Same content, transformed:
 
 - **No `#` headings.** Use `**BREAKING CHANGES**`, `**FEATURES**`, etc. in bold+caps.
-- Emojis per section: ✨ Highlights/Features, 🚨 Breaking, 🐛 Fixes, 📚 Docs, 🛠 Internal.
-- Do **not** include PR links in the Discord file. The committed changelog has the PR attribution.
-- Include documentation links as plain text only when they are useful to readers. **No `[text](url)` markdown link syntax.**
+- Emojis per section: 🚨 Breaking, ✨ Features, 🐛 Fixes, 📚 Docs, 🛠 Internal.
+- URLs as plain text — paste `https://github.com/docukit/docukit/pull/123` literally. **No `[text](url)` markdown link syntax.**
 - Open with a one-line summary: `🚀 DocuKit <tag> released!` then a blank line.
-- End with this line: `Full release notes with PRs: https://github.com/docukit/docukit/releases/`
 - Keep it skimmable.
 
 This file is gitignored (`changelog/*_DISCORD.md`) — never let it be committed.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -80,6 +80,10 @@ Attribute each bullet to a PR number (squash-merge titles often end with `(#123)
 ```
 # <tag> — YYYY-MM-DD
 
+## Highlights
+
+- **[Major release headline.]** [Why users should care.] (#123) Optional docs: [Doc title](https://docukit.dev/...)
+
 ## Breaking changes
 
 - [Short description.] **Migration:** [what the consumer changes]. (#123)
@@ -105,19 +109,24 @@ Rules:
 
 - If no breaking changes were found, write `_No breaking changes in this release._` under that section. **Do not omit the section** — explicit emptiness lets a reviewer catch a false negative.
 - Keep bullets user-facing. "Renamed `foo` → `bar`" — not "refactored internal foo helpers".
-- Group bullets that share a migration.
+- Open with a market-facing **Highlights** section. Put the most important story first, not the biggest diff. Make the top bullets attractive and clear for readers who will only skim.
+- Order bullets by user impact, not by commit order.
+- Link to documentation when it helps users adopt or understand the change.
+- Group related breaking changes by product area and shared migration so the section stays readable, but do not omit any real breaking change.
 - Omit empty Features/Fixes/Docs/Internal sections silently — only Breaking is mandatory.
 
 Use today's date from the environment.
 
 ### Discord sibling — `changelog/<tag>_DISCORD.md`
 
-Same content, transformed:
+Same story, transformed for Discord:
 
 - **No `#` headings.** Use `**BREAKING CHANGES**`, `**FEATURES**`, etc. in bold+caps.
-- Emojis per section: 🚨 Breaking, ✨ Features, 🐛 Fixes, 📚 Docs, 🛠 Internal.
-- URLs as plain text — paste `https://github.com/docukit/docukit/pull/123` literally. **No `[text](url)` markdown link syntax.**
+- Emojis per section: ✨ Highlights/Features, 🚨 Breaking, 🐛 Fixes, 📚 Docs, 🛠 Internal.
+- Do **not** include PR links in the Discord file. The committed changelog has the PR attribution.
+- Include documentation links as plain text only when they are useful to readers. **No `[text](url)` markdown link syntax.**
 - Open with a one-line summary: `🚀 DocuKit <tag> released!` then a blank line.
+- End with this line: `Full release notes with PRs: https://github.com/docukit/docukit/releases/`
 - Keep it skimmable.
 
 This file is gitignored (`changelog/*_DISCORD.md`) — never let it be committed.

--- a/changelog/v0.4.0.md
+++ b/changelog/v0.4.0.md
@@ -1,0 +1,44 @@
+# v0.4.0 — 2026-06-20
+
+## Highlights
+
+- **DocNode is now open source and MIT licensed.** `@docukit/docnode`, `@docukit/docnode-lexical`, and the DocNode companion packages now ship with MIT package metadata and license files. (#28) See the [DocNode docs](https://docukit.dev/docnode).
+- **Undo/redo is now built into `Doc`.** Every document has `doc.undoManager`, with `mergeInterval`, `skipUndo`, stack metadata, and events for editor integrations. (#27, #29) See the [Undo Manager docs](https://docukit.dev/docnode/undo-manager).
+- **DocNode-Lexical now handles remote user selection correctly.** Collaborative cursors and restored selections survive more real-world remote edits, deleted nodes, remapped nodes, undo/redo, and presence updates. (#23, #33) See the [Lexical integration docs](https://docukit.dev/docnode/lexical).
+- **DocSync got a large reliability pass.** Query state, fetch status, stable document IDs, local-tab sync, presence debounce, reconnect handling, and collaboration awareness all received feature work and bug fixes. (#31, #32, #34, #35, #36) See the [DocSync client docs](https://docukit.dev/docsync/client).
+
+## Breaking changes
+
+- **DocNode undo moved onto `Doc`.** `@docukit/docnode` no longer exports `UndoManager` directly. **Migration:** configure undo on the document with `new Doc({ ..., undoManager: { maxUndoSteps: N, mergeInterval: 500 } })`, then call `doc.undoManager.undo()` / `doc.undoManager.redo()`. (#27, #29)
+- **DocSync document loading and query state were tightened.** `createIfMissing` now requires a stable `id`; query status changed from `"loading"` to `"pending"`; every query result includes `fetchStatus`; `@docukit/docsync/shared` now only exports `DocBinding`; and presence no longer travels on `SyncRequest`. **Migration:** call `useDoc({ type, id, createIfMissing: true })`, update loading checks to `pending`, read `fetchStatus`, import client types from `@docukit/docsync/client`, and use `setPresence` / `getPresence` for presence. (#31, #32, #34, #35, #36, #39)
+- **DocNode-Lexical cleaned up its public surface.** `lexicalDocNodeConfig` and `createLexicalDoc` were replaced by `createLexicalDocNodeConfig`; `@docukit/docnode-lexical/react` no longer re-exports presence types; and `lexical`, `@lexical/react`, and `@lexical/selection` are now peer dependencies. **Migration:** call `createLexicalDocNodeConfig(...)`, import presence types from `@docukit/docnode-lexical`, and install compatible Lexical packages in the consuming app. (#23, #33, #40)
+
+## Features
+
+- Made DocNode open source under the MIT license, including package metadata and license updates for publishable DocNode packages. (#28)
+- Added `doc.undoManager`, `UndoManagerConfig`, `TransactionFlags`, `skipUndo`, stack metadata, `onPush` / `onPop`, and configurable `mergeInterval`. (#27, #29)
+- Added Lexical undo/redo binding, selection capture/restore, `SKIP_UNDO_TAG`, and remote selection recovery for collaborative editors. (#23, #27, #29)
+- Added default Lexical presence user handling, so missing names and colors get safe defaults. (#33)
+- Added `fetchStatus` to DocSync query results so apps can separate data state from network fetch state. (#36)
+- Added DocSync timing options for collaboration-aware debouncing and single-client debouncing. (#31, #32)
+- Added server collaboration broadcasts so clients know when another user is online in the same document. (#32)
+- Added `mergeOperations` to `@docukit/docnode`. (#29)
+
+## Fixes
+
+- Fixed remote Lexical selection restoration when collaborative edits delete, move, or remap the selected nodes. (#23)
+- Forwarded transaction flags through `applyOperations` and DocSync bindings so remote or skipped updates do not pollute undo history. (#22, #27)
+- Fixed DocSync local operation and presence debounce propagation across local tabs, collaborators, reconnects, and disconnects. (#31, #32)
+- Made DocSync query state preserve useful data during network errors and paused fetches. (#36)
+- Tightened DocSync object type bounds without changing the CRDT-agnostic sync model. (#39)
+
+## Docs
+
+- Added and updated docs for [Undo Manager](https://docukit.dev/docnode/undo-manager), [Lexical integration](https://docukit.dev/docnode/lexical), [DocSync client state](https://docukit.dev/docsync/client), [DocSync providers](https://docukit.dev/docsync/providers), and the SQLite collaboration server example. (#23, #29, #31, #32, #35, #36)
+- Moved examples into the main docs app and added dedicated pages for editor and subdocument demos. (#25)
+
+## Internal
+
+- Added the custom release workflow, bump CLI, validator, publisher, and release skill. (#21)
+- Added workflow timeouts and updated `concurrently`. (#37, #38)
+- Cleaned up DocSync development logs. (#30)

--- a/packages/docnode-lexical/package.json
+++ b/packages/docnode-lexical/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docukit/docnode-lexical",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "license": "MIT",
   "homepage": "https://docukit.dev",

--- a/packages/docnode/package.json
+++ b/packages/docnode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docukit/docnode",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Type-safe documents with conflict resolution. Faster than any CRDT.",
   "type": "module",

--- a/packages/docsync-react/package.json
+++ b/packages/docsync-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docukit/docsync-react",
-  "version": "0.3.1-alpha.2",
+  "version": "0.4.0-alpha.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "homepage": "https://docukit.dev/docsync",

--- a/packages/docsync/package.json
+++ b/packages/docsync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docukit/docsync",
-  "version": "0.3.1-alpha.2",
+  "version": "0.4.0-alpha.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "homepage": "https://docukit.dev/docsync",


### PR DESCRIPTION
Release PR. See `changelog/v0.4.0.md` for notes.