### PR TITLE
fix(docnode-lexical): preserve root state

### DIFF
--- a/packages/docnode-lexical/src/exports/index.ts
+++ b/packages/docnode-lexical/src/exports/index.ts
@@ -2,6 +2,7 @@ export { syncLexicalWithDoc } from "../index.js";
 export { SKIP_UNDO_TAG } from "../constants.js";
 export {
   LexicalDocNode,
+  LexicalDocRootNode,
   createLexicalDocNodeConfig,
 } from "../lexicalDocNode.js";
 export { syncPresence, updatePresence } from "../presence/index.js";

--- a/packages/docnode-lexical/src/initializeEditorFromDoc.ts
+++ b/packages/docnode-lexical/src/initializeEditorFromDoc.ts
@@ -8,7 +8,7 @@ import {
   type LexicalNode,
 } from "lexical";
 
-import { LexicalDocNode } from "./lexicalDocNode.js";
+import { createLexicalDocRootNode, LexicalDocNode } from "./lexicalDocNode.js";
 import type { KeyBinding } from "./types.js";
 
 /**
@@ -29,6 +29,10 @@ export function initializeEditorFromDoc(
     () => {
       const root = $getRoot();
       root.clear();
+      const rootDefinition = createLexicalDocRootNode(doc.root.type);
+      if (doc.root.is(rootDefinition)) {
+        root.updateFromJSON(doc.root.state.j.get());
+      }
 
       const processChildren = (
         parentDocNode: DocNode,

--- a/packages/docnode-lexical/src/lexicalDocNode.ts
+++ b/packages/docnode-lexical/src/lexicalDocNode.ts
@@ -1,5 +1,18 @@
 import { defineNode, defineState, type DocConfig } from "@docukit/docnode";
-import type { SerializedLexicalNode } from "lexical";
+import type { SerializedLexicalNode, SerializedRootNode } from "lexical";
+
+const defaultSerializedRoot: SerializedRootNode = {
+  children: [],
+  direction: null,
+  format: "",
+  indent: 0,
+  type: "root",
+  version: 1,
+};
+
+const lexicalRootState = defineState({
+  fromJSON: (json) => (json ?? defaultSerializedRoot) as SerializedRootNode,
+});
 
 export const LexicalDocNode = defineNode({
   type: "l",
@@ -11,12 +24,20 @@ export const LexicalDocNode = defineNode({
   },
 });
 
+export function createLexicalDocRootNode<T extends string>(type: T) {
+  return defineNode({ type, state: { j: lexicalRootState } });
+}
+
+export const LexicalDocRootNode = createLexicalDocRootNode("docnode-lexical");
+
 export function createLexicalDocNodeConfig(
   config?: Omit<Partial<DocConfig>, "extensions">,
 ): DocConfig {
+  const type = config?.type ?? LexicalDocRootNode.type;
+
   return {
-    type: "docnode-lexical",
     ...config,
-    extensions: [{ nodes: [LexicalDocNode] }],
+    type,
+    extensions: [{ nodes: [LexicalDocNode, createLexicalDocRootNode(type)] }],
   };
 }

--- a/packages/docnode-lexical/src/syncDocNodeToLexical/syncDocNodeToLexical.ts
+++ b/packages/docnode-lexical/src/syncDocNodeToLexical/syncDocNodeToLexical.ts
@@ -11,7 +11,7 @@ import {
   type SerializedLexicalNode,
 } from "lexical";
 
-import { LexicalDocNode } from "../lexicalDocNode.js";
+import { createLexicalDocRootNode, LexicalDocNode } from "../lexicalDocNode.js";
 import {
   getIsApplyingOwnChanges,
   setIsApplyingOwnChanges,
@@ -266,6 +266,14 @@ function $applyDocNodeOperations(
   // Apply state patches (update node properties)
   // updateFromJSON() safely updates properties while preserving children
   for (const docNodeId in statePatch) {
+    if (docNodeId === doc.root.id) {
+      const rootDefinition = createLexicalDocRootNode(doc.root.type);
+      if (doc.root.is(rootDefinition)) {
+        lexicalRoot.getWritable().updateFromJSON(doc.root.state.j.get());
+      }
+      continue;
+    }
+
     const lexicalKey = docNodeIdToLexicalKey.get(docNodeId);
     if (!lexicalKey) {
       continue;

--- a/packages/docnode-lexical/src/syncLexicalToDocNode.ts
+++ b/packages/docnode-lexical/src/syncLexicalToDocNode.ts
@@ -7,9 +7,10 @@ import {
   type LexicalEditor,
   type LexicalNode,
   type NodeKey,
+  type SerializedRootNode,
 } from "lexical";
 
-import { LexicalDocNode } from "./lexicalDocNode.js";
+import { createLexicalDocRootNode, LexicalDocNode } from "./lexicalDocNode.js";
 import { SKIP_UNDO_TAG } from "./constants.js";
 import type { KeyBinding } from "./types.js";
 
@@ -60,6 +61,14 @@ export function syncLexicalToDocNode(
           // Read Lexical state and sync to DocNode
           editorState.read(() => {
             const lexicalRoot = $getRoot();
+            const rootDefinition = createLexicalDocRootNode(doc.root.type);
+            if (doc.root.is(rootDefinition)) {
+              const serialized: SerializedRootNode = {
+                ...lexicalRoot.exportJSON(),
+                children: [],
+              };
+              doc.root.state.j.set(serialized);
+            }
             $syncLexicalToDocNode(
               doc,
               doc.root,

--- a/tests/docnode-lexical/syncDocNodeToLexical.test.ts
+++ b/tests/docnode-lexical/syncDocNodeToLexical.test.ts
@@ -3,14 +3,77 @@ import {
   createEditor,
   type ParagraphNode,
   type SerializedParagraphNode,
+  type SerializedRootNode,
   type SerializedTextNode,
 } from "lexical";
 import { describe, expect, test } from "vitest";
 
-import { syncLexicalWithDoc, LexicalDocNode } from "@docukit/docnode-lexical";
+import { Doc } from "@docukit/docnode";
+import {
+  createLexicalDocNodeConfig,
+  LexicalDocNode,
+  LexicalDocRootNode,
+  syncLexicalWithDoc,
+} from "@docukit/docnode-lexical";
 import { createLexicalDoc } from "./utils.js";
 
+const createDocWithRootState = (rootState: SerializedRootNode) =>
+  Doc.fromJSON(createLexicalDocNodeConfig(), [
+    "01kc52hq510g6y44jhq0wqrjb3",
+    "docnode-lexical",
+    { j: JSON.stringify(rootState) },
+  ]);
+
 describe("docnode to lexical sync", () => {
+  test("initializes root metadata", () => {
+    const rootState: SerializedRootNode = {
+      children: [],
+      direction: "rtl",
+      format: "",
+      indent: 0,
+      type: "root",
+      version: 1,
+    };
+    const doc = createDocWithRootState(rootState);
+    const editor = createEditor({
+      namespace: "MyEditor",
+      onError: (error) => {
+        console.error(error);
+      },
+    });
+
+    syncLexicalWithDoc(editor, doc);
+
+    expect(editor.getEditorState().toJSON().root).toStrictEqual(rootState);
+  });
+
+  test("syncs live root metadata updates", () => {
+    const rootState: SerializedRootNode = {
+      children: [],
+      direction: "rtl",
+      format: "",
+      indent: 0,
+      type: "root",
+      version: 1,
+    };
+    const doc = createDocWithRootState(rootState);
+    const editor = createEditor({
+      namespace: "MyEditor",
+      onError: (error) => {
+        console.error(error);
+      },
+    });
+    syncLexicalWithDoc(editor, doc);
+
+    if (!doc.root.is(LexicalDocRootNode)) {
+      throw new Error("Expected a LexicalDocRootNode");
+    }
+    doc.root.state.j.set({ ...rootState, direction: "ltr" });
+    doc.forceCommit();
+
+    expect(editor.getEditorState().toJSON().root.direction).toBe("ltr");
+  });
+
   test("add paragraph to empty doc", () => {
     const editor = createEditor({
       namespace: "MyEditor",

--- a/tests/docnode-lexical/syncLexicalToDocNode.test.ts
+++ b/tests/docnode-lexical/syncLexicalToDocNode.test.ts
@@ -127,6 +127,71 @@ describe("docnode to lexical", () => {
 });
 
 describe("lexical to docnode sync", () => {
+  test("preserves the full serialized editor state", () => {
+    const sourceEditor = createEditor({
+      namespace: "SourceEditor",
+      onError: (error) => {
+        console.error(error);
+      },
+    });
+    const doc = createLexicalDoc();
+    syncLexicalWithDoc(sourceEditor, doc);
+
+    sourceEditor.update(
+      () => {
+        const root = $getRoot();
+        root.setDirection("rtl");
+        root.append($createParagraphNode().append($createTextNode("Hello")));
+      },
+      { discrete: true },
+    );
+    const expected = JSON.stringify(sourceEditor.getEditorState().toJSON());
+
+    const restoredEditor = createEditor({
+      namespace: "RestoredEditor",
+      onError: (error) => {
+        console.error(error);
+      },
+    });
+    syncLexicalWithDoc(restoredEditor, doc);
+
+    expect(JSON.stringify(restoredEditor.getEditorState().toJSON())).toBe(
+      expected,
+    );
+  });
+
+  test("syncs root metadata", () => {
+    const editor = createEditor({
+      namespace: "MyEditor",
+      onError: (error) => {
+        console.error(error);
+      },
+    });
+    const doc = createLexicalDoc();
+    syncLexicalWithDoc(editor, doc);
+
+    editor.update(
+      () => {
+        $getRoot().setDirection("rtl");
+      },
+      { discrete: true },
+    );
+
+    assertJson(doc, [
+      "root",
+      {
+        j: JSON.stringify({
+          children: [],
+          direction: "rtl",
+          format: "",
+          indent: 0,
+          type: "root",
+          version: 1,
+        }),
+      },
+    ]);
+  });
+
   test("add paragraph to empty editor", () => {
     const editor = createEditor({
       namespace: "MyEditor",


### PR DESCRIPTION
## Summary

- register a Lexical root node definition through `createLexicalDocNodeConfig`
- synchronize root metadata in both directions, including live DocNode updates
- preserve custom document root types and export the default `LexicalDocRootNode`
- verify full serialized Lexical state equality after a Lexical -> DocNode -> Lexical round trip

## Verification

- `pnpm vitest --coverage --watch=false --project node` (503 passed; core `docnode` remains at 100% coverage)
- `pnpm fix`
- targeted `docnode-lexical` tests (19 passed)

## Known repository issue

`pnpm test:coverage:once` cannot start the browser projects because their global setup cannot resolve the private `@docukit/docsync2/docnode` workspace export. The complete Node project passes and covers this change.