### PR TITLE
Handle DocSync snapshot reconciliation during sync

### DIFF
--- a/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../../../shared/types.js";
 import type { DocSyncClient } from "../../../index.js";
 import type { ClientProvider } from "../../../types.js";
+import { getLocalDocVersion } from "../../../utils/localDocVersion.js";
 
 export type ReconcileSyncResult<D extends object, O extends object> =
   | { type: "none" }
@@ -32,16 +33,38 @@ export async function reconcileSyncResponse<
     docId: string;
     operationsBatches: O[][];
     localOperations: O[];
+    requestLocalVersion: number;
     data: Extract<SyncResponse<S, O>, { data: unknown }>["data"];
   },
 ): Promise<ReconcileSyncResult<D, O>> {
-  const { provider, docId, operationsBatches, localOperations, data } = args;
+  const {
+    provider,
+    docId,
+    operationsBatches,
+    localOperations,
+    requestLocalVersion,
+    data,
+  } = args;
   const hasServerSnapshot = data.serializedDoc !== null;
   let didConsolidate = false;
+  let pendingProviderOperations: O[] = [];
   let replacementDoc: D | undefined;
 
   await provider.transaction("readwrite", async (ctx) => {
     const stored = await ctx.getSerializedDoc({ docId });
+    // A newer sync already updated IndexedDB; this response must not rewind it.
+    if (stored !== undefined && stored.clock > data.clock) {
+      return;
+    }
+    if (
+      stored !== undefined &&
+      stored.clock >= data.clock &&
+      localOperations.length === 0 &&
+      data.operations.length > 0
+    ) {
+      return;
+    }
+
     const baseSerializedDoc = data.serializedDoc ?? stored?.serializedDoc;
     if (baseSerializedDoc === undefined) return;
 
@@ -54,6 +77,11 @@ export async function reconcileSyncResponse<
     ) {
       return;
     }
+
+    const currentOperationsBatches = await ctx.getOperations({ docId });
+    pendingProviderOperations = currentOperationsBatches
+      .slice(operationsBatches.length)
+      .flat();
 
     const doc = client["_docBinding"].deserialize(baseSerializedDoc);
     applyOperations(client, doc, data.operations, { skipUndo: true });
@@ -73,9 +101,22 @@ export async function reconcileSyncResponse<
   });
 
   if (replacementDoc && hasServerSnapshot) {
-    const pendingLocalOperations =
+    const pendingMemoryOperations =
       client["_localOpsBatchState"].get(docId)?.data ?? [];
-    applyOperations(client, replacementDoc, pendingLocalOperations);
+    const hasUnrebuildableLocalMemory =
+      getLocalDocVersion(client, docId) > requestLocalVersion &&
+      pendingProviderOperations.length === 0 &&
+      pendingMemoryOperations.length === 0;
+
+    if (hasUnrebuildableLocalMemory) {
+      if (didConsolidate && data.operations.length > 0) {
+        return { type: "applyServerOperations", operations: data.operations };
+      }
+      return { type: "none" };
+    }
+
+    applyOperations(client, replacementDoc, pendingProviderOperations);
+    applyOperations(client, replacementDoc, pendingMemoryOperations);
     return { type: "replaceDoc", doc: replacementDoc };
   }
 

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
@@ -100,7 +100,13 @@ export async function reconcileSyncResponse<
     didConsolidate = true;
   });
 
-  if (replacementDoc && hasServerSnapshot) {
+  const hasConcurrentServerAndLocalOperations =
+    data.operations.length > 0 && localOperations.length > 0;
+
+  if (
+    replacementDoc &&
+    (hasServerSnapshot || hasConcurrentServerAndLocalOperations)
+  ) {
     const pendingMemoryOperations =
       client["_localOpsBatchState"].get(docId)?.data ?? [];
     const hasUnrebuildableLocalMemory =

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
@@ -1,0 +1,88 @@
+import type {
+  SyncResponse,
+  TransactionFlags,
+} from "../../../../shared/types.js";
+import type { DocSyncClient } from "../../../index.js";
+import type { ClientProvider } from "../../../types.js";
+
+export type ReconcileSyncResult<D extends object, O extends object> =
+  | { type: "none" }
+  | { type: "replaceDoc"; doc: D }
+  | { type: "applyServerOperations"; operations: O[] };
+
+function applyOperations<D extends object, S extends object, O extends object>(
+  client: DocSyncClient<D, S, O>,
+  doc: D,
+  operations: O[],
+  flags?: TransactionFlags,
+): void {
+  for (const op of operations) {
+    client["_docBinding"].applyOperations(doc, op, flags);
+  }
+}
+
+export async function reconcileSyncResponse<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
+  client: DocSyncClient<D, S, O>,
+  args: {
+    provider: ClientProvider<S, O>;
+    docId: string;
+    operationsBatches: O[][];
+    localOperations: O[];
+    data: Extract<SyncResponse<S, O>, { data: unknown }>["data"];
+  },
+): Promise<ReconcileSyncResult<D, O>> {
+  const { provider, docId, operationsBatches, localOperations, data } = args;
+  const hasServerSnapshot = data.serializedDoc !== null;
+  let didConsolidate = false;
+  let replacementDoc: D | undefined;
+
+  await provider.transaction("readwrite", async (ctx) => {
+    if (operationsBatches.length > 0) {
+      await ctx.deleteOperations({ docId, count: operationsBatches.length });
+    }
+
+    const stored = await ctx.getSerializedDoc({ docId });
+    const baseSerializedDoc = data.serializedDoc ?? stored?.serializedDoc;
+    if (baseSerializedDoc === undefined) return;
+
+    if (
+      !hasServerSnapshot &&
+      stored !== undefined &&
+      stored.clock >= data.clock &&
+      data.operations.length === 0 &&
+      localOperations.length === 0
+    ) {
+      return;
+    }
+
+    const doc = client["_docBinding"].deserialize(baseSerializedDoc);
+    applyOperations(client, doc, data.operations, { skipUndo: true });
+    applyOperations(client, doc, localOperations);
+    const serializedDoc = client["_docBinding"].serialize(doc);
+
+    const recheckStored = await ctx.getSerializedDoc({ docId });
+    if (stored !== undefined && recheckStored?.clock !== stored.clock) return;
+    if (stored === undefined && recheckStored !== undefined) return;
+
+    await ctx.saveSerializedDoc({ serializedDoc, docId, clock: data.clock });
+    replacementDoc = doc;
+    didConsolidate = true;
+  });
+
+  if (replacementDoc && hasServerSnapshot) {
+    const pendingLocalOperations =
+      client["_localOpsBatchState"].get(docId)?.data ?? [];
+    applyOperations(client, replacementDoc, pendingLocalOperations);
+    return { type: "replaceDoc", doc: replacementDoc };
+  }
+
+  if (didConsolidate && data.operations.length > 0) {
+    return { type: "applyServerOperations", operations: data.operations };
+  }
+
+  return { type: "none" };
+}

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
@@ -41,10 +41,6 @@ export async function reconcileSyncResponse<
   let replacementDoc: D | undefined;
 
   await provider.transaction("readwrite", async (ctx) => {
-    if (operationsBatches.length > 0) {
-      await ctx.deleteOperations({ docId, count: operationsBatches.length });
-    }
-
     const stored = await ctx.getSerializedDoc({ docId });
     const baseSerializedDoc = data.serializedDoc ?? stored?.serializedDoc;
     if (baseSerializedDoc === undefined) return;
@@ -69,6 +65,9 @@ export async function reconcileSyncResponse<
     if (stored === undefined && recheckStored !== undefined) return;
 
     await ctx.saveSerializedDoc({ serializedDoc, docId, clock: data.clock });
+    if (operationsBatches.length > 0) {
+      await ctx.deleteOperations({ docId, count: operationsBatches.length });
+    }
     replacementDoc = doc;
     didConsolidate = true;
   });

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -6,6 +6,7 @@ import {
   dispatchNetworkDocNotFound,
 } from "../../../utils/dispatchDocQueryAction.js";
 import { getOwnPresencePatch } from "../../../utils/getOwnPresencePatch.js";
+import { getLocalDocVersion } from "../../../utils/localDocVersion.js";
 import { request } from "../../../utils/request.js";
 import { setupDocChangeListener } from "../../../utils/setupDocChangeListener.js";
 import { reconcileSyncResponse } from "./reconcileSyncResponse.js";
@@ -45,6 +46,7 @@ function replaceDocInCache<
   client["_docsCache"].set(args.docId, {
     promisedDoc: nextPromisedDoc,
     refCount: cacheEntry.refCount,
+    localVersion: cacheEntry.localVersion,
     type: cacheEntry.type,
     ...(cacheEntry.localLoadMode && {
       localLoadMode: cacheEntry.localLoadMode,
@@ -94,6 +96,7 @@ export const handleSync = async <
   if (client["_localOpsBatchState"].has(docId)) {
     await client["_flushLocalOperations"](docId, { sync: false });
   }
+  const requestLocalVersion = getLocalDocVersion(client, docId);
 
   const { provider } = await client["_localPromise"];
   const socket = client["_socket"];
@@ -158,6 +161,7 @@ export const handleSync = async <
     docId,
     operationsBatches,
     localOperations: operations,
+    requestLocalVersion,
     data,
   });
 

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -71,6 +71,27 @@ function replaceDocInCache<
     .catch(() => undefined);
 }
 
+function broadcastServerOperations<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
+  client: DocSyncClient<D, S, O>,
+  args: { docId: string; operations: O[] },
+): void {
+  const presence = getOwnPresencePatch(client, args.docId);
+  for (const op of args.operations) {
+    client["_bcHelper"]?.broadcast({
+      type: "OPERATIONS",
+      source: "network",
+      operations: op,
+      docId: args.docId,
+      flags: {},
+      presence,
+    });
+  }
+}
+
 /**
  * Sync (push) a document to the server. Queues if already pushing (sets
  * pushing-with-pending), otherwise sets pushing and runs the sync.
@@ -168,23 +189,16 @@ export const handleSync = async <
   if (reconcileResult.type === "replaceDoc") {
     replaceDocInCache(client, { docId, doc: reconcileResult.doc });
     dispatchLocalDocFound(client, docId, { doc: reconcileResult.doc, docId });
+    broadcastServerOperations(client, { docId, operations: data.operations });
   } else if (reconcileResult.type === "applyServerOperations") {
     await applyServerOperations(client, {
       docId,
       operations: reconcileResult.operations,
     });
-
-    const presence = getOwnPresencePatch(client, docId);
-    for (const op of reconcileResult.operations) {
-      client["_bcHelper"]?.broadcast({
-        type: "OPERATIONS",
-        source: "network",
-        operations: op,
-        docId,
-        flags: {},
-        presence,
-      });
-    }
+    broadcastServerOperations(client, {
+      docId,
+      operations: reconcileResult.operations,
+    });
   }
 
   const currentStatus = pushStatusByDocId.get(docId);

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -1,7 +1,14 @@
-import type { SyncRequest, SyncResponse } from "../../../shared/types.js";
-import type { DocSyncClient } from "../../index.js";
-import { getOwnPresencePatch } from "../../utils/getOwnPresencePatch.js";
-import { request } from "../../utils/request.js";
+import type { SyncRequest, SyncResponse } from "../../../../shared/types.js";
+import type { DocSyncClient } from "../../../index.js";
+import {
+  dispatchLocalDocFound,
+  dispatchNetworkDocFound,
+  dispatchNetworkDocNotFound,
+} from "../../../utils/dispatchDocQueryAction.js";
+import { getOwnPresencePatch } from "../../../utils/getOwnPresencePatch.js";
+import { request } from "../../../utils/request.js";
+import { setupDocChangeListener } from "../../../utils/setupDocChangeListener.js";
+import { reconcileSyncResponse } from "./reconcileSyncResponse.js";
 
 /** Applies server operations to the cached doc. */
 async function applyServerOperations<
@@ -23,27 +30,20 @@ async function applyServerOperations<
   }
 }
 
