### PR TITLE
ci: configure npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches: [main]
@@ -34,11 +35,12 @@ jobs:
         run: node scripts/validate-release-pr.ts
 
   publish:
-    if: "github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore: release v')"
+    if: "github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore: release v'))"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: write
+      id-token: write
     concurrency:
       group: release-publish
       cancel-in-progress: false
@@ -58,6 +60,9 @@ jobs:
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -68,8 +73,6 @@ jobs:
 
       - name: Publish to npm
         id: publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node scripts/publish.ts
 
       - name: Create GitHub Release

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -5,9 +5,11 @@ import {
   statSync,
   existsSync,
   appendFileSync,
+  mkdtempSync,
 } from "node:fs";
 import { execSync } from "node:child_process";
 import { join, resolve, dirname } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -18,6 +20,10 @@ type Loaded = { dir: string; pkg: Package };
 const run = (cmd: string) => {
   console.log(`$ ${cmd}`);
   execSync(cmd, { cwd: ROOT, stdio: "inherit" });
+};
+const captureRequired = (cmd: string, cwd = ROOT): string => {
+  console.log(`$ ${cmd}`);
+  return execSync(cmd, { cwd, encoding: "utf8" }).trim();
 };
 const capture = (cmd: string): string | undefined => {
   try {
@@ -78,8 +84,7 @@ if (loaded.length === 0) {
   process.exit(1);
 }
 
-console.log("Fail-fast npm auth check...");
-run("npm whoami");
+const packDir = mkdtempSync(join(tmpdir(), "docukit-publish-"));
 
 const results: { published: string[]; skipped: string[]; failed: string[] } = {
   published: [],
@@ -87,7 +92,7 @@ const results: { published: string[]; skipped: string[]; failed: string[] } = {
   failed: [],
 };
 
-for (const { pkg } of loaded) {
+for (const { dir, pkg } of loaded) {
   const version = pkg.version;
   if (!version) continue;
   const spec = `${pkg.name}@${version}`;
@@ -101,13 +106,15 @@ for (const { pkg } of loaded) {
   }
 
   try {
-    const tagFlag = isAlpha ? " --tag alpha" : "";
-    run(
-      `pnpm publish --filter ${pkg.name} --access public --no-git-checks${tagFlag}`,
+    const packedPath = captureRequired(
+      `pnpm pack --pack-destination ${JSON.stringify(packDir)}`,
+      dir,
     );
-    if (isAlpha) {
-      run(`npm dist-tag add ${spec} latest`);
-    }
+    const tarball = resolve(dir, packedPath);
+    const tagFlag = isAlpha ? " --tag latest" : "";
+    run(
+      `npm publish ${JSON.stringify(tarball)} --access public --provenance${tagFlag}`,
+    );
     results.published.push(spec);
   } catch (err) {
     results.failed.push(spec);


### PR DESCRIPTION
## Summary
- configure release publishing to use npm Trusted Publishing/OIDC instead of NPM_TOKEN
- add manual workflow dispatch so the failed release can be retried with the updated workflow
- publish packed tarballs with npm provenance and avoid unsupported OIDC dist-tag commands

## Verification
- pnpm fix
- pnpm test:coverage:once
