### PR TITLE
Add DocSync document subscription events

### DIFF
--- a/docs/collab-server/docsync-server.ts
+++ b/docs/collab-server/docsync-server.ts
@@ -9,7 +9,7 @@ if (!Number.isInteger(port) || port <= 0) {
   throw new Error("PORT/DOCSYNC_PORT must be a positive integer");
 }
 
-new DocSyncServer({
+const server = new DocSyncServer({
   docBinding: DocNodeBinding([
     indexDocConfig,
     createLexicalDocNodeConfig({ undoManager: { maxUndoSteps: 100 } }),
@@ -23,3 +23,17 @@ new DocSyncServer({
   }),
   authenticate: ({ token }) => ({ userId: token }), // Use token as userId
 });
+
+server.onDocSubscribe(({ docId, userId, deviceId, clientId, socketId }) => {
+  console.log(
+    `[docsync] doc connect docId=${docId} userId=${userId} deviceId=${deviceId} clientId=${clientId} socketId=${socketId}`,
+  );
+});
+
+server.onDocUnsubscribe(
+  ({ docId, userId, deviceId, clientId, socketId, reason }) => {
+    console.log(
+      `[docsync] doc disconnect docId=${docId} userId=${userId} deviceId=${deviceId} clientId=${clientId} socketId=${socketId} reason=${reason}`,
+    );
+  },
+);

--- a/docs/collab-server/docsync-server.ts
+++ b/docs/collab-server/docsync-server.ts
@@ -24,16 +24,14 @@ const server = new DocSyncServer({
   authenticate: ({ token }) => ({ userId: token }), // Use token as userId
 });
 
-server.onDocSubscribe(({ docId, userId, deviceId, clientId, socketId }) => {
+server.onDocSubscribe(({ docId, userId, deviceId, clientId }) => {
   console.log(
-    `[docsync] doc connect docId=${docId} userId=${userId} deviceId=${deviceId} clientId=${clientId} socketId=${socketId}`,
+    `[docsync] doc connect docId=${docId} userId=${userId} deviceId=${deviceId} clientId=${clientId}`,
   );
 });
 
-server.onDocUnsubscribe(
-  ({ docId, userId, deviceId, clientId, socketId, reason }) => {
-    console.log(
-      `[docsync] doc disconnect docId=${docId} userId=${userId} deviceId=${deviceId} clientId=${clientId} socketId=${socketId} reason=${reason}`,
-    );
-  },
-);
+server.onDocUnsubscribe(({ docId, userId, deviceId, clientId, reason }) => {
+  console.log(
+    `[docsync] doc disconnect docId=${docId} userId=${userId} deviceId=${deviceId} clientId=${clientId} reason=${reason}`,
+  );
+});

--- a/docs/content/docs/docsync/server.mdx
+++ b/docs/content/docs/docsync/server.mdx
@@ -180,7 +180,10 @@ server.onClientConnect((event) => {
   type={{
     userId: { description: "Authenticated user ID.", type: "string" },
     deviceId: { description: "Unique device identifier.", type: "string" },
-    socketId: { description: "Socket.IO socket ID.", type: "string" },
+    clientId: {
+      description: "Client instance identifier used for presence.",
+      type: "string",
+    },
     context: {
       description: "Context object from authenticate().",
       type: "TContext",
@@ -208,13 +211,70 @@ server.onClientDisconnect((event) => {
       description: 'Device ID (or "unknown" if auth failed).',
       type: "string",
     },
-    socketId: {
-      description: 'Socket ID (or "unknown" if auth failed).',
+    clientId: {
+      description: 'Client ID (or "unknown" if auth failed).',
       type: "string",
     },
     reason: {
       description:
         'Disconnect reason (e.g., "transport close", "Authentication failed: invalid token").',
+      type: "string",
+    },
+  }}
+/>
+
+### onDocSubscribe
+
+Called when a connected client starts syncing a document.
+
+```ts
+server.onDocSubscribe((event) => {
+  console.log(`Client ${event.clientId} opened doc ${event.docId}`);
+});
+```
+
+<TypeTable
+  type={{
+    userId: { description: "Authenticated user ID.", type: "string" },
+    deviceId: {
+      description: "Device that opened the document.",
+      type: "string",
+    },
+    clientId: {
+      description: "Client instance identifier used for presence.",
+      type: "string",
+    },
+    docId: { description: "Document ID.", type: "string" },
+  }}
+/>
+
+### onDocUnsubscribe
+
+Called when a connected client stops syncing a document, either by unsubscribing or disconnecting.
+
+```ts
+server.onDocUnsubscribe((event) => {
+  console.log(
+    `Client ${event.clientId} closed doc ${event.docId}: ${event.reason}`,
+  );
+});
+```
+
+<TypeTable
+  type={{
+    userId: { description: "Authenticated user ID.", type: "string" },
+    deviceId: {
+      description: "Device that closed the document.",
+      type: "string",
+    },
+    clientId: {
+      description: "Client instance identifier used for presence.",
+      type: "string",
+    },
+    docId: { description: "Document ID.", type: "string" },
+    reason: {
+      description:
+        'Reason the client stopped syncing the document, such as "unsubscribe-doc" or a disconnect reason.',
       type: "string",
     },
   }}
@@ -236,7 +296,10 @@ server.onSyncRequest((event) => {
   type={{
     userId: { description: "User who made the request.", type: "string" },
     deviceId: { description: "Device that made the request.", type: "string" },
-    socketId: { description: "Socket ID.", type: "string" },
+    clientId: {
+      description: "Client instance that made the request.",
+      type: "string",
+    },
     status: { description: "Request outcome.", type: '"success" | "error"' },
     durationMs: {
       description: "Processing time in milliseconds.",

--- a/packages/docsync/src/exports/server.ts
+++ b/packages/docsync/src/exports/server.ts
@@ -5,6 +5,8 @@ export type {
   ServerProviderContext,
   ClientConnectEvent,
   ClientDisconnectEvent,
+  DocSubscribeEvent,
+  DocUnsubscribeEvent,
   SyncRequestEvent,
 } from "../server/types.js";
 export { inMemoryServerProvider } from "../server/providers/memory.js";

--- a/packages/docsync/src/server/handlers/disconnect.ts
+++ b/packages/docsync/src/server/handlers/disconnect.ts
@@ -37,7 +37,6 @@ export function handleDisconnect<
           userId,
           deviceId,
           clientId,
-          socketId: socket.id,
           docId,
           reason,
         });
@@ -49,7 +48,7 @@ export function handleDisconnect<
     server["_emit"](server["_clientDisconnectEventListeners"], {
       userId,
       deviceId,
-      socketId: socket.id,
+      clientId,
       reason,
     });
   });

--- a/packages/docsync/src/server/handlers/disconnect.ts
+++ b/packages/docsync/src/server/handlers/disconnect.ts
@@ -33,6 +33,14 @@ export function handleDisconnect<
           presence: null,
         });
         broadcastCollaborationState(server, docId);
+        server["_emit"](server["_docUnsubscribeEventListeners"], {
+          userId,
+          deviceId,
+          clientId,
+          socketId: socket.id,
+          docId,
+          reason,
+        });
       }
 
       socketToDocsMap.delete(socket.id);

--- a/packages/docsync/src/server/handlers/sync.ts
+++ b/packages/docsync/src/server/handlers/sync.ts
@@ -20,12 +20,14 @@ export function handleSync<
   socket,
   userId,
   deviceId,
+  clientId,
   context,
 }: {
   server: DocSyncServer<TContext, D, S, O>;
   socket: ServerConnectionSocket<TContext, S, O>;
   userId: string;
   deviceId: string;
+  clientId: string;
   context: TContext;
 }): void {
   socket.on(
@@ -72,10 +74,20 @@ export function handleSync<
       if (!room?.has(socket.id)) {
         await socket.join(`doc:${docId}`);
 
-        if (!socketToDocsMap.has(socket.id)) {
-          socketToDocsMap.set(socket.id, new Set());
+        let subscribedDocs = socketToDocsMap.get(socket.id);
+        if (!subscribedDocs) {
+          subscribedDocs = new Set();
+          socketToDocsMap.set(socket.id, subscribedDocs);
         }
-        socketToDocsMap.get(socket.id)!.add(docId);
+        subscribedDocs.add(docId);
+
+        server["_emit"](server["_docSubscribeEventListeners"], {
+          userId,
+          deviceId,
+          clientId,
+          socketId: socket.id,
+          docId,
+        });
 
         const presence = presenceByDoc.get(docId);
         if (presence) socket.emit("presence", { docId, presence });

--- a/packages/docsync/src/server/handlers/sync.ts
+++ b/packages/docsync/src/server/handlers/sync.ts
@@ -53,7 +53,7 @@ export function handleSync<
         server["_emit"](server["_syncRequestEventListeners"], {
           userId,
           deviceId,
-          socketId: socket.id,
+          clientId,
           status: "error",
           req,
           error: errorEvent,
@@ -85,7 +85,6 @@ export function handleSync<
           userId,
           deviceId,
           clientId,
-          socketId: socket.id,
           docId,
         });
 
@@ -148,7 +147,7 @@ export function handleSync<
         server["_emit"](server["_syncRequestEventListeners"], {
           userId,
           deviceId,
-          socketId: socket.id,
+          clientId,
           status: "success",
           req,
           ...(result.operations || result.serializedDoc
@@ -208,7 +207,7 @@ export function handleSync<
         server["_emit"](server["_syncRequestEventListeners"], {
           userId,
           deviceId,
-          socketId: socket.id,
+          clientId,
           status: "error",
           req,
           error: {

--- a/packages/docsync/src/server/handlers/unsubscribe.ts
+++ b/packages/docsync/src/server/handlers/unsubscribe.ts
@@ -59,7 +59,6 @@ export function handleUnsubscribeDoc<
         userId,
         deviceId,
         clientId,
-        socketId: socket.id,
         docId,
         reason: "unsubscribe-doc",
       });

--- a/packages/docsync/src/server/handlers/unsubscribe.ts
+++ b/packages/docsync/src/server/handlers/unsubscribe.ts
@@ -20,10 +20,14 @@ export function handleUnsubscribeDoc<
 >({
   server,
   socket,
+  userId,
+  deviceId,
   clientId,
 }: {
   server: DocSyncServer<TContext, D, S, O>;
   socket: ServerConnectionSocket<TContext, S, O>;
+  userId: string;
+  deviceId: string;
   clientId: string;
 }): void {
   const socketToDocsMap = server["_socketToDocsMap"];
@@ -50,6 +54,15 @@ export function handleUnsubscribeDoc<
         presence: null,
       });
       broadcastCollaborationState(server, docId);
+
+      server["_emit"](server["_docUnsubscribeEventListeners"], {
+        userId,
+        deviceId,
+        clientId,
+        socketId: socket.id,
+        docId,
+        reason: "unsubscribe-doc",
+      });
 
       cb({ success: true });
     },

--- a/packages/docsync/src/server/index.ts
+++ b/packages/docsync/src/server/index.ts
@@ -124,7 +124,7 @@ export class DocSyncServer<
         this._emit(this._clientDisconnectEventListeners, {
           userId: "unknown",
           deviceId,
-          socketId: "unknown",
+          clientId: "unknown",
           reason: `Authentication failed: ${err.message}`,
         });
       },
@@ -137,7 +137,7 @@ export class DocSyncServer<
       this._emit(this._clientConnectEventListeners, {
         userId,
         deviceId,
-        socketId: socket.id,
+        clientId,
         context,
       });
 

--- a/packages/docsync/src/server/index.ts
+++ b/packages/docsync/src/server/index.ts
@@ -9,6 +9,8 @@ import type {
   AuthenticatedSocketData,
   ClientConnectEventListener,
   ClientDisconnectEventListener,
+  DocSubscribeEventListener,
+  DocUnsubscribeEventListener,
   ServerConfig,
   ServerProvider,
   ServerSocket,
@@ -44,6 +46,9 @@ export class DocSyncServer<
   private _clientConnectEventListeners = new Set<ClientConnectEventListener>();
   private _clientDisconnectEventListeners =
     new Set<ClientDisconnectEventListener>();
+  private _docSubscribeEventListeners = new Set<DocSubscribeEventListener>();
+  private _docUnsubscribeEventListeners =
+    new Set<DocUnsubscribeEventListener>();
   private _syncRequestEventListeners = new Set<SyncRequestEventListener>();
 
   constructor(config: ServerConfig<TContext, D, S, O>) {
@@ -139,8 +144,8 @@ export class DocSyncServer<
       const server = this;
       handleDisconnect({ server, socket, userId, deviceId, clientId });
       // prettier-ignore
-      handleSync({ server, socket, userId, deviceId, context });
-      handleUnsubscribeDoc({ server, socket, clientId });
+      handleSync({ server, socket, userId, deviceId, clientId, context });
+      handleUnsubscribeDoc({ server, socket, userId, deviceId, clientId });
       handlePresence({ server, socket, userId, clientId, context });
       handleDeleteDoc({ server, socket, userId, context });
     });
@@ -180,6 +185,28 @@ export class DocSyncServer<
     this._clientDisconnectEventListeners.add(listener);
     return () => {
       this._clientDisconnectEventListeners.delete(listener);
+    };
+  }
+
+  /**
+   * Register a listener for document subscription events.
+   * @returns Unsubscribe function
+   */
+  onDocSubscribe(listener: DocSubscribeEventListener): () => void {
+    this._docSubscribeEventListeners.add(listener);
+    return () => {
+      this._docSubscribeEventListeners.delete(listener);
+    };
+  }
+
+  /**
+   * Register a listener for document unsubscription events.
+   * @returns Unsubscribe function
+   */
+  onDocUnsubscribe(listener: DocUnsubscribeEventListener): () => void {
+    this._docUnsubscribeEventListeners.add(listener);
+    return () => {
+      this._docUnsubscribeEventListeners.delete(listener);
     };
   }
 

--- a/packages/docsync/src/server/types.ts
+++ b/packages/docsync/src/server/types.ts
@@ -16,7 +16,7 @@ import type { Server, Socket } from "socket.io";
 export type ClientConnectEvent<TContext = unknown> = {
   userId: string;
   deviceId: string;
-  socketId: string;
+  clientId: string;
   context: TContext;
 };
 
@@ -24,12 +24,12 @@ export type ClientConnectEvent<TContext = unknown> = {
  * Emitted when client disconnects.
  *
  * Also emitted when a connection attempt fails (e.g., authentication failure).
- * In that case, userId and deviceId may not be available.
+ * In that case, userId, deviceId, and clientId may not be available.
  */
 export type ClientDisconnectEvent = {
   userId: string;
   deviceId: string;
-  socketId: string;
+  clientId: string;
   reason: string;
 };
 
@@ -38,7 +38,6 @@ export type DocSubscribeEvent = {
   userId: string;
   deviceId: string;
   clientId: string;
-  socketId: string;
   docId: string;
 };
 
@@ -47,7 +46,6 @@ export type DocUnsubscribeEvent = {
   userId: string;
   deviceId: string;
   clientId: string;
-  socketId: string;
   docId: string;
   reason: string;
 };
@@ -56,7 +54,7 @@ export type DocUnsubscribeEvent = {
 export type SyncRequestEvent<O = unknown, S = unknown> = {
   userId: string;
   deviceId: string;
-  socketId: string;
+  clientId: string;
   status: "success" | "error";
 
   req: { type: string; docId: string; operations?: O[]; clock: number };

--- a/packages/docsync/src/server/types.ts
+++ b/packages/docsync/src/server/types.ts
@@ -33,6 +33,25 @@ export type ClientDisconnectEvent = {
   reason: string;
 };
 
+/** Emitted when a connected client subscribes to a document. */
+export type DocSubscribeEvent = {
+  userId: string;
+  deviceId: string;
+  clientId: string;
+  socketId: string;
+  docId: string;
+};
+
+/** Emitted when a connected client unsubscribes from a document. */
+export type DocUnsubscribeEvent = {
+  userId: string;
+  deviceId: string;
+  clientId: string;
+  socketId: string;
+  docId: string;
+  reason: string;
+};
+
 /** Emitted once after sync request completes. */
 export type SyncRequestEvent<O = unknown, S = unknown> = {
   userId: string;
@@ -61,6 +80,8 @@ export type ClientConnectEventListener<TContext = unknown> = (
 export type ClientDisconnectEventListener = (
   event: ClientDisconnectEvent,
 ) => void;
+export type DocSubscribeEventListener = (event: DocSubscribeEvent) => void;
+export type DocUnsubscribeEventListener = (event: DocUnsubscribeEvent) => void;
 export type SyncRequestEventListener<O = unknown, S = unknown> = (
   event: SyncRequestEvent<O, S>,
 ) => void;

--- a/tests/docsync/unit/server/events.test.ts
+++ b/tests/docsync/unit/server/events.test.ts
@@ -5,6 +5,8 @@ import { DocNodeBinding } from "@docukit/docsync/docnode";
 import type {
   ClientConnectEvent,
   ClientDisconnectEvent,
+  DocSubscribeEvent,
+  DocUnsubscribeEvent,
   SyncRequestEvent,
 } from "@docukit/docsync/server";
 
@@ -224,6 +226,139 @@ describe("Server Events", () => {
         expect(capturedEvent).toBeDefined();
         expect(capturedEvent?.reason).toBeDefined();
         expect(typeof capturedEvent?.reason).toBe("string");
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // onDocSubscribe / onDocUnsubscribe
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe("document subscription events", () => {
+    test("should emit when client subscribes to a document", async () => {
+      const auth = { getToken: () => "valid-user-doc-subscribe" };
+      await testWrapper({ auth }, async (T) => {
+        let capturedEvent: DocSubscribeEvent | undefined;
+
+        T.server.onDocSubscribe((event) => {
+          capturedEvent = event;
+        });
+
+        await T.waitForConnect();
+        await T.sync({
+          type: "test",
+          docId: "doc-subscribe",
+          operations: [{ type: "insert" }],
+          clock: 0,
+        });
+
+        expect(capturedEvent).toMatchObject({
+          userId: "user-doc-subscribe",
+          docId: "doc-subscribe",
+          socketId: T.socket.id,
+        });
+        expect(capturedEvent?.deviceId).toBeDefined();
+        expect(capturedEvent?.clientId).toBeDefined();
+      });
+    });
+
+    test("should emit once per socket and document subscription", async () => {
+      const auth = { getToken: () => "valid-user-doc-subscribe-once" };
+      await testWrapper({ auth }, async (T) => {
+        const docIds: string[] = [];
+
+        T.server.onDocSubscribe((event) => {
+          docIds.push(event.docId);
+        });
+
+        await T.waitForConnect();
+        await T.sync({ type: "test", docId: "doc-subscribe-once", clock: 0 });
+        await T.sync({ type: "test", docId: "doc-subscribe-once", clock: 0 });
+
+        expect(docIds).toStrictEqual(["doc-subscribe-once"]);
+      });
+    });
+
+    test("should emit when client explicitly unsubscribes from a document", async () => {
+      const auth = { getToken: () => "valid-user-doc-unsubscribe" };
+      await testWrapper({ auth }, async (T) => {
+        let capturedEvent: DocUnsubscribeEvent | undefined;
+
+        T.server.onDocUnsubscribe((event) => {
+          capturedEvent = event;
+        });
+
+        await T.waitForConnect();
+        await T.sync({ type: "test", docId: "doc-unsubscribe", clock: 0 });
+        await new Promise<void>((resolve) => {
+          T.socket.emit("unsubscribe-doc", { docId: "doc-unsubscribe" }, () => {
+            resolve();
+          });
+        });
+
+        expect(capturedEvent).toMatchObject({
+          userId: "user-doc-unsubscribe",
+          docId: "doc-unsubscribe",
+          socketId: T.socket.id,
+          reason: "unsubscribe-doc",
+        });
+        expect(capturedEvent?.deviceId).toBeDefined();
+        expect(capturedEvent?.clientId).toBeDefined();
+      });
+    });
+
+    test("should emit for each subscribed document on disconnect", async () => {
+      const auth = { getToken: () => "valid-user-doc-disconnect" };
+      await testWrapper({ auth }, async (T) => {
+        const capturedEvents: DocUnsubscribeEvent[] = [];
+
+        T.server.onDocUnsubscribe((event) => {
+          capturedEvents.push(event);
+        });
+
+        await T.waitForConnect();
+        await T.sync({ type: "test", docId: "doc-disconnect-a", clock: 0 });
+        await T.sync({ type: "test", docId: "doc-disconnect-b", clock: 0 });
+
+        const socketId = T.socket.id;
+        T.socket.disconnect();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        expect(capturedEvents.map((event) => event.docId)).toStrictEqual([
+          "doc-disconnect-a",
+          "doc-disconnect-b",
+        ]);
+        expect(capturedEvents).toMatchObject([
+          { userId: "user-doc-disconnect", socketId },
+          { userId: "user-doc-disconnect", socketId },
+        ]);
+        expect(capturedEvents[0]?.reason).toBeDefined();
+        expect(capturedEvents[1]?.reason).toBeDefined();
+      });
+    });
+
+    test("should allow unsubscribing document event listeners", async () => {
+      const auth = { getToken: () => "valid-user-doc-listener" };
+      await testWrapper({ auth }, async (T) => {
+        let subscribeCalled = false;
+        let unsubscribeCalled = false;
+
+        const removeSubscribeListener = T.server.onDocSubscribe(() => {
+          subscribeCalled = true;
+        });
+        const removeUnsubscribeListener = T.server.onDocUnsubscribe(() => {
+          unsubscribeCalled = true;
+        });
+        removeSubscribeListener();
+        removeUnsubscribeListener();
+
+        await T.waitForConnect();
+        await T.sync({ type: "test", docId: "doc-listener", clock: 0 });
+        T.socket.disconnect();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        expect(subscribeCalled).toBe(false);
+        expect(unsubscribeCalled).toBe(false);
       });
     });
   });

--- a/tests/docsync/unit/server/events.test.ts
+++ b/tests/docsync/unit/server/events.test.ts
@@ -121,10 +121,11 @@ describe("Server Events", () => {
       await server.close();
     });
 
-    test("should include socketId", async () => {
+    test("should include clientId", async () => {
       const auth = { getToken: () => "valid-user4" };
       await testWrapper({ auth }, async (T) => {
         let capturedEvent: ClientConnectEvent | undefined;
+        const clientId = T.client["_clientId"];
 
         T.server.onClientConnect((event) => {
           capturedEvent = event;
@@ -133,7 +134,7 @@ describe("Server Events", () => {
         await T.waitForConnect();
 
         expect(capturedEvent).toBeDefined();
-        expect(capturedEvent?.socketId).toBe(T.socket.id);
+        expect(capturedEvent?.clientId).toBe(clientId);
       });
     });
   });
@@ -213,6 +214,7 @@ describe("Server Events", () => {
       const auth = { getToken: () => "valid-user8" };
       await testWrapper({ auth }, async (T) => {
         let capturedEvent: ClientDisconnectEvent | undefined;
+        const clientId = T.client["_clientId"];
 
         await T.waitForConnect();
 
@@ -226,6 +228,7 @@ describe("Server Events", () => {
         expect(capturedEvent).toBeDefined();
         expect(capturedEvent?.reason).toBeDefined();
         expect(typeof capturedEvent?.reason).toBe("string");
+        expect(capturedEvent?.clientId).toBe(clientId);
       });
     });
   });
@@ -239,6 +242,7 @@ describe("Server Events", () => {
       const auth = { getToken: () => "valid-user-doc-subscribe" };
       await testWrapper({ auth }, async (T) => {
         let capturedEvent: DocSubscribeEvent | undefined;
+        const clientId = T.client["_clientId"];
 
         T.server.onDocSubscribe((event) => {
           capturedEvent = event;
@@ -255,10 +259,9 @@ describe("Server Events", () => {
         expect(capturedEvent).toMatchObject({
           userId: "user-doc-subscribe",
           docId: "doc-subscribe",
-          socketId: T.socket.id,
+          clientId,
         });
         expect(capturedEvent?.deviceId).toBeDefined();
-        expect(capturedEvent?.clientId).toBeDefined();
       });
     });
 
@@ -283,6 +286,7 @@ describe("Server Events", () => {
       const auth = { getToken: () => "valid-user-doc-unsubscribe" };
       await testWrapper({ auth }, async (T) => {
         let capturedEvent: DocUnsubscribeEvent | undefined;
+        const clientId = T.client["_clientId"];
 
         T.server.onDocUnsubscribe((event) => {
           capturedEvent = event;
@@ -299,11 +303,10 @@ describe("Server Events", () => {
         expect(capturedEvent).toMatchObject({
           userId: "user-doc-unsubscribe",
           docId: "doc-unsubscribe",
-          socketId: T.socket.id,
+          clientId,
           reason: "unsubscribe-doc",
         });
         expect(capturedEvent?.deviceId).toBeDefined();
-        expect(capturedEvent?.clientId).toBeDefined();
       });
     });
 
@@ -311,6 +314,7 @@ describe("Server Events", () => {
       const auth = { getToken: () => "valid-user-doc-disconnect" };
       await testWrapper({ auth }, async (T) => {
         const capturedEvents: DocUnsubscribeEvent[] = [];
+        const clientId = T.client["_clientId"];
 
         T.server.onDocUnsubscribe((event) => {
           capturedEvents.push(event);
@@ -320,7 +324,6 @@ describe("Server Events", () => {
         await T.sync({ type: "test", docId: "doc-disconnect-a", clock: 0 });
         await T.sync({ type: "test", docId: "doc-disconnect-b", clock: 0 });
 
-        const socketId = T.socket.id;
         T.socket.disconnect();
         await new Promise((resolve) => setTimeout(resolve, 20));
 
@@ -329,8 +332,8 @@ describe("Server Events", () => {
           "doc-disconnect-b",
         ]);
         expect(capturedEvents).toMatchObject([
-          { userId: "user-doc-disconnect", socketId },
-          { userId: "user-doc-disconnect", socketId },
+          { userId: "user-doc-disconnect", clientId },
+          { userId: "user-doc-disconnect", clientId },
         ]);
         expect(capturedEvents[0]?.reason).toBeDefined();
         expect(capturedEvents[1]?.reason).toBeDefined();
@@ -388,7 +391,7 @@ describe("Server Events", () => {
         expect(capturedEvent).toMatchObject({
           userId: "user9",
           deviceId: expect.any(String) as string,
-          socketId: expect.any(String) as string,
+          clientId: expect.any(String) as string,
           status: "success",
           req: { docId: "doc-1", operations: [{ type: "insert" }], clock: 0 },
           // res is optional - only present if operations/serializedDoc returned
@@ -733,7 +736,7 @@ describe("Server Events", () => {
         // Core fields (always present)
         expect(capturedEvent?.userId).toBeDefined();
         expect(capturedEvent?.deviceId).toBeDefined();
-        expect(capturedEvent?.socketId).toBeDefined();
+        expect(capturedEvent?.clientId).toBeDefined();
         expect(capturedEvent?.status).toBeDefined();
 
         // Request context (always present)


### PR DESCRIPTION
## Summary
- add public DocSync server events for document subscribe/unsubscribe
- emit unsubscribe events for explicit unsubscribe and socket disconnect
- log doc connect/disconnect events in the docs DocSync server

## Verification
- pnpm test:once tests/docsync/unit/server/events.test.ts
- pnpm fix
- pnpm check
- pnpm test:coverage:once