-/**
- * TODO: Replaces the cached document (e.g. when server responds with a squashed doc).
- * Keeps refCount, presence, and presenceListeners unchanged.
- */
-function _replaceDocInCache<
+function replaceDocInCache<
   D extends object,
   S extends object,
   O extends object,
->(
-  client: DocSyncClient<D, S, O>,
-  args: { docId: string; doc?: D; serializedDoc?: S },
-): void {
+>(client: DocSyncClient<D, S, O>, args: { docId: string; doc: D }): void {
   const cacheEntry = client["_docsCache"].get(args.docId);
   if (!cacheEntry) return;
-  if (args.doc === undefined && args.serializedDoc === undefined) return;
 
-  const newDoc =
-    args.doc ?? client["_docBinding"].deserialize(args.serializedDoc!);
+  const previousPromisedDoc = cacheEntry.promisedDoc;
+  const nextPromisedDoc = Promise.resolve(args.doc);
+  setupDocChangeListener(client, args);
 
   client["_docsCache"].set(args.docId, {
-    promisedDoc: Promise.resolve(newDoc),
+    promisedDoc: nextPromisedDoc,
     refCount: cacheEntry.refCount,
     type: cacheEntry.type,
     ...(cacheEntry.localLoadMode && {
@@ -54,6 +54,19 @@ function _replaceDocInCache<
     presence: cacheEntry.presence,
     presenceListeners: cacheEntry.presenceListeners,
   });
+
+  void previousPromisedDoc
+    .then((previousDoc) => {
+      const currentEntry = client["_docsCache"].get(args.docId);
+      if (
+        currentEntry?.promisedDoc === nextPromisedDoc &&
+        previousDoc &&
+        previousDoc !== args.doc
+      ) {
+        client["_docBinding"].dispose(previousDoc);
+      }
+    })
+    .catch(() => undefined);
 }
 
 /**
@@ -84,7 +97,6 @@ export const handleSync = async <
 
   const { provider } = await client["_localPromise"];
   const socket = client["_socket"];
-  const docBinding = client["_docBinding"];
 
   // Prepare payload: read operations and clock from provider.
   const [operationsBatches, stored] = await provider.transaction(
@@ -106,13 +118,14 @@ export const handleSync = async <
     return;
   }
   const type = cacheEntry.type;
-  const payload: SyncRequest<O> = {
+  const payload: SyncRequest<S, O> = {
     type,
     clock: clientClock,
     docId,
     operations,
+    serializedDoc: stored?.serializedDoc ?? null,
   };
-  const req = { type, docId, operations, clock: clientClock };
+  const req = payload;
 
   let response: SyncResponse<S, O>;
   try {
@@ -139,47 +152,26 @@ export const handleSync = async <
 
   const { data } = response;
   client["_events"].emit("sync", { req, data });
-  let didConsolidate = false;
 
-  await provider.transaction("readwrite", async (ctx) => {
-    if (operationsBatches.length > 0) {
-      await ctx.deleteOperations({ docId, count: operationsBatches.length });
-    }
-
-    const stored = await ctx.getSerializedDoc({ docId });
-    if (!stored) return;
-
-    if (stored.clock >= data.clock) {
-      didConsolidate = false;
-      return;
-    }
-
-    const serverOps = data.operations ?? [];
-    const allOps = [...serverOps, ...operations];
-    if (allOps.length === 0) return;
-
-    const doc = docBinding.deserialize(stored.serializedDoc);
-    for (const op of allOps) {
-      docBinding.applyOperations(doc, op);
-    }
-    const serializedDoc = docBinding.serialize(doc);
-
-    const recheckStored = await ctx.getSerializedDoc({ docId });
-    if (recheckStored?.clock !== stored.clock) return;
-
-    await ctx.saveSerializedDoc({ serializedDoc, docId, clock: data.clock });
-    didConsolidate = true;
+  const reconcileResult = await reconcileSyncResponse(client, {
+    provider,
+    docId,
+    operationsBatches,
+    localOperations: operations,
+    data,
   });
 
-  const persistedServerOperations = data.operations ?? [];
-  if (didConsolidate && persistedServerOperations.length > 0) {
+  if (reconcileResult.type === "replaceDoc") {
+    replaceDocInCache(client, { docId, doc: reconcileResult.doc });
+    dispatchLocalDocFound(client, docId, { doc: reconcileResult.doc, docId });
+  } else if (reconcileResult.type === "applyServerOperations") {
     await applyServerOperations(client, {
       docId,
-      operations: persistedServerOperations,
+      operations: reconcileResult.operations,
     });
 
     const presence = getOwnPresencePatch(client, docId);
-    for (const op of persistedServerOperations) {
+    for (const op of reconcileResult.operations) {
       client["_bcHelper"]?.broadcast({
         type: "OPERATIONS",
         source: "network",
@@ -198,5 +190,19 @@ export const handleSync = async <
     void handleSync(client, docId);
     return;
   }
-  client["_markDocQueryIdle"](docId);
+  const latestCacheEntry = client["_docsCache"].get(docId);
+  if (!latestCacheEntry) return;
+  if (latestCacheEntry.queryResult.fetchStatus === "idle") return;
+
+  if (
+    latestCacheEntry.queryResult.status === "success" &&
+    latestCacheEntry.queryResult.data !== undefined
+  ) {
+    dispatchNetworkDocFound(client, docId, latestCacheEntry.queryResult.data);
+    return;
+  }
+
+  dispatchNetworkDocNotFound(client, docId, {
+    createIfMissing: latestCacheEntry.localLoadMode === "loadOrCreate",
+  });
 };

--- a/packages/docsync/src/client/handlers/connection/connect.ts
+++ b/packages/docsync/src/client/handlers/connection/connect.ts
@@ -1,5 +1,6 @@
 import type { DocSyncClient } from "../../index.js";
-import { handleSync } from "../clientInitiated/sync.js";
+import { dispatchDocQueryConnected } from "../../utils/dispatchDocQueryAction.js";
+import { handleSync } from "../clientInitiated/sync/sync.js";
 
 export function handleConnect<
   D extends object = object,
@@ -24,7 +25,11 @@ export function handleConnect<
       );
 
       for (const docId of client["_docsCache"].keys()) {
-        if (!syncedDocIds.has(docId)) void handleSync(client, docId);
+        dispatchDocQueryConnected(client, docId);
+        const pushStatus = client["_pushStatusByDocId"].get(docId) ?? "idle";
+        if (!syncedDocIds.has(docId) && pushStatus === "idle") {
+          void handleSync(client, docId);
+        }
       }
     })();
   });

--- a/packages/docsync/src/client/handlers/connection/disconnect.ts
+++ b/packages/docsync/src/client/handlers/connection/disconnect.ts
@@ -1,4 +1,5 @@
 import type { DocSyncClient } from "../../index.js";
+import { dispatchDocQueryDisconnected } from "../../utils/dispatchDocQueryAction.js";
 
 export function handleDisconnect<
   D extends object = object,
@@ -13,6 +14,7 @@ export function handleDisconnect<
       delete state.timeout;
     }
     for (const docId of client["_docsCache"].keys()) {
+      dispatchDocQueryDisconnected(client, docId);
       client["_bcHelper"]?.broadcast({
         type: "PRESENCE",
         docId,
@@ -22,6 +24,9 @@ export function handleDisconnect<
     client["_events"].emit("disconnect", { reason });
   });
   client["_socket"].on("connect_error", (err) => {
+    for (const docId of client["_docsCache"].keys()) {
+      dispatchDocQueryDisconnected(client, docId);
+    }
     client["_events"].emit("disconnect", { reason: err.message });
   });
 }

--- a/packages/docsync/src/client/handlers/serverInitiated/dirty.ts
+++ b/packages/docsync/src/client/handlers/serverInitiated/dirty.ts
@@ -1,5 +1,5 @@
 import type { DocSyncClient } from "../../index.js";
-import { handleSync } from "../clientInitiated/sync.js";
+import { handleSync } from "../clientInitiated/sync/sync.js";
 
 export function handleDirty<
   D extends object = object,

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -56,6 +56,7 @@ type QueryListener = (result: QueryResult<DocData<object> | undefined>) => void;
 type DocCacheEntry<D> = {
   promisedDoc: Promise<D | undefined>;
   refCount: number;
+  localVersion: number;
   type: string;
   localLoadMode?: LocalLoadMode;
   queryResult: QueryResult<DocData<D> | undefined>;
@@ -233,6 +234,7 @@ export class DocSyncClient<
       this._docsCache.set(docId, {
         promisedDoc,
         refCount: 1,
+        localVersion: 0,
         type,
         localLoadMode,
         queryResult,

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -21,21 +21,22 @@ import { handleDeleteDoc } from "./handlers/clientInitiated/deleteDoc.js";
 import { handleDisconnect } from "./handlers/connection/disconnect.js";
 import { handleCollaboration } from "./handlers/serverInitiated/collaboration.js";
 import { handleDirty } from "./handlers/serverInitiated/dirty.js";
-import {
-  flushPresenceDebounce,
-  handlePresence,
-} from "./handlers/clientInitiated/presence.js";
+import { handlePresence } from "./handlers/clientInitiated/presence.js";
 import { handlePresence as handleServerPresence } from "./handlers/serverInitiated/presence.js";
-import { handleSync } from "./handlers/clientInitiated/sync.js";
+import { handleSync } from "./handlers/clientInitiated/sync/sync.js";
 import { handleUnsubscribe } from "./handlers/clientInitiated/unsubscribe.js";
 import { handleIdentity } from "./handlers/serverInitiated/identity.js";
 import type { BCHelper } from "./utils/BCHelper.js";
+import {
+  dispatchLocalDocFound,
+  dispatchLocalQueryError,
+} from "./utils/dispatchDocQueryAction.js";
 import { getDeviceId } from "./utils/getDeviceId.js";
-import { getOwnPresencePatch } from "./utils/getOwnPresencePatch.js";
 import {
   clearLocalIdentity as clearStoredLocalIdentity,
   readLocalIdentity,
 } from "./utils/localIdentity.js";
+import { setupDocChangeListener } from "./utils/setupDocChangeListener.js";
 import { setupLocalPromise } from "./utils/setupLocalPromise.js";
 
 // TODO: review this type!
@@ -262,17 +263,6 @@ export class DocSyncClient<
     }
   }
 
-  protected _markDocQueryIdle(docId: string): void {
-    const cacheEntry = this._docsCache.get(docId);
-    if (!cacheEntry) return;
-    if (cacheEntry.queryResult.fetchStatus === "idle") return;
-
-    this._emitQueryResult(docId, {
-      ...cacheEntry.queryResult,
-      fetchStatus: "idle",
-    });
-  }
-
   private _observePromisedDoc(
     docId: string,
     promisedDoc: Promise<D | undefined>,
@@ -287,7 +277,7 @@ export class DocSyncClient<
         delete cacheEntry.localLoadMode;
 
         if (doc) {
-          this._setupChangeListener(doc, docId);
+          setupDocChangeListener(this, { doc, docId });
           this._events.emit("docLoad", {
             docId,
             source: localLoadMode === "loadOrCreate" ? "created" : "local",
@@ -295,13 +285,11 @@ export class DocSyncClient<
           });
         }
 
-        this._emitQueryResult(docId, {
-          status: "success",
-          fetchStatus: doc ? cacheEntry.queryResult.fetchStatus : "idle",
-          data: doc ? { doc, docId } : undefined,
-        });
-
         if (doc) {
+          dispatchLocalDocFound(this, docId, { doc, docId });
+        }
+
+        if (this._socket.connected) {
           void handleSync(this, docId);
         }
       } catch (e) {
@@ -311,11 +299,7 @@ export class DocSyncClient<
         delete cacheEntry.localLoadMode;
 
         const error = e instanceof Error ? e : new Error(String(e));
-        this._emitQueryResult(docId, {
-          ...cacheEntry.queryResult,
-          status: "error",
-          error,
-        });
+        dispatchLocalQueryError(this, docId, error);
       }
     })();
   }
@@ -360,44 +344,6 @@ export class DocSyncClient<
 
   setPresence({ docId, presence }: { docId: string; presence: unknown }) {
     void handlePresence(this, { docId, presence });
-  }
-
-  private _setupChangeListener(doc: D, docId: string) {
-    this._docBinding.onChange(doc, ({ flags, operations }) => {
-      const changeOrigin = this._changeOrigin;
-
-      this._events.emit("change", {
-        docId,
-        origin: changeOrigin,
-        operation: operations,
-      });
-
-      if (changeOrigin !== "local") {
-        const timeoutBeforeChange =
-          this._presenceDebounceState.get(docId)?.timeout;
-        queueMicrotask(() =>
-          flushPresenceDebounce(this, docId, { timeoutBeforeChange }),
-        );
-        return;
-      }
-
-      void this.onLocalOperations({ docId, operations: [operations] });
-
-      // Defer BC send so Lexical can update selection first; then the presence we
-      // include is the new cursor. Two frames so setPresence (from selection change) has run.
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          this._bcHelper?.broadcast({
-            type: "OPERATIONS",
-            source: "local-broadcast",
-            operations,
-            docId,
-            flags: flags?.skipUndo ? { skipUndo: true } : {},
-            presence: getOwnPresencePatch(this, docId),
-          });
-        });
-      });
-    });
   }
 
   protected _applyOperationsFrom(

--- a/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
+++ b/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
@@ -1,0 +1,97 @@
+import type { DocSyncClient } from "../index.js";
+import type { DocData } from "../types.js";
+import { createQueryResultReducer } from "./queryResultReducer.js";
+
+export function dispatchLocalDocFound<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string, data: DocData<D>): void {
+  const cacheEntry = client["_docsCache"].get(docId);
+  if (!cacheEntry) return;
+
+  const reducer = createQueryResultReducer({
+    initialState: cacheEntry.queryResult,
+  });
+  const next = reducer.action.localDocFound({ data });
+  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
+}
+
+export function dispatchLocalQueryError<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string, error: Error): void {
+  const cacheEntry = client["_docsCache"].get(docId);
+  if (!cacheEntry) return;
+
+  const reducer = createQueryResultReducer({
+    initialState: cacheEntry.queryResult,
+  });
+  const next = reducer.action.localQueryError({ error });
+  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
+}
+
+export function dispatchDocQueryConnected<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string): void {
+  const cacheEntry = client["_docsCache"].get(docId);
+  if (!cacheEntry) return;
+
+  const reducer = createQueryResultReducer({
+    initialState: cacheEntry.queryResult,
+  });
+  const next = reducer.action.connected(undefined);
+  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
+}
+
+export function dispatchDocQueryDisconnected<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string): void {
+  const cacheEntry = client["_docsCache"].get(docId);
+  if (!cacheEntry) return;
+
+  const reducer = createQueryResultReducer({
+    initialState: cacheEntry.queryResult,
+  });
+  const next = reducer.action.disconnected(undefined);
+  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
+}
+
+export function dispatchNetworkDocFound<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string, data: DocData<D>): void {
+  const cacheEntry = client["_docsCache"].get(docId);
+  if (!cacheEntry) return;
+
+  const reducer = createQueryResultReducer({
+    initialState: cacheEntry.queryResult,
+  });
+  const next = reducer.action.networkDocFound({ data });
+  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
+}
+
+export function dispatchNetworkDocNotFound<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
+  client: DocSyncClient<D, S, O>,
+  docId: string,
+  payload: { createIfMissing: boolean },
+): void {
+  const cacheEntry = client["_docsCache"].get(docId);
+  if (!cacheEntry) return;
+
+  const reducer = createQueryResultReducer({
+    initialState: cacheEntry.queryResult,
+  });
+  const next = reducer.action.networkDocNotFound(payload);
+  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
+}

--- a/packages/docsync/src/client/utils/events.ts
+++ b/packages/docsync/src/client/utils/events.ts
@@ -13,7 +13,7 @@ export type ChangeEvent<O = unknown> = {
 };
 
 /** Emitted once after sync completes (success or error). */
-export type SyncEvent<O = unknown, S = unknown> = { req: SyncRequest<O> } & (
+export type SyncEvent<O = unknown, S = unknown> = { req: SyncRequest<S, O> } & (
   | SyncResponse<S, O>
   | { error: { type: "NetworkError"; message: string }; data?: never }
 );

--- a/packages/docsync/src/client/utils/localDocVersion.ts
+++ b/packages/docsync/src/client/utils/localDocVersion.ts
@@ -1,0 +1,19 @@
+import type { DocSyncClient } from "../index.js";
+
+export function getLocalDocVersion<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string): number {
+  return client["_docsCache"].get(docId)?.localVersion ?? 0;
+}
+
+export function markLocalDocChanged<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string): void {
+  const cacheEntry = client["_docsCache"].get(docId);
+  if (!cacheEntry) return;
+  cacheEntry.localVersion += 1;
+}

--- a/packages/docsync/src/client/utils/setupDocChangeListener.ts
+++ b/packages/docsync/src/client/utils/setupDocChangeListener.ts
@@ -1,0 +1,47 @@
+import type { DocSyncClient } from "../index.js";
+import { flushPresenceDebounce } from "../handlers/clientInitiated/presence.js";
+import { getOwnPresencePatch } from "./getOwnPresencePatch.js";
+
+export function setupDocChangeListener<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, args: { doc: D; docId: string }): void {
+  const { doc, docId } = args;
+
+  client["_docBinding"].onChange(doc, ({ flags, operations }) => {
+    const changeOrigin = client["_changeOrigin"];
+
+    client["_events"].emit("change", {
+      docId,
+      origin: changeOrigin,
+      operation: operations,
+    });
+
+    if (changeOrigin !== "local") {
+      const timeoutBeforeChange =
+        client["_presenceDebounceState"].get(docId)?.timeout;
+      queueMicrotask(() =>
+        flushPresenceDebounce(client, docId, { timeoutBeforeChange }),
+      );
+      return;
+    }
+
+    void client.onLocalOperations({ docId, operations: [operations] });
+
+    // Defer BC send so Lexical can update selection first; then the presence we
+    // include is the new cursor. Two frames so setPresence (from selection change) has run.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        client["_bcHelper"]?.broadcast({
+          type: "OPERATIONS",
+          source: "local-broadcast",
+          operations,
+          docId,
+          flags: flags?.skipUndo ? { skipUndo: true } : {},
+          presence: getOwnPresencePatch(client, docId),
+        });
+      });
+    });
+  });
+}

