### PR TITLE
Make DocSync sync payloads explicit

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -197,7 +197,7 @@ export const rootEslintConfig = tseslint.config(
         },
       ],
     },
-    ignores: ["**/*.test.ts"],
+    ignores: ["**/*.test.ts", "**/docsync*/**"],
   },
   ...nextVitals.map((config) => ({ ...config, files: ["**/*.{jsx,tsx}"] })),
   {

--- a/packages/docsync/SYNC-MODEL.md
+++ b/packages/docsync/SYNC-MODEL.md
@@ -216,10 +216,10 @@ If a client was offline for a long time and accumulated many operations:
 
 ```typescript
 // Request
-{ docId: string; operations: O[] | null; clock: number }
+{ docId: string; operations: O[]; clock: number }
 
 // Response
-{ docId: string; operations: O[] | null; serializedDoc: S; clock: number }
+{ docId: string; operations: O[]; serializedDoc: S | null; clock: number }
 ```
 
 This simplifies error handling and transaction scope.

--- a/packages/docsync/src/client/handlers/clientInitiated/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync.ts
@@ -138,15 +138,7 @@ export const handleSync = async <
   }
 
   const { data } = response;
-  client["_events"].emit("sync", {
-    req,
-    data: {
-      docId: data.docId,
-      ...(data.operations ? { operations: data.operations } : {}),
-      ...(data.serializedDoc ? { serializedDoc: data.serializedDoc } : {}),
-      clock: data.clock,
-    },
-  });
+  client["_events"].emit("sync", { req, data });
   let didConsolidate = false;
 
   await provider.transaction("readwrite", async (ctx) => {
@@ -186,14 +178,15 @@ export const handleSync = async <
       operations: persistedServerOperations,
     });
 
-    const presencePatch = getOwnPresencePatch(client, docId);
+    const presence = getOwnPresencePatch(client, docId);
     for (const op of persistedServerOperations) {
       client["_bcHelper"]?.broadcast({
         type: "OPERATIONS",
         source: "network",
         operations: op,
         docId,
-        ...(presencePatch && { presence: presencePatch }),
+        flags: {},
+        presence,
       });
     }
   }

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -109,7 +109,7 @@ export class DocSyncClient<
         const authPayload = {
           deviceId: this._deviceId,
           clientId: this._clientId,
-          ...(cachedIdentity && { claimedUserId: cachedIdentity.userId }),
+          claimedUserId: cachedIdentity?.userId ?? null,
         };
 
         if (config.server.auth.mode === "request") {
@@ -387,14 +387,13 @@ export class DocSyncClient<
       // include is the new cursor. Two frames so setPresence (from selection change) has run.
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          const presencePatch = getOwnPresencePatch(this, docId);
           this._bcHelper?.broadcast({
             type: "OPERATIONS",
             source: "local-broadcast",
             operations,
             docId,
-            ...(flags?.skipUndo && { flags: { skipUndo: true } }),
-            ...(presencePatch && { presence: presencePatch }),
+            flags: flags?.skipUndo ? { skipUndo: true } : {},
+            presence: getOwnPresencePatch(this, docId),
           });
         });
       });

--- a/packages/docsync/src/client/utils/BCHelper.ts
+++ b/packages/docsync/src/client/utils/BCHelper.ts
@@ -9,8 +9,8 @@ type BroadcastMessage<O> =
       source: BroadcastSource;
       operations: O;
       docId: string;
-      flags?: { skipUndo?: boolean };
-      presence?: Record<string, unknown>;
+      flags: { skipUndo?: boolean };
+      presence: Record<string, unknown>;
     }
   | { type: "PRESENCE"; docId: string; presence: Record<string, unknown> };
 
@@ -34,11 +34,9 @@ export class BCHelper<
           client["_pushStatusByDocId"].set(docId, "pushing-with-pending");
         }
         void this._applyOperations(client, operations, docId, source, flags);
