### PR TITLE
ci: skip existing GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,11 @@ jobs:
             echo "✖ changelog file $NOTES not found"
             exit 1
           fi
-          gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — skipping creation"
+          else
+            gh release create "$TAG" --title "$TAG" --notes-file "$NOTES"
+          fi
 
       - name: Deploy DocSync server to Railway
         env:


### PR DESCRIPTION
## Summary
- make the GitHub Release creation step idempotent
- skip release creation when the tag already exists so reruns can continue to Railway and Vercel

## Verification
- pnpm fix
