### PR TITLE
Fix DocSync IDB persistence debounce

### DIFF
--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -106,6 +106,10 @@ export const handleSync = async <
 ): Promise<void> => {
   if (!client["_socket"].connected) return;
 
+  const syncDebounceState = client["_syncDebounceState"].get(docId);
+  clearTimeout(syncDebounceState?.timeout);
+  client["_syncDebounceState"].delete(docId);
+
   const pushStatusByDocId = client["_pushStatusByDocId"];
   const status = pushStatusByDocId.get(docId) ?? "idle";
   if (status !== "idle") {

--- a/packages/docsync/src/client/handlers/connection/connect.ts
+++ b/packages/docsync/src/client/handlers/connection/connect.ts
@@ -11,7 +11,6 @@ export function handleConnect<
     client["_events"].emit("connect");
     void (async () => {
       const syncedDocIds = new Set<string>();
-      // TODO: This is defensive for long debounces; consider debouncing only server sync, not local IDB persistence.
       await Promise.all(
         [...client["_localOpsBatchState"].keys()].map(async (docId) => {
           const didFlush = await client["_flushLocalOperations"](docId, {

--- a/packages/docsync/src/client/handlers/serverInitiated/collaboration.ts
+++ b/packages/docsync/src/client/handlers/serverInitiated/collaboration.ts
@@ -1,5 +1,6 @@
 import type { DocSyncClient } from "../../index.js";
 import { emitCurrentServerPresence } from "../clientInitiated/presence.js";
+import { handleSync } from "../clientInitiated/sync/sync.js";
 
 export function handleCollaboration<
   D extends object = object,
@@ -10,7 +11,12 @@ export function handleCollaboration<
     if (hasCollaborators) {
       client["_collabDocIds"].add(docId);
       emitCurrentServerPresence(client, docId);
-      void client["_flushLocalOperations"](docId);
+      const hadPendingSync = client["_syncDebounceState"].has(docId);
+      void client["_flushLocalOperations"](docId, { sync: false }).then(
+        (didFlush) => {
+          if (didFlush || hadPendingSync) void handleSync(client, docId);
+        },
+      );
     } else {
       client["_collabDocIds"].delete(docId);
     }

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -49,6 +49,11 @@ type LocalOpsBatchState<O extends object> = DeferredState<O[]> & {
   startedAt: number;
 };
 
+type SyncDebounceState = {
+  timeout?: ReturnType<typeof setTimeout>;
+  startedAt: number;
+};
+
 type PushStatus = "idle" | "pushing" | "pushing-with-pending";
 type ChangeOrigin = "local" | "network" | "local-broadcast";
 type LocalLoadMode = "load" | "loadOrCreate";
@@ -64,6 +69,8 @@ type DocCacheEntry<D> = {
   presence: Presence;
   presenceListeners: Set<(presence: Presence) => void>;
 };
+
+const LOCAL_IDB_MAX_DEBOUNCE = 50;
 
 export class DocSyncClient<
   D extends object = object,
@@ -82,6 +89,7 @@ export class DocSyncClient<
 
   // Flow control state (batching, debouncing, push queueing)
   protected _localOpsBatchState = new Map<string, LocalOpsBatchState<O>>();
+  protected _syncDebounceState = new Map<string, SyncDebounceState>();
   protected _collabMaxDebounce: number;
   protected _singleClientMaxDebounce: number;
   protected _collabDocIds = new Set<string>();
@@ -422,6 +430,9 @@ export class DocSyncClient<
       const currentEntry = this._docsCache.get(docId);
       if (currentEntry?.refCount === 0) {
         this._docsCache.delete(docId);
+        const syncState = this._syncDebounceState.get(docId);
+        clearTimeout(syncState?.timeout);
+        this._syncDebounceState.delete(docId);
         const presenceState = this._presenceDebounceState.get(docId);
         clearTimeout(presenceState?.timeout);
         this._presenceDebounceState.delete(docId);
@@ -438,7 +449,7 @@ export class DocSyncClient<
     // Get or create the batch state for this document
     let state = this._localOpsBatchState.get(docId);
     const now = Date.now();
-    const maxDebounce = this._collabDocIds.has(docId)
+    const syncMaxDebounce = this._collabDocIds.has(docId)
       ? this._collabMaxDebounce
       : this._singleClientMaxDebounce;
 
@@ -453,8 +464,34 @@ export class DocSyncClient<
       state.data.push(...operations);
     }
 
+    if (now - state.startedAt >= LOCAL_IDB_MAX_DEBOUNCE) {
+      void this._flushLocalOperations(docId, { sync: false });
+    } else {
+      state.timeout ??= setTimeout(
+        () => {
+          void this._flushLocalOperations(docId, { sync: false });
+        },
+        LOCAL_IDB_MAX_DEBOUNCE - (now - state.startedAt),
+      );
+    }
+
+    this._debounceSync(docId, syncMaxDebounce, now);
+  }
+
+  protected _debounceSync(
+    docId: string,
+    maxDebounce: number,
+    now: number,
+  ): void {
+    let state = this._syncDebounceState.get(docId);
+
+    if (!state) {
+      state = { startedAt: now };
+      this._syncDebounceState.set(docId, state);
+    }
+
     if (maxDebounce === 0 || now - state.startedAt >= maxDebounce) {
-      void this._flushLocalOperations(docId);
+      void handleSync(this, docId);
       return;
     }
 
@@ -462,7 +499,7 @@ export class DocSyncClient<
 
     state.timeout = setTimeout(
       () => {
-        void this._flushLocalOperations(docId);
+        void handleSync(this, docId);
       },
       maxDebounce - (now - state.startedAt),
     );
@@ -476,6 +513,7 @@ export class DocSyncClient<
     if (!currentState) return false;
 
     const opsToSave = currentState.data;
+    clearTimeout(currentState.timeout);
     this._localOpsBatchState.delete(docId);
 
     if (opsToSave.length > 0) {

--- a/tests/docsync/int/index.browser.test.ts
+++ b/tests/docsync/int/index.browser.test.ts
@@ -99,6 +99,49 @@ describe("Local-First", () => {
     });
   });
 
+  test("same-user client syncs operations persisted before server debounce", async () => {
+    await testWrapper(async ({ docId, reference, otherTab, otherDevice }) => {
+      const syncCallCount = (client: typeof reference) =>
+        client.reqSpy.mock.calls.filter(
+          ([event, payload]) => event === "sync" && payload.docId === docId,
+        ).length;
+
+      otherTab.disconnect();
+      otherDevice.disconnect();
+
+      await reference.loadDoc();
+      await reference.assertIDBDoc(emptyIDB);
+      reference.client["_singleClientMaxDebounce"] = 1500;
+      reference.client["_collabMaxDebounce"] = 1500;
+      const referenceSyncCallsBeforeChange = syncCallCount(reference);
+
+      reference.addChild("Hello");
+      await reference.assertMemoryDoc(["Hello"]);
+      await reference.assertIDBDoc({ doc: [], ops: ["Hello"] });
+      expect(syncCallCount(reference)).toBe(referenceSyncCallsBeforeChange);
+
+      reference.disconnect();
+      reference.unLoadDoc();
+
+      const otherTabSyncCallsBeforeLoad = syncCallCount(otherTab);
+      await otherTab.loadDoc();
+      await otherTab.assertMemoryDoc(["Hello"]);
+      await otherTab.assertIDBDoc({ doc: [], ops: ["Hello"] });
+      expect(syncCallCount(otherTab)).toBe(otherTabSyncCallsBeforeLoad);
+
+      otherTab.connect();
+      await otherTab.assertIDBDoc({ doc: ["Hello"], ops: [] });
+      expect(syncCallCount(otherTab)).toBeGreaterThan(
+        otherTabSyncCallsBeforeLoad,
+      );
+
+      otherDevice.connect();
+      await otherDevice.loadDoc();
+      await otherDevice.assertMemoryDoc(["Hello"]);
+      await otherDevice.assertIDBDoc({ doc: ["Hello"], ops: [] });
+    });
+  });
+
   test("load -> add child", async () => {
     await testWrapper(async ({ reference, otherDevice, otherTab }) => {
       await reference.loadDoc();

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -795,7 +795,7 @@ describe("DocSyncClient", () => {
   });
 
   describe("local operations debounce", () => {
-    test("batches collaborative local operation persistence until max debounce", async () => {
+    test("persists collaborative local operations every fixed IDB debounce while server sync waits for collab debounce", async () => {
       vi.useFakeTimers();
 
       try {
@@ -807,13 +807,14 @@ describe("DocSyncClient", () => {
           timing: { collabMaxDebounce: 1000 },
         });
         await client["_localPromise"];
+        cacheDebounceTestDoc(client, "doc-1");
         client["_collabDocIds"].add("doc-1");
 
         client.onLocalOperations({
           docId: "doc-1",
           operations: [{ value: "A" }],
         });
-        await vi.advanceTimersByTimeAsync(999);
+        await vi.advanceTimersByTimeAsync(49);
         expect(saveOperations).not.toHaveBeenCalled();
 
         client.onLocalOperations({
@@ -828,13 +829,37 @@ describe("DocSyncClient", () => {
           docId: "doc-1",
           operations: [{ value: "A" }, { value: "B" }],
         });
+
+        const emitMock = getSocketEmitMock(client);
+        expect(emitMock).not.toHaveBeenCalledWith(
+          "sync",
+          expect.objectContaining({ docId: "doc-1" }),
+          expect.any(Function),
+        );
+
+        await vi.advanceTimersByTimeAsync(949);
+        await flushMicrotasks();
+        expect(emitMock).not.toHaveBeenCalledWith(
+          "sync",
+          expect.objectContaining({ docId: "doc-1" }),
+          expect.any(Function),
+        );
+
+        await vi.advanceTimersByTimeAsync(1);
+        await flushMicrotasks();
+
+        expect(emitMock).toHaveBeenCalledWith(
+          "sync",
+          expect.objectContaining({ docId: "doc-1" }),
+          expect.any(Function),
+        );
         client.disconnect();
       } finally {
         vi.useRealTimers();
       }
     });
 
-    test("uses single-client debounce when document has no collaborators", async () => {
+    test("persists single-client local operations every fixed IDB debounce", async () => {
       vi.useFakeTimers();
 
       try {
@@ -843,7 +868,7 @@ describe("DocSyncClient", () => {
         );
         const client = createDebounceTestClient({
           saveOperations,
-          timing: { collabMaxDebounce: 50, singleClientMaxDebounce: 100 },
+          timing: { collabMaxDebounce: 50, singleClientMaxDebounce: 1000 },
         });
         await client["_localPromise"];
 
@@ -857,13 +882,7 @@ describe("DocSyncClient", () => {
           docId: "doc-1",
           operations: [{ value: "B" }],
         });
-        await vi.advanceTimersByTimeAsync(40);
-
-        client.onLocalOperations({
-          docId: "doc-1",
-          operations: [{ value: "C" }],
-        });
-        await vi.advanceTimersByTimeAsync(19);
+        await vi.advanceTimersByTimeAsync(9);
         await flushMicrotasks();
         expect(saveOperations).not.toHaveBeenCalled();
 
@@ -873,7 +892,24 @@ describe("DocSyncClient", () => {
         expect(saveOperations).toHaveBeenCalledOnce();
         expect(saveOperations).toHaveBeenCalledWith({
           docId: "doc-1",
-          operations: [{ value: "A" }, { value: "B" }, { value: "C" }],
+          operations: [{ value: "A" }, { value: "B" }],
+        });
+
+        client.onLocalOperations({
+          docId: "doc-1",
+          operations: [{ value: "C" }],
+        });
+        await vi.advanceTimersByTimeAsync(49);
+        await flushMicrotasks();
+        expect(saveOperations).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(1);
+        await flushMicrotasks();
+
+        expect(saveOperations).toHaveBeenCalledTimes(2);
+        expect(saveOperations).toHaveBeenLastCalledWith({
+          docId: "doc-1",
+          operations: [{ value: "C" }],
         });
         client.disconnect();
       } finally {
@@ -881,7 +917,7 @@ describe("DocSyncClient", () => {
       }
     });
 
-    test("flushes pending single-client operations when a collaborator appears", async () => {
+    test("syncs saved single-client operations when a collaborator appears", async () => {
       vi.useFakeTimers();
 
       try {
@@ -898,10 +934,7 @@ describe("DocSyncClient", () => {
         cacheDebounceTestDoc(client, docId);
         client.onLocalOperations({ docId, operations: [{ value: "A" }] });
 
-        await vi.advanceTimersByTimeAsync(2999);
-        expect(saveOperations).not.toHaveBeenCalled();
-
-        emitMockedCollaboration(client, { docId, hasCollaborators: true });
+        await vi.advanceTimersByTimeAsync(50);
         await flushMicrotasks();
 
         expect(saveOperations).toHaveBeenCalledWith({
@@ -910,6 +943,23 @@ describe("DocSyncClient", () => {
         });
 
         const emitMock = getSocketEmitMock(client);
+        expect(emitMock).not.toHaveBeenCalledWith(
+          "sync",
+          expect.objectContaining({ docId }),
+          expect.any(Function),
+        );
+
+        await vi.advanceTimersByTimeAsync(2949);
+        await flushMicrotasks();
+        expect(emitMock).not.toHaveBeenCalledWith(
+          "sync",
+          expect.objectContaining({ docId }),
+          expect.any(Function),
+        );
+
+        emitMockedCollaboration(client, { docId, hasCollaborators: true });
+        await flushMicrotasks();
+
         await expect
           .poll(() => emitMock.mock.calls.some(([event]) => event === "sync"))
           .toBe(true);


### PR DESCRIPTION
## Summary
- Keep local IndexedDB persistence on a fixed 50ms debounce.
- Move server sync timing to a separate debounce state so collabMaxDebounce can be larger without delaying IDB writes.
- Update DocSync debounce tests for fixed IDB persistence and delayed server sync.

## Verification
- SKIP_ENV_VALIDATION=true pnpm build
- NEXT_PUBLIC_DOCSYNC_SERVER_URL=ws://localhost:8081 pnpm check
- NEXT_PUBLIC_DOCSYNC_SERVER_URL=ws://localhost:8081 CI=true pnpm test:coverage:once