### PR TITLE
Allow dynamic createIfMissing in useDoc

### DIFF
--- a/packages/docsync-react/src/index.tsx
+++ b/packages/docsync-react/src/index.tsx
@@ -48,7 +48,7 @@ export function createDocSyncClient<T extends ClientConfig<any, any, any>>(
   function useDoc(args: {
     type: string;
     id: string;
-    createIfMissing?: false;
+    createIfMissing?: boolean;
   }): QueryResult<DocData | undefined>;
   function useDoc(args: GetDocArgs): QueryResult<DocData | undefined> {
     const [result, setResult] = useState<QueryResult<DocData | undefined>>({

--- a/tests/docsync-react/index.browser.test.tsx
+++ b/tests/docsync-react/index.browser.test.tsx
@@ -46,6 +46,14 @@ test("createDocSyncClient", async () => {
   expectTypeOf<ReturnType<typeof useDoc>>().toEqualTypeOf<MaybeDocResult>();
 
   const typeCheck = (hook: typeof useDoc) => {
+    const shouldCreate = Math.random() > 0.5;
+    const dynamicCreateIfMissingResult = hook({
+      type: "test",
+      id: "123",
+      createIfMissing: shouldCreate,
+    });
+    expectTypeOf(dynamicCreateIfMissingResult).toEqualTypeOf<MaybeDocResult>();
+
     // @ts-expect-error - type is required
     hook({ createIfMissing: true, id: "123" });
 


### PR DESCRIPTION
## Summary
- Allow the fallback `useDoc` overload to accept a dynamic boolean for `createIfMissing`.
- Keep the literal `true` overload first, so `createIfMissing: true` still returns non-optional doc data.
- Add a type check for dynamic boolean usage.

## Verification
- `pnpm exec vitest --watch=false --project browser tests/docsync-react/index.browser.test.tsx`
- `pnpm fix`