-        if (presence) {
-          const cacheEntry = client["_docsCache"].get(docId);
-          if (cacheEntry)
-            applyPresencePatch(client["_clientId"], cacheEntry, presence);
-        }
+        const cacheEntry = client["_docsCache"].get(docId);
+        if (cacheEntry)
+          applyPresencePatch(client["_clientId"], cacheEntry, presence);
         return;
       }
       if (msg.type === "PRESENCE") {
@@ -55,7 +53,7 @@ export class BCHelper<
     operations: O,
     docId: string,
     source: BroadcastSource,
-    flags?: { skipUndo?: boolean },
+    flags: { skipUndo?: boolean },
   ): Promise<void> {
     const cacheEntry = client["_docsCache"].get(docId);
     if (!cacheEntry) return;

--- a/packages/docsync/src/client/utils/getOwnPresencePatch.ts
+++ b/packages/docsync/src/client/utils/getOwnPresencePatch.ts
@@ -4,11 +4,8 @@ export function getOwnPresencePatch<
   D extends object,
   S extends object,
   O extends object,
->(
-  client: DocSyncClient<D, S, O>,
-  docId: string,
-): Record<string, unknown> | undefined {
+>(client: DocSyncClient<D, S, O>, docId: string): Record<string, unknown> {
   const state = client["_presenceDebounceState"].get(docId);
   if (state) return { [client["_clientId"]]: state.data };
-  return undefined;
+  return {};
 }

--- a/packages/docsync/src/server/handlers/sync.ts
+++ b/packages/docsync/src/server/handlers/sync.ts
@@ -36,7 +36,7 @@ export function handleSync<
       req: SyncRequest<O>,
       cb: (res: SyncResponse<S, O>) => void,
     ): Promise<void> => {
-      const { type, docId, operations = [], clock } = req;
+      const { type, docId, operations, clock } = req;
       const startTime = Date.now();
 
       // TODO: we should validate req with Valibot here
@@ -56,7 +56,7 @@ export function handleSync<
           clientId,
           status: "error",
           req,
-          error: errorEvent,
+          error: { ...errorEvent, stack: null },
           durationMs: Date.now() - startTime,
         });
 
@@ -101,10 +101,8 @@ export function handleSync<
 
           return {
             docId,
-            ...(serverOps.length > 0 ? { operations: serverOps.flat() } : {}),
-            ...(serverDoc?.serializedDoc
-              ? { serializedDoc: serverDoc.serializedDoc }
-              : {}),
+            operations: serverOps.flat(),
+            serializedDoc: serverDoc?.serializedDoc ?? null,
             clock: newClock,
           };
         });
@@ -112,10 +110,8 @@ export function handleSync<
         cb({
           data: {
             docId: result.docId,
-            ...(result.operations ? { operations: result.operations } : {}),
-            ...(result.serializedDoc
-              ? { serializedDoc: result.serializedDoc }
-              : {}),
+            operations: result.operations,
+            serializedDoc: result.serializedDoc,
             clock: result.clock,
           },
         });
@@ -150,28 +146,17 @@ export function handleSync<
           clientId,
           status: "success",
           req,
-          ...(result.operations || result.serializedDoc
-            ? {
-                res: {
-                  ...(result.operations
-                    ? { operations: result.operations }
-                    : {}),
-                  ...(result.serializedDoc
-                    ? { serializedDoc: result.serializedDoc }
-                    : {}),
-                  clock: result.clock,
-                },
-              }
-            : {}),
+          res: {
+            operations: result.operations,
+            serializedDoc: result.serializedDoc,
+            clock: result.clock,
+          },
           durationMs: Date.now() - startTime,
           clientsCount: docRoom?.size ?? 0,
           devicesCount: devicesInRoom.size,
         });
 
