### PR TITLE
chore: exclude docsync2 packages from releases

### DIFF
--- a/packages/docsync2-react/package.json
+++ b/packages/docsync2-react/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@docukit/docsync2-react",
+  "private": true,
   "version": "0.0.0-alpha.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",

--- a/packages/docsync2/package.json
+++ b/packages/docsync2/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@docukit/docsync2",
+  "private": true,
   "version": "0.0.0-alpha.0",
   "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",


### PR DESCRIPTION
Marks the temporary docsync2 packages as private so release tooling skips them.\n\nThis keeps pnpm bump/publish focused on the current publishable packages.