--- a/packages/docsync/src/client/utils/setupDocChangeListener.ts
+++ b/packages/docsync/src/client/utils/setupDocChangeListener.ts
@@ -1,6 +1,7 @@
 import type { DocSyncClient } from "../index.js";
 import { flushPresenceDebounce } from "../handlers/clientInitiated/presence.js";
 import { getOwnPresencePatch } from "./getOwnPresencePatch.js";
+import { markLocalDocChanged } from "./localDocVersion.js";
 
 export function setupDocChangeListener<
   D extends object,
@@ -17,6 +18,10 @@ export function setupDocChangeListener<
       origin: changeOrigin,
       operation: operations,
     });
+
+    if (changeOrigin !== "network") {
+      markLocalDocChanged(client, docId);
+    }
 
     if (changeOrigin !== "local") {
       const timeoutBeforeChange =

--- a/packages/docsync/src/server/handlers/sync.ts
+++ b/packages/docsync/src/server/handlers/sync.ts
@@ -105,7 +105,7 @@ export function handleSync<
           let operationsClock = clock;
           if (
             serverDoc !== undefined &&
-            (serializedDoc === null || serverDoc.clock >= clock)
+            (serializedDoc === null || serverDoc.clock > clock)
           ) {
             responseSerializedDoc = serverDoc.serializedDoc;
             operationsClock = serverDoc.clock;

--- a/packages/docsync/src/server/handlers/sync.ts
+++ b/packages/docsync/src/server/handlers/sync.ts
@@ -6,7 +6,7 @@ import { broadcastCollaborationState } from "../utils/broadcastCollaborationStat
 const OPERATION_THRESHOLD = 100;
 
 export type SyncHandler<S = unknown, O = unknown> = (
-  payload: SyncRequest<O>,
+  payload: SyncRequest<S, O>,
   cb: (res: SyncResponse<S, O>) => void,
 ) => void | Promise<void>;
 
@@ -33,10 +33,10 @@ export function handleSync<
   socket.on(
     "sync",
     async (
-      req: SyncRequest<O>,
+      req: SyncRequest<S, O>,
       cb: (res: SyncResponse<S, O>) => void,
     ): Promise<void> => {
-      const { type, docId, operations, clock } = req;
+      const { type, docId, operations, serializedDoc, clock } = req;
       const startTime = Date.now();
 
       // TODO: we should validate req with Valibot here
@@ -95,14 +95,32 @@ export function handleSync<
 
       try {
         const result = await provider.transaction("readwrite", async (ctx) => {
-          const serverOps = await ctx.getOperations({ docId, clock });
           const serverDoc = await ctx.getSerializedDoc({ docId });
+
+          if (serverDoc === undefined && serializedDoc !== null) {
+            await ctx.saveSerializedDoc({ docId, serializedDoc, clock });
+          }
+
+          let responseSerializedDoc: S | null = null;
+          let operationsClock = clock;
+          if (
+            serverDoc !== undefined &&
+            (serializedDoc === null || serverDoc.clock >= clock)
+          ) {
+            responseSerializedDoc = serverDoc.serializedDoc;
+            operationsClock = serverDoc.clock;
+          }
+
+          const serverOps = await ctx.getOperations({
+            docId,
+            clock: operationsClock,
+          });
           const newClock = await ctx.saveOperations({ docId, operations });
 
           return {
             docId,
             operations: serverOps.flat(),
-            serializedDoc: serverDoc?.serializedDoc ?? null,
+            serializedDoc: responseSerializedDoc,
             clock: newClock,
           };
         });
@@ -164,9 +182,10 @@ export function handleSync<
             clock: resultClock,
           } = result;
           const allOperations = [...serverOps, ...operations];
-          const doc = serializedDoc
-            ? docBinding.deserialize(serializedDoc)
-            : docBinding.create(type, resultDocId).doc;
+          const doc =
+            serializedDoc !== null
+              ? docBinding.deserialize(serializedDoc)
+              : docBinding.create(type, resultDocId).doc;
           allOperations.forEach((operation) => {
             docBinding.applyOperations(doc, operation);
           });

--- a/packages/docsync/src/server/types.ts
+++ b/packages/docsync/src/server/types.ts
@@ -58,7 +58,13 @@ export type SyncRequestEvent<O = unknown, S = unknown> = {
   clientId: string;
   status: "success" | "error";
 
-  req: { type: string; docId: string; operations: O[]; clock: number };
+  req: {
+    type: string;
+    docId: string;
+    operations: O[];
+    serializedDoc: S | null;
+    clock: number;
+  };
 
   res?: { operations: O[]; clock: number | null; serializedDoc: S | null };
 

--- a/packages/docsync/src/shared/types.ts
+++ b/packages/docsync/src/shared/types.ts
@@ -52,10 +52,11 @@ export type Result<D, E = Error> =
 // ============================================================================
 
 /** Shared request payload for the sync event (client sends, server receives). */
-export type SyncRequest<O = unknown> = {
+export type SyncRequest<S = unknown, O = unknown> = {
   type: string;
   docId: string;
   operations: O[];
+  serializedDoc: S | null;
   clock: number;
 };
 

--- a/tests/docsync-react/index.browser.test.tsx
+++ b/tests/docsync-react/index.browser.test.tsx
@@ -26,12 +26,14 @@ const countChildren = (doc: Doc): number => {
   });
   return count;
 };
+const reactUserId = "John";
 
 test("createDocSyncClient", async () => {
+  localStorage.setItem("docsync:localUserId", reactUserId);
   const { useDoc } = createDocSyncClient({
     server: {
       url: testServerUrl(),
-      auth: { mode: "token", getToken: () => "test-token-John" },
+      auth: { mode: "token", getToken: () => `test-token-${reactUserId}` },
     },
     local: { provider: indexedDBProvider },
     docBinding: DocNodeBinding([docConfig]),
@@ -128,10 +130,11 @@ test("createDocSyncClient", async () => {
 }, 5000);
 
 test("client keeps own presence for debounced outgoing sync", async () => {
+  localStorage.setItem("docsync:localUserId", reactUserId);
   const { useDoc, usePresence, client } = createDocSyncClient({
     server: {
       url: testServerUrl(),
-      auth: { mode: "token", getToken: () => "test-token-John" },
+      auth: { mode: "token", getToken: () => `test-token-${reactUserId}` },
     },
     local: { provider: indexedDBProvider },
     timing: { singleClientMaxDebounce: 200 },

--- a/tests/docsync-react/index.browser.test.tsx
+++ b/tests/docsync-react/index.browser.test.tsx
@@ -7,7 +7,7 @@ import { DocNodeBinding } from "@docukit/docsync-react/docnode";
 import type { Doc } from "@docukit/docnode";
 import type { DocData, QueryResult } from "@docukit/docsync/client";
 import { renderHook } from "vitest-browser-react";
-import { docConfig, id } from "./utils.js";
+import { ChildNode, docConfig, id } from "./utils.js";
 
 declare global {
   var __TEST_SERVER_PORT__: number | undefined;
@@ -15,6 +15,14 @@ declare global {
 
 const testServerUrl = () =>
   `ws://localhost:${globalThis.__TEST_SERVER_PORT__ ?? 8082}`;
+
+const countChildren = (doc: Doc): number => {
+  let count = 0;
+  doc.root.children().forEach(() => {
+    count += 1;
+  });
+  return count;
+};
 
 test("createDocSyncClient", async () => {
   const { useDoc } = createDocSyncClient({
@@ -172,3 +180,101 @@ test("client keeps own presence for debounced outgoing sync", async () => {
   client.disconnect();
   client["_bcHelper"]?.close();
 });
+
+test("useDoc rerenders with the server doc after replacing an optimistic local doc", async () => {
+  const docId = id.ending(Date.now().toString().slice(-6));
+
+  localStorage.removeItem("docsync:localUserId");
+  const source = createDocSyncClient({
+    server: {
+      url: testServerUrl(),
+      auth: { mode: "token", getToken: () => `test-token-source-${docId}` },
+    },
+    local: { provider: indexedDBProvider },
+    timing: { singleClientMaxDebounce: 0 },
+    docBinding: DocNodeBinding([docConfig]),
+  });
+
+  if (!source.client) {
+    throw new Error("Expected source client in browser tests");
+  }
+  const sourceClient = source.client;
+  const sourceSyncedLocalOperation: boolean[] = [];
+  sourceClient.on("sync", (event) => {
+    if (event.req.operations.length > 0 && event.data) {
+      sourceSyncedLocalOperation.push(true);
+    }
+  });
+
+  const { result: sourceResult } = await renderHook(() =>
+    source.useDoc({ type: "test", id: docId, createIfMissing: true }),
+  );
+
+  await expect
+    .poll(
+      () =>
+        sourceResult.current.status === "success"
+          ? sourceResult.current.fetchStatus
+          : undefined,
+      { interval: 20, timeout: 2000 },
+    )
+    .toBe("idle");
+
+  if (sourceResult.current.status !== "success") {
+    throw new Error("Expected source doc result");
+  }
+
+  const sourceDoc = sourceResult.current.data.doc;
+  const child = sourceDoc.createNode(ChildNode);
+  child.state.value.set("server");
+  sourceDoc.root.append(child);
+
+  await expect
+    .poll(() => sourceSyncedLocalOperation.includes(true), {
+      interval: 20,
+      timeout: 2000,
+    })
+    .toBe(true);
+
+  sourceClient.disconnect();
+  sourceClient["_bcHelper"]?.close();
+
+  localStorage.removeItem("docsync:localUserId");
+  const reader = createDocSyncClient({
+    server: {
+      url: testServerUrl(),
+      auth: { mode: "token", getToken: () => `test-token-reader-${docId}` },
+    },
+    local: { provider: indexedDBProvider },
+    docBinding: DocNodeBinding([docConfig]),
+  });
+
+  if (!reader.client) {
+    throw new Error("Expected reader client in browser tests");
+  }
+  const readerClient = reader.client;
+
+  const { result: readerResult } = await renderHook(() =>
+    reader.useDoc({ type: "test", id: docId, createIfMissing: true }),
+  );
+
+  await expect
+    .poll(
+      () => {
+        const current = readerResult.current;
+        if (current.status !== "success" || current.fetchStatus !== "idle")
+          return -1;
+
+        return countChildren(current.data.doc);
+      },
+      { interval: 20, timeout: 2000 },
+    )
+    .toBe(1);
+
+  if (readerResult.current.status !== "success") {
+    throw new Error("Expected reader doc result");
+  }
+
+  readerClient.disconnect();
+  readerClient["_bcHelper"]?.close();
+}, 5000);

--- a/tests/docsync-react/utils.ts
+++ b/tests/docsync-react/utils.ts
@@ -1,8 +1,13 @@
-import type { DocConfig } from "@docukit/docnode";
+import { defineNode, string, type DocConfig } from "@docukit/docnode";
+
+export const ChildNode = defineNode({
+  type: "child",
+  state: { value: string("") },
+});
 
 export const docConfig: DocConfig = {
   type: "test",
-  extensions: [{ nodes: [{ type: "test", state: {} }] }],
+  extensions: [{ nodes: [ChildNode] }],
 };
 
 export const id = {

--- a/tests/docsync/int/index.browser.test.ts
+++ b/tests/docsync/int/index.browser.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { emptyIDB, testWrapper } from "./utils.js";
+import { emptyIDB, testWrapper, waitForLocalBroadcast } from "./utils.js";
 
 describe("Local-First", () => {
   test("cannot load doc twice", async () => {
@@ -130,6 +130,7 @@ describe("Local-First", () => {
       otherTab.doc?.forceCommit();
 
       reference.addChild("Hello");
+      reference.doc?.forceCommit();
       await otherTab.assertMemoryDoc(["Hello"]);
       await reference.assertMemoryDoc(["Hello"]);
 
@@ -146,6 +147,7 @@ describe("Local-First", () => {
       otherTab.doc?.forceCommit();
 
       reference.addChildSkippingUndo("Hello");
+      await waitForLocalBroadcast();
 
       await reference.assertMemoryDoc(["Hello"]);
       await otherTab.assertMemoryDoc(["Hello"]);

--- a/tests/docsync/int/index.browser.test.ts
+++ b/tests/docsync/int/index.browser.test.ts
@@ -111,6 +111,7 @@ describe("Local-First", () => {
       await otherTab.assertMemoryDoc([]);
       await otherDevice.assertMemoryDoc([]);
       await reference.assertIDBDoc({ doc: [], ops: [] });
+      await waitForLocalBroadcast();
       await otherTab.assertMemoryDoc(["Hello"]);
 
       // broadcastChannel then IDB
@@ -131,6 +132,7 @@ describe("Local-First", () => {
 
       reference.addChild("Hello");
       reference.doc?.forceCommit();
+      await waitForLocalBroadcast();
       await otherTab.assertMemoryDoc(["Hello"]);
       await reference.assertMemoryDoc(["Hello"]);
 

--- a/tests/docsync/int/index.browser.test.ts
+++ b/tests/docsync/int/index.browser.test.ts
@@ -231,10 +231,7 @@ describe("Local-First", () => {
       otherDevice.connect();
       await reference.assertMemoryDoc(["A", "B"]);
       await otherTab.assertMemoryDoc(["A", "B"]);
-      // otherDevice added B locally first, then received A from server
-      // CRDT ordering may differ based on insertion order vs deterministic ID ordering
-      // TODO: find a way to deterministically insert with conflicts
-      await otherDevice.assertMemoryDoc(["B", "A"]);
+      await otherDevice.assertMemoryDoc(["A", "B"]);
 
       await reference.assertIDBDoc({ doc: ["A", "B"], ops: [] });
       await otherTab.assertIDBDoc({ doc: ["A", "B"], ops: [] });
@@ -280,10 +277,7 @@ describe("Local-First", () => {
       otherDevice.connect();
       await reference.assertMemoryDoc(["A", "B", "C"]);
       await otherTab.assertMemoryDoc(["B", "A", "C"]);
-      // otherDevice added B locally first, then received A from server
-      // CRDT ordering may differ based on insertion order vs deterministic ID ordering
-      // TODO: find a way to deterministically insert with conflicts
-      await otherDevice.assertMemoryDoc(["C", "A", "B"]);
+      await otherDevice.assertMemoryDoc(["A", "B", "C"]);
 
       await reference.assertIDBDoc({ doc: ["A", "B", "C"], ops: [] });
       await otherTab.assertIDBDoc({ doc: ["A", "B", "C"], ops: [] });

--- a/tests/docsync/int/utils.ts
+++ b/tests/docsync/int/utils.ts
@@ -24,6 +24,58 @@ import { expect, inject, vi, type Mock } from "vitest";
  * Use sparingly - prefer explicit waitFor conditions when possible.
  */
 const tick = (ms = 3) => new Promise((resolve) => setTimeout(resolve, ms));
+const animationFrame = () =>
+  new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+const testBroadcastChannels = new Map<string, Set<TestBroadcastChannel>>();
+
+class TestBroadcastChannel extends EventTarget implements BroadcastChannel {
+  onmessage: ((this: BroadcastChannel, ev: MessageEvent) => unknown) | null =
+    null;
+  onmessageerror:
+    | ((this: BroadcastChannel, ev: MessageEvent) => unknown)
+    | null = null;
+
+  #closed = false;
+
+  constructor(readonly name: string) {
+    super();
+    const channels = testBroadcastChannels.get(name) ?? new Set();
+    channels.add(this);
+    testBroadcastChannels.set(name, channels);
+  }
+
+  postMessage(message: unknown): void {
+    const channels = testBroadcastChannels.get(this.name);
+    if (!channels) return;
+
+    for (const channel of channels) {
+      if (channel === this) continue;
+      queueMicrotask(() => {
+        if (channel.#closed) return;
+        const event = new MessageEvent("message", { data: message });
+        channel.onmessage?.call(channel, event);
+        channel.dispatchEvent(event);
+      });
+    }
+  }
+
+  close(): void {
+    this.#closed = true;
+    const channels = testBroadcastChannels.get(this.name);
+    if (!channels) return;
+    channels.delete(this);
+    if (channels.size === 0) {
+      testBroadcastChannels.delete(this.name);
+    }
+  }
+}
+
+const testBroadcastChannel: typeof BroadcastChannel = TestBroadcastChannel;
+
+export const waitForLocalBroadcast = async (): Promise<void> => {
+  await animationFrame();
+  await animationFrame();
+};
 
 // ============================================================================
 // Constants
@@ -66,11 +118,10 @@ const createDocBinding = () => DocNodeBinding([testDocConfig]);
 // Generators
 // ============================================================================
 
+const runId = crypto.randomUUID();
 let clientCounter = 0;
-let testCounter = 0; // Add test counter for isolation
 
-const generateUserId = () =>
-  `integration-user-${Date.now()}-test${++testCounter}-${++clientCounter}`;
+const generateUserId = () => `integration-user-${runId}-${++clientCounter}`;
 
 const generateDocId = () => ulid().toLowerCase();
 
@@ -171,10 +222,12 @@ export const testWrapper = async (
  */
 const createClientWithConfig = (config: {
   userId: string;
+  deviceId: string;
   token: string;
   docBinding: ReturnType<typeof createDocBinding>;
 }): DocSyncClient<Doc, JsonDoc, Operations> => {
   localStorage.setItem("docsync:localUserId", config.userId);
+  localStorage.setItem("docsync:deviceId", config.deviceId);
 
   const clientConfig: ClientConfig<Doc, JsonDoc, Operations> = {
     server: {
@@ -186,7 +239,13 @@ const createClientWithConfig = (config: {
     local: { provider: indexedDBProvider },
   };
 
-  return new DocSyncClient(clientConfig);
+  const currentBroadcastChannel = globalThis.BroadcastChannel;
+  globalThis.BroadcastChannel = testBroadcastChannel;
+  try {
+    return new DocSyncClient(clientConfig);
+  } finally {
+    globalThis.BroadcastChannel = currentBroadcastChannel;
+  }
 };
 
 // ============================================================================
@@ -199,8 +258,10 @@ const setupClients = async (): Promise<ClientsSetup> => {
 
   // Reference: local + RT + BC enabled (userId1)
   const referenceUserId = generateUserId();
+  const referenceDeviceId = crypto.randomUUID();
   const referenceClient = createClientWithConfig({
     userId: referenceUserId,
+    deviceId: referenceDeviceId,
     token: createTestToken(referenceUserId),
     docBinding,
   });
@@ -208,20 +269,17 @@ const setupClients = async (): Promise<ClientsSetup> => {
   // OtherTab: local + RT + BC enabled (same userId1 as reference)
   const otherTabClient = createClientWithConfig({
     userId: referenceUserId, // Same user for broadcast channel and IDB sharing
+    deviceId: referenceDeviceId,
     token: createTestToken(referenceUserId),
     docBinding,
   });
 
   // OtherDevice: local enabled with different userId2, RT enabled, BC disabled
   const otherDeviceUserId = generateUserId();
-  // Wait for reference and otherTab sockets to connect before creating otherDevice
-  // This ensures they get their deviceId before we change it
-  await new Promise((resolve) => setTimeout(resolve, 40));
-  // Force a different deviceId for otherDevice to simulate a different physical device
-  const newDeviceId = crypto.randomUUID();
-  localStorage.setItem("docsync:deviceId", newDeviceId);
+  const otherDeviceId = crypto.randomUUID();
   const otherDeviceClient = createClientWithConfig({
     userId: otherDeviceUserId, // Different user = different IDB + BC namespace
+    deviceId: otherDeviceId,
     token: createTestToken(otherDeviceUserId),
     docBinding,
   });

--- a/tests/docsync/ui/editor/utils.ts
+++ b/tests/docsync/ui/editor/utils.ts
@@ -772,12 +772,14 @@ export async function createEditorPair(page: Page, context: BrowserContext) {
 }
 
 async function waitForEditorReady(page: Page) {
-  const reference = page.locator("#reference").first();
-  await reference.waitFor({ state: "visible" });
-  await reference
-    .locator("[data-lexical-editor] p")
-    .first()
-    .waitFor({ state: "visible" });
+  for (const selector of ["#reference", "#otherTab", "#otherDevice"]) {
+    const editor = page.locator(selector).first();
+    await editor.waitFor({ state: "visible" });
+    await editor
+      .locator("[data-lexical-editor] p")
+      .first()
+      .waitFor({ state: "visible" });
+  }
 }
 
 export function collapsed(offset: number): SelectionExpectation {

--- a/tests/docsync/unit/client/events.browser.test.ts
+++ b/tests/docsync/unit/client/events.browser.test.ts
@@ -16,6 +16,7 @@ import {
   emptyOps,
   spyOnRequest,
   triggerSync,
+  s,
 } from "../client2/utils.js";
 
 describe("Client Events", () => {
@@ -112,7 +113,7 @@ describe("Client Events", () => {
       const testOps = [emptyOps()];
       await saveOperations(client, docId, testOps);
 
-      spyOnRequest(client).mockResolvedValue({ data: { docId, clock: 1 } });
+      spyOnRequest(client).mockResolvedValue({ data: s({ docId, clock: 1 }) });
 
       let syncSuccess = false;
       client.on("sync", (event) => {

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -1324,6 +1324,59 @@ describe("DocSyncClient", () => {
         expect(stored?.serializedDoc).toStrictEqual(serverDoc.serializedDoc);
       });
 
+      test("createIfMissing true should invalidate the optimistic doc after reconciling with a server snapshot", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const serverDoc = createDocWithChild(client);
+
+        socketMockState.syncResponses.set(serverDoc.docId, {
+          data: {
+            docId: serverDoc.docId,
+            operations: [],
+            serializedDoc: serverDoc.serializedDoc,
+            clock: 0,
+          },
+        });
+
+        client.getDoc(
+          { type: "test", id: serverDoc.docId, createIfMissing: true },
+          callback,
+        );
+
+        await expect
+          .poll(() =>
+            callback.mock.calls.find(
+              ([result]) =>
+                result.status === "success" &&
+                result.fetchStatus === "fetching",
+            ),
+          )
+          .toBeDefined();
+
+        const optimisticResult = callback.mock.calls.find(
+          ([result]) =>
+            result.status === "success" && result.fetchStatus === "fetching",
+        )?.[0];
+        if (
+          optimisticResult?.status !== "success" ||
+          optimisticResult.data === undefined
+        ) {
+          throw new Error("Expected optimistic doc result");
+        }
+        const optimisticDoc = optimisticResult.data.doc;
+
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        await Promise.resolve();
+
+        expect(() => {
+          const child = optimisticDoc.createNode(ChildNode);
+          optimisticDoc.root.append(child);
+        }).toThrow();
+      });
+
       test("should emit local success while network fetch is still active", async () => {
         const client = createClient();
         const callback = createCallback();

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -299,6 +299,7 @@ describe("DocSyncClient", () => {
     client["_docsCache"].set(docId, {
       promisedDoc: Promise.resolve(doc),
       refCount: 1,
+      localVersion: 0,
       type: "test",
       queryResult: {
         status: "success",

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -44,6 +44,7 @@ type MockIdentityPayload = { userId: string };
 const socketMockState = vi.hoisted(() => ({
   autoIdentity: true,
   identityPayload: undefined as MockIdentityPayload | undefined,
+  syncResponses: new Map<string, unknown>(),
 }));
 
 // Mock socket.io-client to avoid real connections
@@ -81,8 +82,21 @@ const ioMock = vi.hoisted(() =>
               "docId" in _payload &&
               "clock" in _payload
             ) {
+              const docId = _payload.docId;
+              const clock = _payload.clock;
+              if (typeof docId !== "string" || typeof clock !== "number") {
+                callback({ data: undefined, success: true });
+                return;
+              }
+
+              const mockedResponse = socketMockState.syncResponses.get(docId);
+              if (mockedResponse !== undefined) {
+                callback(mockedResponse);
+                return;
+              }
+
               callback({
-                data: { docId: _payload.docId, clock: _payload.clock },
+                data: { docId, operations: [], serializedDoc: null, clock },
               });
               return;
             }
@@ -106,6 +120,7 @@ describe("DocSyncClient", () => {
     ioMock.mockClear();
     socketMockState.autoIdentity = true;
     socketMockState.identityPayload = undefined;
+    socketMockState.syncResponses.clear();
     clearCachedLocalIdentity();
   });
 
@@ -1053,6 +1068,18 @@ describe("DocSyncClient", () => {
   // ──────────────────────────────────────────────────────────────────────────
 
   describe("getDoc", () => {
+    const createDocWithChild = (client: ReturnType<typeof createClient>) => {
+      const docId = ulid().toLowerCase();
+      const { doc } = client["_docBinding"].create("test", docId);
+      doc.root.append(doc.createNode(ChildNode));
+      doc.forceCommit();
+      return {
+        docId,
+        doc,
+        serializedDoc: client["_docBinding"].serialize(doc),
+      };
+    };
+
     describe("Get existing document", () => {
       test("should emit pending status initially", () => {
         const client = createClient();
@@ -1074,6 +1101,44 @@ describe("DocSyncClient", () => {
         await expect
           .poll(() => callback.mock.calls.at(-1)?.[0])
           .toEqual({ status: "success", fetchStatus: "idle", data: undefined });
+      });
+
+      test("should load a server-only document when createIfMissing is false", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const serverDoc = createDocWithChild(client);
+
+        socketMockState.syncResponses.set(serverDoc.docId, {
+          data: {
+            docId: serverDoc.docId,
+            operations: [],
+            serializedDoc: serverDoc.serializedDoc,
+            clock: 0,
+          },
+        });
+
+        client.getDoc(
+          { type: "test", id: serverDoc.docId, createIfMissing: false },
+          callback,
+        );
+
+        await expect
+          .poll(() => {
+            const latest = callback.mock.calls.at(-1)?.[0];
+            return latest?.status === "success" && latest.data
+              ? latest.data.doc.toJSON()
+              : undefined;
+          })
+          .toStrictEqual(serverDoc.doc.toJSON());
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        const { provider } = await client["_localPromise"];
+        const stored = await provider.transaction("readonly", (ctx) =>
+          ctx.getSerializedDoc({ docId: serverDoc.docId }),
+        );
+        expect(stored?.serializedDoc).toStrictEqual(serverDoc.serializedDoc);
       });
 
       test("should return cached document when requested multiple times", async () => {
@@ -1185,6 +1250,78 @@ describe("DocSyncClient", () => {
 
         const cacheEntry = client["_docsCache"].get(customId);
         expect(cacheEntry?.refCount).toBe(2);
+      });
+
+      test("createIfMissing true should send the optimistic local snapshot to sync", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const customId = ulid().toLowerCase();
+
+        client.getDoc(
+          { type: "test", id: customId, createIfMissing: true },
+          callback,
+        );
+
+        await expect.poll(() => getSuccessData(callback)).toBeDefined();
+        const emitMock = getSocketEmitMock(client);
+        await expect
+          .poll(() =>
+            emitMock.mock.calls.some(
+              ([event, payload]) =>
+                event === "sync" &&
+                typeof payload === "object" &&
+                payload !== null &&
+                "serializedDoc" in payload,
+            ),
+          )
+          .toBe(true);
+      });
+
+      test("createIfMissing true should reconcile with an existing server snapshot", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const serverDoc = createDocWithChild(client);
+
+        socketMockState.syncResponses.set(serverDoc.docId, {
+          data: {
+            docId: serverDoc.docId,
+            operations: [],
+            serializedDoc: serverDoc.serializedDoc,
+            clock: 0,
+          },
+        });
+
+        client.getDoc(
+          { type: "test", id: serverDoc.docId, createIfMissing: true },
+          callback,
+        );
+
+        await expect
+          .poll(() =>
+            callback.mock.calls.some(
+              ([result]) =>
+                result.status === "success" &&
+                result.fetchStatus === "fetching",
+            ),
+          )
+          .toBe(true);
+        await expect
+          .poll(() => {
+            const latest = callback.mock.calls.at(-1)?.[0];
+            return latest?.status === "success" && latest.data
+              ? latest.data.doc.toJSON()
+              : undefined;
+          })
+          .toStrictEqual(serverDoc.doc.toJSON());
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        const { provider } = await client["_localPromise"];
+        const stored = await provider.transaction("readonly", (ctx) =>
+          ctx.getSerializedDoc({ docId: serverDoc.docId }),
+        );
+        expect(stored?.serializedDoc).toStrictEqual(serverDoc.serializedDoc);
       });
 
       test("should emit local success while network fetch is still active", async () => {

--- a/tests/docsync/unit/client2/index.browser.test.ts
+++ b/tests/docsync/unit/client2/index.browser.test.ts
@@ -10,6 +10,7 @@ import {
   ops,
   emptyOps,
   ChildNode,
+  s,
   spyOnRequest,
   triggerSync,
 } from "./utils.js";
@@ -41,9 +42,7 @@ describe("Client 2", () => {
       const docId = generateDocId();
       spyOnRequest(client).mockImplementation(
         () =>
-          new Promise((r) =>
-            setTimeout(() => r({ data: { docId, clock: 1 } }), 50),
-          ),
+          new Promise((r) => setTimeout(() => r({ data: s({ docId }) }), 50)),
       );
 
       await saveOperations(client, docId);
@@ -62,10 +61,7 @@ describe("Client 2", () => {
       spyOnRequest(client).mockImplementation(
         (_event, payload) =>
           new Promise((r) =>
-            setTimeout(
-              () => r({ data: { docId: payload.docId, clock: 1 } }),
-              20,
-            ),
+            setTimeout(() => r({ data: s({ docId: payload.docId }) }), 20),
           ),
       );
 
@@ -91,9 +87,7 @@ describe("Client 2", () => {
       const requestSpy = spyOnRequest(client);
       requestSpy.mockImplementation(
         () =>
-          new Promise((r) =>
-            setTimeout(() => r({ data: { docId, clock: 1 } }), 50),
-          ),
+          new Promise((r) => setTimeout(() => r({ data: s({ docId }) }), 50)),
       );
 
       await saveOperations(client, docId);
@@ -113,7 +107,7 @@ describe("Client 2", () => {
       const requestSpy = spyOnRequest(client);
       requestSpy.mockImplementation(() => {
         callCount++;
-        return Promise.resolve({ data: { docId, clock: callCount } });
+        return Promise.resolve({ data: s({ docId, clock: callCount }) });
       });
 
       await setupDocWithOperations(client, docId);
@@ -155,12 +149,15 @@ describe("Client 2", () => {
 
       triggerSync(client, docId);
       await expect.poll(() => requestSpy.mock.calls.length).toBeGreaterThan(0);
-      expect(requestSpy).toHaveBeenCalledWith("sync", {
-        type: "test",
-        clock: 0,
-        docId,
-        operations: testOperations,
-      });
+      expect(requestSpy).toHaveBeenCalledWith(
+        "sync",
+        expect.objectContaining({
+          type: "test",
+          clock: 0,
+          docId,
+          operations: testOperations,
+        }),
+      );
     });
 
     test("should set status to pushing at start", async () => {
@@ -170,7 +167,7 @@ describe("Client 2", () => {
       // eslint-disable-next-line @typescript-eslint/require-await -- sync mock of async interface
       spyOnRequest(client).mockImplementation(async () => {
         statusDuringPush = client["_pushStatusByDocId"].get(docId);
-        return { data: { docId, clock: 1 } };
+        return { data: s({ docId }) };
       });
 
       await setupDocWithOperations(client, docId);
@@ -215,7 +212,7 @@ describe("Client 2", () => {
     test("should handle client sends operations + server returns no operations", async () => {
       const client = await createClient();
       const requestSpy = spyOnRequest(client);
-      requestSpy.mockResolvedValue({ data: { docId: "test-doc", clock: 1 } });
+      requestSpy.mockResolvedValue({ data: s() });
       const docId = generateDocId();
 
       await setupDocWithOperations(client, docId, {
@@ -244,12 +241,7 @@ describe("Client 2", () => {
       // Mock API to return server operations
       const requestSpy = spyOnRequest(client);
       requestSpy.mockResolvedValue({
-        data: {
-          docId,
-          operations: serverOperations,
-          serializedDoc: null,
-          clock: 1,
-        },
+        data: s({ docId, operations: serverOperations }),
       });
 
       await setupDocWithOperations(client, docId, {
@@ -271,7 +263,7 @@ describe("Client 2", () => {
     test("should handle client sends no operations + server returns no operations (pull with no updates)", async () => {
       const client = await createClient();
       const requestSpy = spyOnRequest(client);
-      requestSpy.mockResolvedValue({ data: { docId: "test-doc", clock: 1 } });
+      requestSpy.mockResolvedValue({ data: s() });
       const docId = generateDocId();
 
       // Setup a document without pending operations (pure pull scenario)
@@ -322,12 +314,7 @@ describe("Client 2", () => {
       // Mock API to return server operations
       const requestSpy = spyOnRequest(client);
       requestSpy.mockResolvedValue({
-        data: {
-          docId,
-          operations: serverOperations,
-          serializedDoc: null,
-          clock: 1,
-        },
+        data: s({ docId, operations: serverOperations }),
       });
 
       // Setup a document without pending operations (pure pull scenario)
@@ -375,7 +362,7 @@ describe("Client 2", () => {
     test("should delete operations after successful push", async () => {
       const client = await createClient();
       const docId = generateDocId();
-      spyOnRequest(client).mockResolvedValue({ data: { docId, clock: 1 } });
+      spyOnRequest(client).mockResolvedValue({ data: s({ docId }) });
 
       await setupDocWithOperations(client, docId, {
         operations: [emptyOps(), emptyOps()],
@@ -396,7 +383,7 @@ describe("Client 2", () => {
       requestSpy.mockImplementation(
         () =>
           new Promise((resolve) =>
-            setTimeout(() => resolve({ data: { docId, clock: 1 } }), 30),
+            setTimeout(() => resolve({ data: s({ docId }) }), 30),
           ),
       );
 
@@ -417,7 +404,7 @@ describe("Client 2", () => {
     test("should consolidate operations into serialized doc after push", async () => {
       const client = await createClient();
       const docId = generateDocId();
-      spyOnRequest(client).mockResolvedValue({ data: { docId, clock: 1 } });
+      spyOnRequest(client).mockResolvedValue({ data: s({ docId }) });
 
       const docBinding = client["_docBinding"];
       const provider = (await client["_localPromise"]).provider;
@@ -444,7 +431,7 @@ describe("Client 2", () => {
     test("should increment clock after consolidation", async () => {
       const client = await createClient();
       const docId = generateDocId();
-      spyOnRequest(client).mockResolvedValue({ data: { docId, clock: 6 } });
+      spyOnRequest(client).mockResolvedValue({ data: s({ docId, clock: 6 }) });
 
       await setupDocWithOperations(client, docId, { clock: 5 });
       triggerSync(client, docId);
@@ -456,7 +443,7 @@ describe("Client 2", () => {
     test("should set status to idle after successful push", async () => {
       const client = await createClient();
       const docId = generateDocId();
-      spyOnRequest(client).mockResolvedValue({ data: { docId, clock: 1 } });
+      spyOnRequest(client).mockResolvedValue({ data: s({ docId }) });
 
       await setupDocWithOperations(client, docId);
       triggerSync(client, docId);
@@ -478,7 +465,7 @@ describe("Client 2", () => {
       requestSpy.mockImplementation(
         () =>
           new Promise((resolve) =>
-            setTimeout(() => resolve({ data: { docId, clock: 1 } }), 20),
+            setTimeout(() => resolve({ data: s({ docId }) }), 20),
           ),
       );
 
@@ -498,9 +485,7 @@ describe("Client 2", () => {
       requestSpy.mockImplementation(() => {
         callCount++;
         if (callCount === 1) return Promise.reject(new Error("Network error"));
-        return Promise.resolve({
-          data: { docId, operations: [], serializedDoc: null, clock: 1 },
-        });
+        return Promise.resolve({ data: s({ docId }) });
       });
 
       await setupDocWithOperations(client, docId);
@@ -520,9 +505,7 @@ describe("Client 2", () => {
         statusHistory.push(client["_pushStatusByDocId"].get(docId));
         if (statusHistory.length === 1)
           return Promise.reject(new Error("Network error"));
-        return Promise.resolve({
-          data: { docId, operations: [], serializedDoc: null, clock: 1 },
-        });
+        return Promise.resolve({ data: s({ docId }) });
       });
 
       await setupDocWithOperations(client, docId);
@@ -542,7 +525,7 @@ describe("Client 2", () => {
           receivedOperations.push(payload.operations);
         }
         return Promise.resolve({
-          data: { docId, clock: receivedOperations.length },
+          data: s({ docId, clock: receivedOperations.length }),
         });
       });
 
@@ -574,7 +557,7 @@ describe("Client 2", () => {
         maxConcurrent = Math.max(maxConcurrent, concurrentCalls);
         await tick();
         concurrentCalls--;
-        return { data: { docId, clock: 1 } };
+        return { data: s({ docId }) };
       });
 
       await setupDocWithOperations(client, docId);
@@ -592,7 +575,7 @@ describe("Client 2", () => {
       requestSpy.mockImplementation(
         () =>
           new Promise((resolve) =>
-            setTimeout(() => resolve({ data: { docId, clock: 1 } }), 30),
+            setTimeout(() => resolve({ data: s({ docId }) }), 30),
           ),
       );
 
@@ -622,7 +605,7 @@ describe("Client 2", () => {
       requestSpy.mockImplementation(async (_event, payload) => {
         callOrder.push(payload.docId);
         await tick();
-        return { data: { docId: payload.docId, clock: 1 } };
+        return { data: s({ docId: payload.docId }) };
       });
 
       for (const docId of [docId1, docId2]) {
@@ -644,7 +627,7 @@ describe("Client 2", () => {
       spyOnRequest(client).mockImplementation(
         () =>
           new Promise((resolve) =>
-            setTimeout(() => resolve({ data: { docId, clock: 1 } }), 20),
+            setTimeout(() => resolve({ data: s({ docId }) }), 20),
           ),
       );
 

--- a/tests/docsync/unit/client2/utils.ts
+++ b/tests/docsync/unit/client2/utils.ts
@@ -203,6 +203,7 @@ export const triggerSync = (
     client["_docsCache"].set(docId, {
       promisedDoc: Promise.resolve(doc),
       refCount: 1,
+      localVersion: 0,
       type: "test",
       queryResult: {
         status: "success",

--- a/tests/docsync/unit/client2/utils.ts
+++ b/tests/docsync/unit/client2/utils.ts
@@ -93,6 +93,25 @@ export const tick = (ms = 3) =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
 // ============================================================================
+// Sync Payload Helpers
+// ============================================================================
+
+type SyncPayload = {
+  docId: string;
+  operations: Operations[];
+  serializedDoc: JsonDoc | null;
+  clock: number;
+};
+
+export const s = (payload: Partial<SyncPayload> = {}): SyncPayload => ({
+  docId: "test-doc",
+  operations: [],
+  serializedDoc: null,
+  clock: 1,
+  ...payload,
+});
+
+// ============================================================================
 // Doc Setup Helper
 // ============================================================================
 

--- a/tests/docsync/unit/server/events.test.ts
+++ b/tests/docsync/unit/server/events.test.ts
@@ -393,7 +393,12 @@ describe("Server Events", () => {
           deviceId: expect.any(String) as string,
           clientId: expect.any(String) as string,
           status: "success",
-          req: { docId: "doc-1", operations: [operation], clock: 0 },
+          req: {
+            docId: "doc-1",
+            operations: [operation],
+            serializedDoc: null,
+            clock: 0,
+          },
           durationMs: expect.any(Number) as number,
           clientsCount: expect.any(Number) as number,
           devicesCount: expect.any(Number) as number,
@@ -452,6 +457,7 @@ describe("Server Events", () => {
           type: "test",
           docId: "test-doc",
           operations: [operation],
+          serializedDoc: null,
           clock: 5,
         });
       });

--- a/tests/docsync/unit/server/index.test.ts
+++ b/tests/docsync/unit/server/index.test.ts
@@ -14,6 +14,7 @@ import { DocNodeBinding } from "@docukit/docsync/docnode";
 import { DocSyncClient } from "@docukit/docsync/client";
 import type { ClientAuthConfig } from "@docukit/docsync/client";
 import type { Doc, JsonDoc, Operations } from "@docukit/docnode";
+import { testDocConfig } from "../../int/utils.js";
 
 describe("authentication", () => {
   test("rejects when credentials do not resolve an identity", async () => {
@@ -194,14 +195,14 @@ describe("collaboration", () => {
     await new Promise((resolve) =>
       socket1.emit(
         "sync",
-        { type: "test", docId, operations: [], clock: 0 },
+        { type: "test", docId, operations: [], serializedDoc: null, clock: 0 },
         resolve,
       ),
     );
     await new Promise((resolve) =>
       socketSameUser.emit(
         "sync",
-        { type: "test", docId, operations: [], clock: 0 },
+        { type: "test", docId, operations: [], serializedDoc: null, clock: 0 },
         resolve,
       ),
     );
@@ -218,7 +219,7 @@ describe("collaboration", () => {
     await new Promise((resolve) =>
       socket2.emit(
         "sync",
-        { type: "test", docId, operations: [], clock: 0 },
+        { type: "test", docId, operations: [], serializedDoc: null, clock: 0 },
         resolve,
       ),
     );
@@ -313,14 +314,26 @@ describe("presence", () => {
       new Promise((resolve) =>
         socket1.emit(
           "sync",
-          { type: "test", docId, operations: [], clock: 0 },
+          {
+            type: "test",
+            docId,
+            operations: [],
+            serializedDoc: null,
+            clock: 0,
+          },
           resolve,
         ),
       ),
       new Promise((resolve) =>
         socket2.emit(
           "sync",
-          { type: "test", docId, operations: [], clock: 0 },
+          {
+            type: "test",
+            docId,
+            operations: [],
+            serializedDoc: null,
+            clock: 0,
+          },
           resolve,
         ),
       ),
@@ -426,7 +439,7 @@ describe("presence", () => {
     await new Promise((resolve) => {
       socket1.emit(
         "sync",
-        { type: "test", docId, operations: [], clock: 0 },
+        { type: "test", docId, operations: [], serializedDoc: null, clock: 0 },
         resolve,
       );
     });
@@ -496,6 +509,34 @@ describe("sync", () => {
     });
   });
 
+  test("saves a client snapshot when the server document is missing", async () => {
+    const auth: ClientAuthConfig = {
+      mode: "token",
+      getToken: () => "valid-user1",
+    };
+    await testWrapper({ auth }, async (T) => {
+      await T.waitForConnect();
+
+      const docId = "01kfpgjsabrpdcw0qgh5evhy2h";
+      const docBinding = DocNodeBinding([testDocConfig]);
+      const childNodeDef = testDocConfig.extensions[0]?.nodes?.[0];
+      if (!childNodeDef) throw new Error("Missing child node definition");
+
+      const { doc } = docBinding.create("test", docId);
+      doc.root.append(doc.createNode(childNodeDef));
+      const serializedDoc = docBinding.serialize(doc);
+
+      const saveRes = await T.sync({ docId, serializedDoc, clock: 0 });
+      expect("error" in saveRes).toBe(false);
+
+      const loadRes = await T.sync({ docId, clock: 0 });
+      expect("error" in loadRes).toBe(false);
+      if ("data" in loadRes) {
+        expect(loadRes.data.serializedDoc).toStrictEqual(serializedDoc);
+      }
+    });
+  });
+
   test("squashes operations after threshold", async () => {
     const auth: ClientAuthConfig = {
       mode: "token",
@@ -541,6 +582,15 @@ describe("sync", () => {
         expect(res2.data.clock).toBe(100);
         expect(res2.data.serializedDoc).toBeDefined();
         expect(res2.data.operations).toStrictEqual([]);
+      }
+
+      const res3 = await T.sync({ docId, clock: 0 });
+
+      expect("error" in res3).toBe(false);
+      if ("data" in res3) {
+        expect(res3.data.clock).toBe(100);
+        expect(res3.data.serializedDoc).toBeDefined();
+        expect(res3.data.operations).toStrictEqual([]);
       }
     });
   });

--- a/tests/docsync/unit/server/index.test.ts
+++ b/tests/docsync/unit/server/index.test.ts
@@ -537,6 +537,44 @@ describe("sync", () => {
     });
   });
 
+  test("does not return a server snapshot when the client has a same-clock snapshot", async () => {
+    const auth: ClientAuthConfig = {
+      mode: "token",
+      getToken: () => "valid-user1",
+    };
+    await testWrapper({ auth }, async (T) => {
+      await T.waitForConnect();
+
+      const docId = "01kfpgjsabrpdcw0qgh5evhy2j";
+      const docBinding = DocNodeBinding([testDocConfig]);
+      const { doc } = docBinding.create("test", docId);
+      const serializedDoc = docBinding.serialize(doc);
+
+      const saveRes = await T.sync({ docId, serializedDoc, clock: 0 });
+      expect("error" in saveRes).toBe(false);
+
+      const sameClockRes = await T.sync({ docId, serializedDoc, clock: 0 });
+      expect("error" in sameClockRes).toBe(false);
+      if ("data" in sameClockRes) {
+        expect(sameClockRes.data.serializedDoc).toBe(null);
+        expect(sameClockRes.data.operations).toStrictEqual([]);
+        expect(sameClockRes.data.clock).toBe(0);
+      }
+
+      const noLocalSnapshotRes = await T.sync({
+        docId,
+        serializedDoc: null,
+        clock: 0,
+      });
+      expect("error" in noLocalSnapshotRes).toBe(false);
+      if ("data" in noLocalSnapshotRes) {
+        expect(noLocalSnapshotRes.data.serializedDoc).toStrictEqual(
+          serializedDoc,
+        );
+      }
+    });
+  });
+
   test("squashes operations after threshold", async () => {
     const auth: ClientAuthConfig = {
       mode: "token",

--- a/tests/docsync/unit/server/utils.ts
+++ b/tests/docsync/unit/server/utils.ts
@@ -122,11 +122,7 @@ export async function testWrapper(
     });
   const sync = (payload: SyncPayloadInput) =>
     new Promise<SyncResponse>((resolve) => {
-      socket.emit(
-        "sync",
-        { type: "test", operations: [], clock: 0, ...payload },
-        resolve,
-      );
+      socket.emit("sync", s(payload), resolve);
     });
 
   await fn({ server, client, waitForConnect, waitForError, socket, sync });
@@ -137,10 +133,10 @@ type SyncPayload = {
   type: string;
   docId: string;
   operations: Operations[];
+  serializedDoc: JsonDoc | null;
   clock: number;
 };
-type SyncPayloadInput = Pick<SyncPayload, "docId"> &
-  Partial<Omit<SyncPayload, "docId">>;
+type SyncPayloadInput = Partial<SyncPayload>;
 type SyncResponse =
   | {
       data: {
@@ -156,6 +152,15 @@ type SyncResponse =
         message: string;
       };
     };
+
+export const s = (payload: SyncPayloadInput = {}): SyncPayload => ({
+  type: "test",
+  docId: "test-doc",
+  operations: [],
+  serializedDoc: null,
+  clock: 0,
+  ...payload,
+});
 
 export function createTestOperation(): Operations {
   const doc = new Doc(testDocConfig);


### PR DESCRIPTION
## Summary

This PR fixes two separate DocSync loading/sync problems in the original `@docukit/docsync` client.

1. Local IndexedDB state was being treated as if the network load had finished.
2. Client/server snapshot reconciliation did not have enough information to safely handle server-seeded documents, optimistic local documents, and in-flight local edits.

The fixes are related because both happen during `getDoc`/`sync`, but they are different bugs.

## Problem 1: local data was treated as the final network answer

DocSync has two sources of truth during load:

- IndexedDB: a local cache that can make the document usable quickly.
- Server: the remote source that tells us whether the document already exists elsewhere.

Before this PR, the client could stop too early after reading IndexedDB. In simplified form:

```ts
const localDoc = await loadFromIndexedDB(docId);

if (!localDoc) {
  emit({ status: "success", fetchStatus: "idle", data: undefined });
  return;
}

emit({ status: "success", fetchStatus: "fetching", data: localDoc });
syncWithServer(docId);
```

That created two bad cases:

- A document that existed only on the server could look missing forever, because the client stopped after the local miss.
- A `createIfMissing: true` document could be usable locally, but the UI could not clearly tell that the server check was still in progress.

The new model keeps local load and network load separate:

```ts
const localDoc = await loadOrCreateLocalDoc(docId);

if (localDoc) {
  emit({
    status: "success",
    fetchStatus: connected ? "fetching" : "paused",
    data: localDoc,
  });
}

if (connected) {
  syncWithServer(docId);
}
```

So a local document can be rendered immediately, but `fetchStatus` keeps telling the truth:

- `fetching`: the local doc is usable, but the server result has not finished.
- `paused`: the local doc is usable, but the client is offline.
- `idle`: the server result has been processed.

Connection and disconnection now update that fetch state through the query reducer helpers.

## Problem 2: snapshots could not be reconciled safely

The old sync flow mostly sent operations and a clock:

```ts
client -> server: { docId, clock, operations }
server -> client: { serializedDoc, operations, clock }
```

That was not enough for the hard cases:

- The server may already have a real snapshot while this client only has an optimistic empty document at the same clock.
- The server may be missing the document, and the client needs to upload its initial local snapshot.
- A sync response can come back after the in-memory document changed again.
- A stale server snapshot must not overwrite newer local memory.

This PR makes the sync request snapshot-aware:

```ts
client -> server: {
  docId,
  clock,
  operations,
  serializedDoc: localSnapshotOrNull,
}
```

The server can now do the right thing in both directions:

```ts
if (!serverDoc && clientSerializedDoc) {
  saveClientSnapshot();
}

if (serverDoc && clientNeedsSnapshot) {
  returnServerSnapshot();
}
```

On the client, sync responses are reconciled in layers instead of blindly replacing the live document:

```ts
const base = response.serializedDoc ?? stored.serializedDoc;
const confirmedDoc = deserialize(base);

apply(confirmedDoc, response.operations, { skipUndo: true });
apply(confirmedDoc, localOperationsSentInThisSync);

saveSnapshot(confirmedDoc, response.clock);
deleteOnlyTheSentOperationBatches();
```

Then, before replacing the live cached document, the client reapplies operations that appeared while the request was in flight:

```ts
const replacementDoc = confirmedDoc;

apply(replacementDoc, pendingProviderOperations);
apply(replacementDoc, pendingMemoryOperations);

replaceDocInCache(replacementDoc);
```

There is also a cheap `localVersion` counter on each cached doc. It is not a server clock and it does not inspect CRDT data. It only answers this question:

```ts
const liveDocChangedWhileRequestWasInFlight =
  currentLocalVersion > requestLocalVersion;
```

If the live document changed in a way the client cannot rebuild from pending operations, the client does not replace it with an older snapshot. If the response has server operations, those operations are applied to the live document instead of dropping them.

## Tests

This PR adds and updates tests for:

- server-only documents loading through `getDoc`;
- `createIfMissing: true` uploading an initial client snapshot when the server is missing the doc;
- an optimistic local document being replaced by the real server snapshot;
- reconnect/disconnect `fetchStatus` transitions;
- React rerendering after the cached doc is replaced;
- sync races where stale responses must not overwrite newer local memory.

Extra flake checks from this workspace:

- `both devices add child -> connect`: passed `100/100` repeated runs.
- `tests/docsync/int/index.browser.test.ts`: passed `20/20` repeated runs.

Final verification from this workspace:

- `pnpm fix`
- `pnpm test:coverage:once`