-        if (
-          result.operations &&
-          result.operations.length >= OPERATION_THRESHOLD
-        ) {
+        if (result.operations.length >= OPERATION_THRESHOLD) {
           const {
             docId: resultDocId,
             operations: serverOps,
@@ -212,9 +197,7 @@ export function handleSync<
           req,
           error: {
             ...errorEvent,
-            ...(error instanceof Error && error.stack
-              ? { stack: error.stack }
-              : {}),
+            stack: error instanceof Error ? (error.stack ?? null) : null,
           },
           durationMs: Date.now() - startTime,
         });

--- a/packages/docsync/src/server/index.ts
+++ b/packages/docsync/src/server/index.ts
@@ -98,7 +98,9 @@ export class DocSyncServer<
         return;
       }
 
-      if (claimedUserId !== undefined && typeof claimedUserId !== "string") {
+      const hasClaimedUserId =
+        claimedUserId !== null && claimedUserId !== undefined;
+      if (hasClaimedUserId && typeof claimedUserId !== "string") {
         next(new Error("Authentication failed: invalid claimed user ID"));
         return;
       }
@@ -126,10 +128,7 @@ export class DocSyncServer<
             return;
           }
 
-          if (
-            claimedUserId !== undefined &&
-            authResult.userId !== claimedUserId
-          ) {
+          if (hasClaimedUserId && authResult.userId !== claimedUserId) {
             next(new Error("Authentication failed: claimed user ID mismatch"));
             return;
           }

--- a/packages/docsync/src/server/types.ts
+++ b/packages/docsync/src/server/types.ts
@@ -58,9 +58,9 @@ export type SyncRequestEvent<O = unknown, S = unknown> = {
   clientId: string;
   status: "success" | "error";
 
-  req: { type: string; docId: string; operations?: O[]; clock: number };
+  req: { type: string; docId: string; operations: O[]; clock: number };
 
-  res?: { operations?: O[]; clock?: number; serializedDoc?: S };
+  res?: { operations: O[]; clock: number | null; serializedDoc: S | null };
 
   durationMs?: number;
   devicesCount?: number;
@@ -69,7 +69,7 @@ export type SyncRequestEvent<O = unknown, S = unknown> = {
   error?: {
     type: "AuthorizationError" | "DatabaseError" | "ValidationError";
     message: string;
-    stack?: string;
+    stack: string | null;
   };
 };
 

--- a/packages/docsync/src/shared/types.ts
+++ b/packages/docsync/src/shared/types.ts
@@ -55,13 +55,13 @@ export type Result<D, E = Error> =
 export type SyncRequest<O = unknown> = {
   type: string;
   docId: string;
-  operations?: O[];
+  operations: O[];
   clock: number;
 };
 
 /** Shared response for the sync event (server sends, client receives). */
 export type SyncResponse<S = unknown, O = unknown> = Result<
-  { docId: string; operations?: O[]; serializedDoc?: S; clock: number },
+  { docId: string; operations: O[]; serializedDoc: S | null; clock: number },
   {
     type: "AuthorizationError" | "DatabaseError" | "ValidationError";
     message: string;

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -210,7 +210,7 @@ describe("DocSyncClient", () => {
     expect(typeof authPayload.deviceId).toBe("string");
     expect(authPayload).toMatchObject({ clientId: client["_clientId"] });
     expect(authPayload).not.toHaveProperty("token");
-    expect(authPayload).not.toHaveProperty("claimedUserId");
+    expect(authPayload.claimedUserId).toBe(null);
   });
 
   type DebounceTestClient = DocSyncClient<
@@ -1645,6 +1645,8 @@ describe("DocSyncClient", () => {
           source: "local-broadcast",
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           operations: expect.anything(),
+          flags: {},
+          presence: {},
         });
       } finally {
         globalThis.BroadcastChannel = originalBroadcastChannel;
@@ -1705,7 +1707,14 @@ describe("DocSyncClient", () => {
         // Simulate a message from BroadcastChannel with empty operations
         // Operations format is [OrderedOperation[], StatePatch] - empty is [[], {}]
         messageHandler!({
-          data: { type: "OPERATIONS", docId, operations: [[], {}] },
+          data: {
+            type: "OPERATIONS",
+            docId,
+            source: "local-broadcast",
+            operations: [[], {}],
+            flags: {},
+            presence: {},
+          },
         } as MessageEvent);
         // If we got here without throwing, the message was processed
       } finally {
@@ -1756,7 +1765,14 @@ describe("DocSyncClient", () => {
         // Simulate receiving operations from another tab (empty operations)
         // Operations format is [OrderedOperation[], StatePatch] - empty is [[], {}]
         messageHandler!({
-          data: { type: "OPERATIONS", docId, operations: [[], {}] },
+          data: {
+            type: "OPERATIONS",
+            docId,
+            source: "local-broadcast",
+            operations: [[], {}],
+            flags: {},
+            presence: {},
+          },
         } as MessageEvent);
 
         // postMessage should NOT be called - we don't re-broadcast received operations

--- a/tests/docsync/unit/client2/index.browser.test.ts
+++ b/tests/docsync/unit/client2/index.browser.test.ts
@@ -244,7 +244,12 @@ describe("Client 2", () => {
       // Mock API to return server operations
       const requestSpy = spyOnRequest(client);
       requestSpy.mockResolvedValue({
-        data: { docId, operations: serverOperations, clock: 1 },
+        data: {
+          docId,
+          operations: serverOperations,
+          serializedDoc: null,
+          clock: 1,
+        },
       });
 
       await setupDocWithOperations(client, docId, {
@@ -317,7 +322,12 @@ describe("Client 2", () => {
       // Mock API to return server operations
       const requestSpy = spyOnRequest(client);
       requestSpy.mockResolvedValue({
-        data: { docId, operations: serverOperations, clock: 1 },
+        data: {
+          docId,
+          operations: serverOperations,
+          serializedDoc: null,
+          clock: 1,
+        },
       });
 
       // Setup a document without pending operations (pure pull scenario)
@@ -488,7 +498,9 @@ describe("Client 2", () => {
       requestSpy.mockImplementation(() => {
         callCount++;
         if (callCount === 1) return Promise.reject(new Error("Network error"));
-        return Promise.resolve({ data: { docId, operations: [], clock: 1 } });
+        return Promise.resolve({
+          data: { docId, operations: [], serializedDoc: null, clock: 1 },
+        });
       });
 
       await setupDocWithOperations(client, docId);
@@ -508,7 +520,9 @@ describe("Client 2", () => {
         statusHistory.push(client["_pushStatusByDocId"].get(docId));
         if (statusHistory.length === 1)
           return Promise.reject(new Error("Network error"));
-        return Promise.resolve({ data: { docId, operations: [], clock: 1 } });
+        return Promise.resolve({
+          data: { docId, operations: [], serializedDoc: null, clock: 1 },
+        });
       });
 
       await setupDocWithOperations(client, docId);

--- a/tests/docsync/unit/server/events.test.ts
+++ b/tests/docsync/unit/server/events.test.ts
@@ -256,10 +256,8 @@ describe("Server Events", () => {
 
         await T.waitForConnect();
         await T.sync({
-          type: "test",
           docId: "doc-subscribe",
           operations: [createTestOperation()],
-          clock: 0,
         });
 
         expect(capturedEvent).toMatchObject({
@@ -281,8 +279,8 @@ describe("Server Events", () => {
         });
 
         await T.waitForConnect();
-        await T.sync({ type: "test", docId: "doc-subscribe-once", clock: 0 });
-        await T.sync({ type: "test", docId: "doc-subscribe-once", clock: 0 });
+        await T.sync({ docId: "doc-subscribe-once" });
+        await T.sync({ docId: "doc-subscribe-once" });
 
         expect(docIds).toStrictEqual(["doc-subscribe-once"]);
       });
@@ -299,7 +297,7 @@ describe("Server Events", () => {
         });
 
         await T.waitForConnect();
-        await T.sync({ type: "test", docId: "doc-unsubscribe", clock: 0 });
+        await T.sync({ docId: "doc-unsubscribe" });
         await new Promise<void>((resolve) => {
           T.socket.emit("unsubscribe-doc", { docId: "doc-unsubscribe" }, () => {
             resolve();
@@ -327,8 +325,8 @@ describe("Server Events", () => {
         });
 
         await T.waitForConnect();
-        await T.sync({ type: "test", docId: "doc-disconnect-a", clock: 0 });
-        await T.sync({ type: "test", docId: "doc-disconnect-b", clock: 0 });
+        await T.sync({ docId: "doc-disconnect-a" });
+        await T.sync({ docId: "doc-disconnect-b" });
 
         T.socket.disconnect();
         await new Promise((resolve) => setTimeout(resolve, 20));
@@ -362,7 +360,7 @@ describe("Server Events", () => {
         removeUnsubscribeListener();
 
         await T.waitForConnect();
-        await T.sync({ type: "test", docId: "doc-listener", clock: 0 });
+        await T.sync({ docId: "doc-listener" });
         T.socket.disconnect();
         await new Promise((resolve) => setTimeout(resolve, 20));
 
@@ -387,12 +385,7 @@ describe("Server Events", () => {
         });
 
         await T.waitForConnect();
-        await T.sync({
-          type: "test",
-          docId: "doc-1",
-          operations: [operation],
-          clock: 0,
-        });
+        await T.sync({ docId: "doc-1", operations: [operation] });
 
         expect(capturedEvent).toBeDefined();
         expect(capturedEvent).toMatchObject({
@@ -401,10 +394,10 @@ describe("Server Events", () => {
           clientId: expect.any(String) as string,
           status: "success",
           req: { docId: "doc-1", operations: [operation], clock: 0 },
-          // res is optional - only present if operations/serializedDoc returned
           durationMs: expect.any(Number) as number,
           clientsCount: expect.any(Number) as number,
           devicesCount: expect.any(Number) as number,
+          res: { operations: [], serializedDoc: null, clock: 1 },
         });
       });
     });
@@ -433,12 +426,7 @@ describe("Server Events", () => {
         { auth, url: `ws://localhost:${testPort(4)}` },
         async (T) => {
           await T.waitForConnect();
-          await T.sync({
-            type: "test",
-            docId: "doc-1",
-            operations: [createTestOperation()],
-            clock: 0,
-          });
+          await T.sync({ docId: "doc-1", operations: [createTestOperation()] });
 
           expect(capturedStatus).toBe("error");
         },
@@ -457,12 +445,7 @@ describe("Server Events", () => {
         });
 
         await T.waitForConnect();
-        await T.sync({
-          type: "test",
-          docId: "test-doc",
-          operations: [operation],
-          clock: 5,
-        });
+        await T.sync({ docId: "test-doc", operations: [operation], clock: 5 });
 
         expect(capturedEvent).toBeDefined();
         expect(capturedEvent?.req).toStrictEqual({
@@ -483,12 +466,7 @@ describe("Server Events", () => {
         });
 
         await T.waitForConnect();
-        await T.sync({
-          type: "test",
-          docId: "doc-2",
-          operations: [createTestOperation()],
-          clock: 0,
-        });
+        await T.sync({ docId: "doc-2", operations: [createTestOperation()] });
 
         expect(capturedEvent).toBeDefined();
         expect(capturedEvent?.durationMs).toBeDefined();
@@ -520,12 +498,7 @@ describe("Server Events", () => {
         });
 
         await T.waitForConnect();
-        await T.sync({
-          type: "test",
-          docId: "doc-3",
-          operations: [createTestOperation()],
-          clock: 0,
-        });
+        await T.sync({ docId: "doc-3", operations: [createTestOperation()] });
 
         expect(called1).toBe(true);
         expect(called2).toBe(true);
@@ -542,12 +515,7 @@ describe("Server Events", () => {
         unsubscribe();
 
         await T.waitForConnect();
-        await T.sync({
-          type: "test",
-          docId: "doc-4",
-          operations: [createTestOperation()],
-          clock: 0,
-        });
+        await T.sync({ docId: "doc-4", operations: [createTestOperation()] });
 
         expect(called).toBe(false);
       });
@@ -562,12 +530,7 @@ describe("Server Events", () => {
         });
 
         await T.waitForConnect();
-        await T.sync({
-          type: "test",
-          docId: "doc-5",
-          operations: [createTestOperation()],
-          clock: 0,
-        });
+        await T.sync({ docId: "doc-5", operations: [createTestOperation()] });
 
         expect(capturedEvent).toBeDefined();
         expect(capturedEvent?.status).toBe("success");
@@ -585,14 +548,10 @@ describe("Server Events", () => {
         });
 
         await T.waitForConnect();
-        await T.sync({ type: "test", docId: "doc-6", clock: 0 });
+        await T.sync({ docId: "doc-6" });
 
         expect(capturedEvent).toBeDefined();
-        // When no operations are sent, the server receives an empty array
-        expect(
-          capturedEvent?.req.operations === undefined ||
-            capturedEvent?.req.operations.length === 0,
-        ).toBe(true);
+        expect(capturedEvent?.req.operations).toStrictEqual([]);
         expect(capturedEvent?.status).toBe("success");
       });
     });
@@ -617,12 +576,7 @@ describe("Server Events", () => {
         await T.waitForConnect();
 
         // Do a sync
-        await T.sync({
-          type: "test",
-          docId: "doc-7",
-          operations: [createTestOperation()],
-          clock: 0,
-        });
+        await T.sync({ docId: "doc-7", operations: [createTestOperation()] });
 
         // Disconnect
         T.socket.disconnect();
@@ -649,24 +603,9 @@ describe("Server Events", () => {
 
         await T.waitForConnect();
 
-        await T.sync({
-          type: "test",
-          docId: "doc-a",
-          operations: [createTestOperation()],
-          clock: 0,
-        });
-        await T.sync({
-          type: "test",
-          docId: "doc-b",
-          operations: [createTestOperation()],
-          clock: 0,
-        });
-        await T.sync({
-          type: "test",
-          docId: "doc-c",
-          operations: [createTestOperation()],
-          clock: 0,
-        });
+        await T.sync({ docId: "doc-a", operations: [createTestOperation()] });
+        await T.sync({ docId: "doc-b", operations: [createTestOperation()] });
+        await T.sync({ docId: "doc-c", operations: [createTestOperation()] });
 
         expect(docIds).toStrictEqual(["doc-a", "doc-b", "doc-c"]);
       });
@@ -702,12 +641,7 @@ describe("Server Events", () => {
         { auth, url: `ws://localhost:${testPort(5)}` },
         async (T) => {
           await T.waitForConnect();
-          await T.sync({
-            type: "test",
-            docId: "doc-8",
-            operations: [createTestOperation()],
-            clock: 0,
-          });
+          await T.sync({ docId: "doc-8", operations: [createTestOperation()] });
 
           expect(capturedEvent).toBeDefined();
           expect(capturedEvent?.status).toBe("error");
@@ -732,12 +666,7 @@ describe("Server Events", () => {
 
         await T.waitForConnect();
 
-        await T.sync({
-          type: "test",
-          docId: "doc-9",
-          operations: [createTestOperation()],
-          clock: 0,
-        });
+        await T.sync({ docId: "doc-9", operations: [createTestOperation()] });
 
         expect(capturedEvent).toBeDefined();
 

--- a/tests/docsync/unit/server/index.test.ts
+++ b/tests/docsync/unit/server/index.test.ts
@@ -485,10 +485,8 @@ describe("sync", () => {
       await T.waitForConnect();
       expect(T.socket.connected).toBe(true);
       const res = await T.sync({
-        type: "test",
         docId: "doc-1",
         operations: [createTestOperation()],
-        clock: 0,
       });
 
       expect("error" in res).toBe(false);
@@ -512,12 +510,7 @@ describe("sync", () => {
       // Send 100 operations individually
       for (let i = 0; i < 100; i++) {
         const operation = createTestOperation();
-        const res = await T.sync({
-          type: "test",
-          docId,
-          operations: [operation],
-          clock: i,
-        });
+        const res = await T.sync({ docId, operations: [operation], clock: i });
 
         expect("error" in res).toBe(false);
         if ("data" in res) {
@@ -526,19 +519,14 @@ describe("sync", () => {
       }
 
       // First sync from clock 0: should receive all 100 operations
-      const res1 = await T.sync({
-        type: "test",
-        docId,
-        operations: [],
-        clock: 0,
-      });
+      const res1 = await T.sync({ docId });
 
       expect("error" in res1).toBe(false);
       if ("data" in res1) {
         expect(res1.data.clock).toBe(100);
         expect(res1.data.operations).toBeDefined();
         expect(res1.data.operations?.length).toBe(100);
-        expect(res1.data.serializedDoc).toBeUndefined();
+        expect(res1.data.serializedDoc).toBe(null);
       }
 
       // Wait for squashing to complete (it happens async after the response)
@@ -546,18 +534,13 @@ describe("sync", () => {
 
       // Second sync from clock 100: should receive serializedDoc (squashed)
       // because previous fetch triggered squashing (>= 100 operations)
-      const res2 = await T.sync({
-        type: "test",
-        docId,
-        operations: [],
-        clock: 100,
-      });
+      const res2 = await T.sync({ docId, clock: 100 });
 
       expect("error" in res2).toBe(false);
       if ("data" in res2) {
         expect(res2.data.clock).toBe(100);
         expect(res2.data.serializedDoc).toBeDefined();
-        expect(res2.data.operations).toBeUndefined();
+        expect(res2.data.operations).toStrictEqual([]);
       }
     });
   });

--- a/tests/docsync/unit/server/utils.ts
+++ b/tests/docsync/unit/server/utils.ts
@@ -100,7 +100,7 @@ export async function testWrapper(
     client: TestClient;
     waitForConnect: () => Promise<void>;
     waitForError: () => Promise<Error>;
-    sync: (payload: SyncPayload) => Promise<SyncResponse>;
+    sync: (payload: SyncPayloadInput) => Promise<SyncResponse>;
     socket: TestClient["_socket"];
   }) => Promise<void>,
 ) {
@@ -120,9 +120,13 @@ export async function testWrapper(
     new Promise<Error>((resolve) => {
       socket.on("connect_error", resolve);
     });
-  const sync = (payload: SyncPayload) =>
+  const sync = (payload: SyncPayloadInput) =>
     new Promise<SyncResponse>((resolve) => {
-      socket.emit("sync", payload, resolve);
+      socket.emit(
+        "sync",
+        { type: "test", operations: [], clock: 0, ...payload },
+        resolve,
+      );
     });
 
   await fn({ server, client, waitForConnect, waitForError, socket, sync });
@@ -132,16 +136,18 @@ export async function testWrapper(
 type SyncPayload = {
   type: string;
   docId: string;
-  operations?: Operations[];
+  operations: Operations[];
   clock: number;
 };
+type SyncPayloadInput = Pick<SyncPayload, "docId"> &
+  Partial<Omit<SyncPayload, "docId">>;
 type SyncResponse =
   | {
       data: {
         docId: string;
         clock: number;
-        operations?: unknown[];
-        serializedDoc?: unknown;
+        operations: Operations[];
+        serializedDoc: JsonDoc | null;
       };
     }
   | {


### PR DESCRIPTION
This PR makes DocSync sync payloads use explicit empty values: requests and responses carry operations arrays, and responses use serializedDoc: null when no serialized document is present.

It updates sync events, server response logging, BroadcastChannel operation messages, and auth handshakes to use explicit fields.

It also updates the sync model docs, relaxes the null lint rule for DocSync paths, and adjusts unit tests/helpers to match the new payload shape.