### PR TITLE
Preserve undo history during DocSync document replacement

### DIFF
--- a/docs/content/docs/docnode/undo-manager.mdx
+++ b/docs/content/docs/docnode/undo-manager.mdx
@@ -21,6 +21,9 @@ doc.undoManager.redo(); // redo the last undone transaction
 doc.undoManager.canUndo(); // true if there are undo steps available
 doc.undoManager.canRedo(); // true if there are redo steps available
 doc.undoManager.isEnabled; // true when maxUndoSteps is greater than 0
+
+const history = doc.undoManager.exportHistory(); // the undo and redo history
+doc.undoManager.importHistory(history); // restore exported history
 ```
 
 If `undoManager` is omitted, `maxUndoSteps` defaults to `0`.

--- a/packages/docnode-lexical/src/syncLexicalToDocNode.ts
+++ b/packages/docnode-lexical/src/syncLexicalToDocNode.ts
@@ -208,13 +208,17 @@ function $syncNodeContent(
   }
 
   const serialized = lexicalNode.exportJSON();
-  // const currentJSON = docNode.state.j.get();
+  const lexicalDocNode = docNode as DocNode<typeof LexicalDocNode>;
 
-  // I think this is unnecessary because docnode already does a deep comparison when setting the state.
-  // Deep comparison only when dirty (like Yjs V1 does with prevValue !== nextValue)
-  // if (JSON.stringify(currentJSON) !== JSON.stringify(serialized)) {
-  (docNode as DocNode<typeof LexicalDocNode>).state.j.set(serialized);
-  // }
+  // Lexical can mark nodes dirty while initializing plugins even when their
+  // serialized content did not change. Avoid turning those normalization
+  // updates into local DocNode operations: during stale-while-revalidate, a
+  // redundant local state operation could overwrite newer server content.
+  // Compare the already-parsed JSON values structurally so object key order
+  // does not create a false difference.
+  if (!areJsonValuesEqual(lexicalDocNode.state.j.get(), serialized)) {
+    lexicalDocNode.state.j.set(serialized);
+  }
 
   // Recurse into children if element
   if ($isElementNode(lexicalNode)) {
@@ -227,6 +231,46 @@ function $syncNodeContent(
       keyBinding,
     );
   }
+}
+
+function areJsonValuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) {
+      return false;
+    }
+
+    return (
+      left.length === right.length &&
+      left.every((value, index) => areJsonValuesEqual(value, right[index]))
+    );
+  }
+
+  if (
+    typeof left !== "object" ||
+    left === null ||
+    typeof right !== "object" ||
+    right === null
+  ) {
+    return false;
+  }
+
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const leftKeys = Object.keys(leftRecord);
+  const rightKeys = Object.keys(rightRecord);
+
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) =>
+        Object.hasOwn(rightRecord, key) &&
+        areJsonValuesEqual(leftRecord[key], rightRecord[key]),
+    )
+  );
 }
 
 /**

--- a/packages/docnode/src/exports/index.ts
+++ b/packages/docnode/src/exports/index.ts
@@ -19,3 +19,4 @@ export {
 export { defineNode } from "../utils.js";
 export { boolean, number, string, defineState } from "../stateDefinitions.js";
 export { mergeOperations, type Operations } from "../operations.js";
+export type { UndoHistory, UndoHistoryItem } from "../undoManager.js";

--- a/packages/docnode/src/exports/index.ts
+++ b/packages/docnode/src/exports/index.ts
@@ -19,4 +19,4 @@ export {
 export { defineNode } from "../utils.js";
 export { boolean, number, string, defineState } from "../stateDefinitions.js";
 export { mergeOperations, type Operations } from "../operations.js";
-export type { UndoHistory, UndoHistoryItem } from "../undoManager.js";
+export type { UndoHistory } from "../undoManager.js";

--- a/packages/docnode/src/undoManager.ts
+++ b/packages/docnode/src/undoManager.ts
@@ -214,6 +214,9 @@ function cloneOrderedOperation(operation: OrderedOperation): OrderedOperation {
 function exportStackItem(item: UndoStackItem): UndoHistoryItem {
   return {
     operations: cloneOperations(item.operations),
+    // Intentionally shallow: history handoff normally disposes the source doc,
+    // while persistence owns serialization of its opaque metadata values. A
+    // deep clone would reject valid non-serializable editor metadata.
     meta: Object.fromEntries(item.meta),
   };
 }

--- a/packages/docnode/src/undoManager.ts
+++ b/packages/docnode/src/undoManager.ts
@@ -125,6 +125,9 @@ export class UndoManager {
    * metadata values are supported by their chosen storage format.
    */
   exportHistory(): UndoHistory {
+    // Not only for the history: DocSync relies on this commit to push a pending
+    // edit into its local operations batch, so the replacement document picks
+    // it up. Do not skip it when undo is disabled.
     this._doc.forceCommit();
     return {
       docId: this._doc.root.id,

--- a/packages/docnode/src/undoManager.ts
+++ b/packages/docnode/src/undoManager.ts
@@ -1,9 +1,26 @@
 import { type Doc } from "./main.js";
-import { mergeOperations, type Operations } from "./operations.js";
+import {
+  mergeOperations,
+  type Operations,
+  type OrderedOperation,
+} from "./operations.js";
 import type { UndoManagerConfig } from "./types.js";
 
 /** `meta` is opaque — consumers attach arbitrary data (e.g. selection). */
 type UndoStackItem = { operations: Operations; meta: Map<string, unknown> };
+
+export type UndoHistoryItem = {
+  operations: Operations;
+  meta: Record<string, unknown>;
+};
+
+export type UndoHistory = {
+  docId: string;
+  docType: string;
+  undoStack: UndoHistoryItem[];
+  redoStack: UndoHistoryItem[];
+  lastUpdate?: number;
+};
 
 type UndoManagerEvent = { meta: UndoStackItem["meta"]; type: "undo" | "redo" };
 
@@ -103,6 +120,44 @@ export class UndoManager {
   }
 
   /**
+   * Exports undo and redo state without exporting editor-specific listeners.
+   * Metadata uses plain objects so consumers can persist histories whose
+   * metadata values are supported by their chosen storage format.
+   */
+  exportHistory(): UndoHistory {
+    this._doc.forceCommit();
+    return {
+      docId: this._doc.root.id,
+      docType: this._doc.root.type,
+      undoStack: this._undoStack.map(exportStackItem),
+      redoStack: this._redoStack.map(exportStackItem),
+      ...(this._lastUpdate !== undefined && { lastUpdate: this._lastUpdate }),
+    };
+  }
+
+  /**
+   * Replaces this manager's history with a previously exported history.
+   * The document ID and type must match because operations contain node IDs.
+   */
+  importHistory(history: unknown): void {
+    if (!isUndoHistory(history)) {
+      throw new TypeError("Invalid undo history");
+    }
+    if (
+      history.docId !== this._doc.root.id ||
+      history.docType !== this._doc.root.type
+    ) {
+      throw new Error("Undo history belongs to a different document");
+    }
+
+    const maxSteps = this._maxUndoSteps;
+    this._undoStack = importStack(history.undoStack, maxSteps);
+    this._redoStack = importStack(history.redoStack, maxSteps);
+    this._lastUpdate = history.lastUpdate;
+    this._txType = "update";
+  }
+
+  /**
    * Fires synchronously when an item is pushed to either stack.
    * Text editor bindings will often store selection state here.
    */
@@ -123,4 +178,138 @@ export class UndoManager {
       this._popHandlers.delete(handler);
     };
   }
+}
+
+function cloneOperations(operations: Operations): Operations {
+  const orderedOperations = operations[0].map(cloneOrderedOperation);
+  const statePatch = Object.fromEntries(
+    Object.entries(operations[1]).map(([id, state]) => [id, { ...state }]),
+  );
+  return [orderedOperations, statePatch];
+}
+
+function cloneOrderedOperation(operation: OrderedOperation): OrderedOperation {
+  if (operation[0] === 0) {
+    return [
+      0,
+      operation[1].map(([id, type]) => [id, type]),
+      operation[2],
+      operation[3],
+      operation[4],
+    ];
+  }
+  if (operation[0] === 1) {
+    return [1, operation[1], operation[2]];
+  }
+  return [
+    2,
+    operation[1],
+    operation[2],
+    operation[3],
+    operation[4],
+    operation[5],
+  ];
+}
+
+function exportStackItem(item: UndoStackItem): UndoHistoryItem {
+  return {
+    operations: cloneOperations(item.operations),
+    meta: Object.fromEntries(item.meta),
+  };
+}
+
+function importStack(items: UndoHistoryItem[], maxSteps: number) {
+  const retainedItems = maxSteps === 0 ? [] : items.slice(-maxSteps);
+  return retainedItems.map((item) => ({
+    operations: cloneOperations(item.operations),
+    meta: new Map(Object.entries(item.meta)),
+  }));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype: unknown = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isRecord(value) && Object.values(value).every(isString);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isNodeReference(value: unknown): value is string | 0 {
+  return value === 0 || typeof value === "string";
+}
+
+function isOrderedOperation(value: unknown): boolean {
+  if (!Array.isArray(value)) return false;
+  if (value[0] === 0) {
+    return (
+      value.length === 5 &&
+      Array.isArray(value[1]) &&
+      value[1].every(
+        (node) =>
+          Array.isArray(node) && node.length === 2 && node.every(isString),
+      ) &&
+      isNodeReference(value[2]) &&
+      isNodeReference(value[3]) &&
+      isNodeReference(value[4])
+    );
+  }
+  if (value[0] === 1) {
+    return (
+      value.length === 3 &&
+      typeof value[1] === "string" &&
+      isNodeReference(value[2])
+    );
+  }
+  if (value[0] === 2) {
+    return (
+      value.length === 6 &&
+      typeof value[1] === "string" &&
+      isNodeReference(value[2]) &&
+      isNodeReference(value[3]) &&
+      isNodeReference(value[4]) &&
+      isNodeReference(value[5])
+    );
+  }
+  return false;
+}
+
+function isOperations(value: unknown): value is Operations {
+  if (!Array.isArray(value) || value.length !== 2) return false;
+  const orderedOperations: unknown = value[0];
+  const statePatch: unknown = value[1];
+  return (
+    Array.isArray(orderedOperations) &&
+    orderedOperations.every(isOrderedOperation) &&
+    isRecord(statePatch) &&
+    Object.values(statePatch).every(isStringRecord)
+  );
+}
+
+function isHistoryItem(value: unknown): value is UndoHistoryItem {
+  return (
+    isRecord(value) && isOperations(value.operations) && isRecord(value.meta)
+  );
+}
+
+function isUndoHistory(value: unknown): value is UndoHistory {
+  return (
+    isRecord(value) &&
+    typeof value.docId === "string" &&
+    typeof value.docType === "string" &&
+    Array.isArray(value.undoStack) &&
+    value.undoStack.every(isHistoryItem) &&
+    Array.isArray(value.redoStack) &&
+    value.redoStack.every(isHistoryItem) &&
+    (value.lastUpdate === undefined ||
+      (typeof value.lastUpdate === "number" &&
+        Number.isFinite(value.lastUpdate)))
+  );
 }

--- a/packages/docsync/src/bindings/docnode.ts
+++ b/packages/docsync/src/bindings/docnode.ts
@@ -36,6 +36,10 @@ export const DocNodeBinding = (docConfigs: DocConfig[]) => {
     applyOperations: (doc, operations, flags) => {
       doc.applyOperations(operations, flags);
     },
+    exportHistory: (doc) => doc.undoManager.exportHistory(),
+    importHistory: (doc, history) => {
+      doc.undoManager.importHistory(history);
+    },
     dispose: (doc) => doc.dispose(),
   });
 };

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
@@ -11,6 +11,14 @@ export type ReconcileSyncResult<D extends object, O extends object> =
   | { type: "replaceDoc"; doc: D }
   | { type: "applyServerOperations"; operations: O[] };
 
+type PreparedSyncReconciliation<D extends object, O extends object> = {
+  didConsolidate: boolean;
+  shouldReplaceDoc: boolean;
+  pendingProviderOperations: O[];
+  replacementDoc?: D;
+  serverOperations: O[];
+};
+
 function applyOperations<D extends object, S extends object, O extends object>(
   client: DocSyncClient<D, S, O>,
   doc: D,
@@ -22,7 +30,11 @@ function applyOperations<D extends object, S extends object, O extends object>(
   }
 }
 
-export async function reconcileSyncResponse<
+/**
+ * Performs the asynchronous provider transaction and prepares a possible
+ * replacement. The live in-memory document is intentionally left untouched.
+ */
+export async function prepareSyncReconciliation<
   D extends object,
   S extends object,
   O extends object,
@@ -33,18 +45,10 @@ export async function reconcileSyncResponse<
     docId: string;
     operationsBatches: O[][];
     localOperations: O[];
-    requestLocalVersion: number;
     data: Extract<SyncResponse<S, O>, { data: unknown }>["data"];
   },
-): Promise<ReconcileSyncResult<D, O>> {
-  const {
-    provider,
-    docId,
-    operationsBatches,
-    localOperations,
-    requestLocalVersion,
-    data,
-  } = args;
+): Promise<PreparedSyncReconciliation<D, O>> {
+  const { provider, docId, operationsBatches, localOperations, data } = args;
   const hasServerSnapshot = data.serializedDoc !== null;
   let didConsolidate = false;
   let pendingProviderOperations: O[] = [];
@@ -100,34 +104,67 @@ export async function reconcileSyncResponse<
     didConsolidate = true;
   });
 
-  const hasConcurrentServerAndLocalOperations =
-    data.operations.length > 0 && localOperations.length > 0;
+  return {
+    didConsolidate,
+    shouldReplaceDoc:
+      hasServerSnapshot ||
+      (data.operations.length > 0 && localOperations.length > 0),
+    pendingProviderOperations,
+    ...(replacementDoc && { replacementDoc }),
+    serverOperations: data.operations,
+  };
+}
 
-  if (
-    replacementDoc &&
-    (hasServerSnapshot || hasConcurrentServerAndLocalOperations)
-  ) {
+/**
+ * Finishes reconciliation synchronously so local edits cannot land between
+ * rebuilding a replacement document and swapping it into the cache.
+ */
+export function finalizeSyncReconciliation<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
+  client: DocSyncClient<D, S, O>,
+  args: {
+    docId: string;
+    prepared: PreparedSyncReconciliation<D, O>;
+    requestLocalVersion: number;
+  },
+): ReconcileSyncResult<D, O> {
+  const { docId, prepared, requestLocalVersion } = args;
+
+  if (prepared.replacementDoc && prepared.shouldReplaceDoc) {
     const pendingMemoryOperations =
       client["_localOpsBatchState"].get(docId)?.data ?? [];
     const hasUnrebuildableLocalMemory =
       getLocalDocVersion(client, docId) > requestLocalVersion &&
-      pendingProviderOperations.length === 0 &&
+      prepared.pendingProviderOperations.length === 0 &&
       pendingMemoryOperations.length === 0;
 
     if (hasUnrebuildableLocalMemory) {
-      if (didConsolidate && data.operations.length > 0) {
-        return { type: "applyServerOperations", operations: data.operations };
+      if (prepared.didConsolidate && prepared.serverOperations.length > 0) {
+        return {
+          type: "applyServerOperations",
+          operations: prepared.serverOperations,
+        };
       }
       return { type: "none" };
     }
 
-    applyOperations(client, replacementDoc, pendingProviderOperations);
-    applyOperations(client, replacementDoc, pendingMemoryOperations);
-    return { type: "replaceDoc", doc: replacementDoc };
+    applyOperations(
+      client,
+      prepared.replacementDoc,
+      prepared.pendingProviderOperations,
+    );
+    applyOperations(client, prepared.replacementDoc, pendingMemoryOperations);
+    return { type: "replaceDoc", doc: prepared.replacementDoc };
   }
 
-  if (didConsolidate && data.operations.length > 0) {
-    return { type: "applyServerOperations", operations: data.operations };
+  if (prepared.didConsolidate && prepared.serverOperations.length > 0) {
+    return {
+      type: "applyServerOperations",
+      operations: prepared.serverOperations,
+    };
   }
 
   return { type: "none" };

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
@@ -118,6 +118,10 @@ export async function prepareSyncReconciliation<
 /**
  * Finishes reconciliation synchronously so local edits cannot land between
  * rebuilding a replacement document and swapping it into the cache.
+ *
+ * `pendingMemoryOperations` is resolved by the caller rather than read from the
+ * client here: exporting the undo history force-commits the live doc, which can
+ * flush and delete the in-memory batch in the same synchronous turn.
  */
 export function finalizeSyncReconciliation<
   D extends object,
@@ -129,13 +133,13 @@ export function finalizeSyncReconciliation<
     docId: string;
     prepared: PreparedSyncReconciliation<D, O>;
     requestLocalVersion: number;
+    pendingMemoryOperations: O[];
   },
 ): ReconcileSyncResult<D, O> {
-  const { docId, prepared, requestLocalVersion } = args;
+  const { docId, prepared, requestLocalVersion, pendingMemoryOperations } =
+    args;
 
   if (prepared.replacementDoc && prepared.shouldReplaceDoc) {
-    const pendingMemoryOperations =
-      client["_localOpsBatchState"].get(docId)?.data ?? [];
     const hasUnrebuildableLocalMemory =
       getLocalDocVersion(client, docId) > requestLocalVersion &&
       prepared.pendingProviderOperations.length === 0 &&

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -9,7 +9,10 @@ import { getOwnPresencePatch } from "../../../utils/getOwnPresencePatch.js";
 import { getLocalDocVersion } from "../../../utils/localDocVersion.js";
 import { request } from "../../../utils/request.js";
 import { setupDocChangeListener } from "../../../utils/setupDocChangeListener.js";
-import { reconcileSyncResponse } from "./reconcileSyncResponse.js";
+import {
+  finalizeSyncReconciliation,
+  prepareSyncReconciliation,
+} from "./reconcileSyncResponse.js";
 
 /** Applies server operations to the cached doc. */
 async function applyServerOperations<
@@ -85,7 +88,12 @@ function replaceDocInCache<
     .catch(() => undefined);
 }
 
-async function exportHistoryForPotentialReplacement<
+type HistorySource<D extends object> = {
+  doc: D;
+  promisedDoc: Promise<D | undefined>;
+};
+
+async function resolveHistorySourceForPotentialReplacement<
   D extends object,
   S extends object,
   O extends object,
@@ -96,9 +104,7 @@ async function exportHistoryForPotentialReplacement<
     hasServerSnapshot: boolean;
     hasConcurrentOperations: boolean;
   },
-): Promise<
-  { promisedDoc: Promise<D | undefined>; value: unknown } | undefined
-> {
+): Promise<HistorySource<D> | undefined> {
   if (!args.hasServerSnapshot && !args.hasConcurrentOperations) return;
   const docBinding = client["_docBinding"];
   if (!docBinding.exportHistory) return;
@@ -106,9 +112,29 @@ async function exportHistoryForPotentialReplacement<
   if (!cacheEntry) return;
   const doc = await cacheEntry.promisedDoc;
   if (!doc) return;
+  return { doc, promisedDoc: cacheEntry.promisedDoc };
+}
+
+function exportHistoryFromCurrentSource<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
+  client: DocSyncClient<D, S, O>,
+  docId: string,
+  source: HistorySource<D> | undefined,
+): { promisedDoc: Promise<D | undefined>; value: unknown } | undefined {
+  if (!source) return;
+  const cacheEntry = client["_docsCache"].get(docId);
+  const docBinding = client["_docBinding"];
+  if (
+    cacheEntry?.promisedDoc !== source.promisedDoc ||
+    !docBinding.exportHistory
+  )
+    return;
   return {
-    promisedDoc: cacheEntry.promisedDoc,
-    value: docBinding.exportHistory(doc),
+    promisedDoc: source.promisedDoc,
+    value: docBinding.exportHistory(source.doc),
   };
 }
 
@@ -222,24 +248,38 @@ export const handleSync = async <
   const { data } = response;
   client["_events"].emit("sync", { req, data });
 
-  // Replacement is required when the server supplies a snapshot or when
-  // concurrent operations are order-sensitive. Capture ephemeral history
-  // before reconciliation so DocNode's export can commit any pending edit and
-  // reconciliation can include that edit in the replacement document.
-  const exportedHistory = await exportHistoryForPotentialReplacement(client, {
-    docId,
-    hasServerSnapshot: data.serializedDoc !== null,
-    hasConcurrentOperations:
-      data.operations.length > 0 && operations.length > 0,
-  });
-
-  const reconcileResult = await reconcileSyncResponse(client, {
+  // Resolve the live doc before starting the asynchronous provider work. The
+  // history itself is exported only in the synchronous final section below.
+  const historySource = await resolveHistorySourceForPotentialReplacement(
+    client,
+    {
+      docId,
+      hasServerSnapshot: data.serializedDoc !== null,
+      hasConcurrentOperations:
+        data.operations.length > 0 && operations.length > 0,
+    },
+  );
+  const preparedReconciliation = await prepareSyncReconciliation(client, {
     provider,
     docId,
     operationsBatches,
     localOperations: operations,
-    requestLocalVersion,
     data,
+  });
+
+  // Keep this section synchronous. Exporting DocNode history force-commits a
+  // pending edit, finalize then reads that operation from the memory batch,
+  // and replacement imports the matching history before another user event
+  // can run.
+  const exportedHistory =
+    preparedReconciliation.replacementDoc &&
+    preparedReconciliation.shouldReplaceDoc
+      ? exportHistoryFromCurrentSource(client, docId, historySource)
+      : undefined;
+  const reconcileResult = finalizeSyncReconciliation(client, {
+    docId,
+    prepared: preparedReconciliation,
+    requestLocalVersion,
   });
 
   if (reconcileResult.type === "replaceDoc") {

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -35,12 +35,26 @@ function replaceDocInCache<
   D extends object,
   S extends object,
   O extends object,
->(client: DocSyncClient<D, S, O>, args: { docId: string; doc: D }): void {
+>(
+  client: DocSyncClient<D, S, O>,
+  args: {
+    docId: string;
+    doc: D;
+    exportedHistory?: { promisedDoc: Promise<D | undefined>; value: unknown };
+  },
+): void {
   const cacheEntry = client["_docsCache"].get(args.docId);
   if (!cacheEntry) return;
 
   const previousPromisedDoc = cacheEntry.promisedDoc;
   const nextPromisedDoc = Promise.resolve(args.doc);
+  const docBinding = client["_docBinding"];
+  if (
+    args.exportedHistory?.promisedDoc === previousPromisedDoc &&
+    docBinding.importHistory
+  ) {
+    docBinding.importHistory(args.doc, args.exportedHistory.value);
+  }
   setupDocChangeListener(client, args);
 
   client["_docsCache"].set(args.docId, {
@@ -69,6 +83,33 @@ function replaceDocInCache<
       }
     })
     .catch(() => undefined);
+}
+
+async function exportHistoryForPotentialReplacement<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
+  client: DocSyncClient<D, S, O>,
+  args: {
+    docId: string;
+    hasServerSnapshot: boolean;
+    hasConcurrentOperations: boolean;
+  },
+): Promise<
+  { promisedDoc: Promise<D | undefined>; value: unknown } | undefined
+> {
+  if (!args.hasServerSnapshot && !args.hasConcurrentOperations) return;
+  const docBinding = client["_docBinding"];
+  if (!docBinding.exportHistory) return;
+  const cacheEntry = client["_docsCache"].get(args.docId);
+  if (!cacheEntry) return;
+  const doc = await cacheEntry.promisedDoc;
+  if (!doc) return;
+  return {
+    promisedDoc: cacheEntry.promisedDoc,
+    value: docBinding.exportHistory(doc),
+  };
 }
 
 function broadcastServerOperations<
@@ -181,6 +222,17 @@ export const handleSync = async <
   const { data } = response;
   client["_events"].emit("sync", { req, data });
 
+  // Replacement is required when the server supplies a snapshot or when
+  // concurrent operations are order-sensitive. Capture ephemeral history
+  // before reconciliation so DocNode's export can commit any pending edit and
+  // reconciliation can include that edit in the replacement document.
+  const exportedHistory = await exportHistoryForPotentialReplacement(client, {
+    docId,
+    hasServerSnapshot: data.serializedDoc !== null,
+    hasConcurrentOperations:
+      data.operations.length > 0 && operations.length > 0,
+  });
+
   const reconcileResult = await reconcileSyncResponse(client, {
     provider,
     docId,
@@ -191,7 +243,11 @@ export const handleSync = async <
   });
 
   if (reconcileResult.type === "replaceDoc") {
-    replaceDocInCache(client, { docId, doc: reconcileResult.doc });
+    replaceDocInCache(client, {
+      docId,
+      doc: reconcileResult.doc,
+      ...(exportedHistory && { exportedHistory }),
+    });
     dispatchLocalDocFound(client, docId, { doc: reconcileResult.doc, docId });
     broadcastServerOperations(client, { docId, operations: data.operations });
   } else if (reconcileResult.type === "applyServerOperations") {

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -138,6 +138,37 @@ function exportHistoryFromCurrentSource<
   };
 }
 
+/**
+ * Resolves the in-memory operations batch across the history export.
+ *
+ * `exportHistory` force-commits the live doc, which pushes the resulting
+ * operation into the batch *and* can flush it in the same synchronous turn:
+ * `_flushLocalOperations` deletes the batch entry before its first await, so
+ * reading the batch only after the export would miss that operation. The
+ * replacement doc would then be swapped in without an edit whose undo entry we
+ * just exported. The flush keeps the array it took, and the push happens before
+ * it, so the reference captured beforehand still holds the operation.
+ */
+function resolvePendingMemoryOperations<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
+  client: DocSyncClient<D, S, O>,
+  docId: string,
+  batchBeforeExport: O[] | undefined,
+): O[] {
+  const batchAfterExport = client["_localOpsBatchState"].get(docId)?.data;
+  if (batchBeforeExport === undefined) return batchAfterExport ?? [];
+  if (
+    batchAfterExport === undefined ||
+    batchAfterExport === batchBeforeExport
+  ) {
+    return batchBeforeExport;
+  }
+  return [...batchBeforeExport, ...batchAfterExport];
+}
+
 function broadcastServerOperations<
   D extends object,
   S extends object,
@@ -184,143 +215,157 @@ export const handleSync = async <
     return;
   }
   pushStatusByDocId.set(docId, "pushing");
-
-  if (client["_localOpsBatchState"].has(docId)) {
-    await client["_flushLocalOperations"](docId, { sync: false });
-  }
-  const requestLocalVersion = getLocalDocVersion(client, docId);
-
-  const { provider } = await client["_localPromise"];
-  const socket = client["_socket"];
-
-  // Prepare payload: read operations and clock from provider.
-  const [operationsBatches, stored] = await provider.transaction(
-    "readonly",
-    async (ctx) => {
-      return Promise.all([
-        ctx.getOperations({ docId }),
-        ctx.getSerializedDoc({ docId }),
-      ]);
-    },
-  );
-  const operations = operationsBatches.flat();
-  const clientClock = stored?.clock ?? 0;
-
-  const cacheEntry = client["_docsCache"].get(docId);
-  if (!cacheEntry) {
-    // Doc was unloaded while this sync was in-flight — abort.
-    pushStatusByDocId.set(docId, "idle");
-    return;
-  }
-  const type = cacheEntry.type;
-  const payload: SyncRequest<S, O> = {
-    type,
-    clock: clientClock,
-    docId,
-    operations,
-    serializedDoc: stored?.serializedDoc ?? null,
-  };
-  const req = payload;
-
-  let response: SyncResponse<S, O>;
+  // Any throw below would leave the push status stuck on "pushing", and every
+  // later handleSync call would early-return on it — the document would stop
+  // syncing until a reload. Reset the status and rethrow so the failure stays
+  // loud.
   try {
-    response = await request(socket, "sync", payload);
-  } catch (error) {
-    client["_events"].emit("sync", {
-      req,
-      error: {
-        type: "NetworkError",
-        message: error instanceof Error ? error.message : String(error),
+    if (client["_localOpsBatchState"].has(docId)) {
+      await client["_flushLocalOperations"](docId, { sync: false });
+    }
+    const requestLocalVersion = getLocalDocVersion(client, docId);
+
+    const { provider } = await client["_localPromise"];
+    const socket = client["_socket"];
+
+    // Prepare payload: read operations and clock from provider.
+    const [operationsBatches, stored] = await provider.transaction(
+      "readonly",
+      async (ctx) => {
+        return Promise.all([
+          ctx.getOperations({ docId }),
+          ctx.getSerializedDoc({ docId }),
+        ]);
       },
+    );
+    const operations = operationsBatches.flat();
+    const clientClock = stored?.clock ?? 0;
+
+    const cacheEntry = client["_docsCache"].get(docId);
+    if (!cacheEntry) {
+      // Doc was unloaded while this sync was in-flight — abort.
+      pushStatusByDocId.set(docId, "idle");
+      return;
+    }
+    const type = cacheEntry.type;
+    const payload: SyncRequest<S, O> = {
+      type,
+      clock: clientClock,
+      docId,
+      operations,
+      serializedDoc: stored?.serializedDoc ?? null,
+    };
+    const req = payload;
+
+    let response: SyncResponse<S, O>;
+    try {
+      response = await request(socket, "sync", payload);
+    } catch (error) {
+      client["_events"].emit("sync", {
+        req,
+        error: {
+          type: "NetworkError",
+          message: error instanceof Error ? error.message : String(error),
+        },
+      });
+      pushStatusByDocId.set(docId, "idle");
+      void handleSync(client, docId);
+      return;
+    }
+
+    if ("error" in response && response.error) {
+      client["_events"].emit("sync", { req, error: response.error });
+      pushStatusByDocId.set(docId, "idle");
+      void handleSync(client, docId);
+      return;
+    }
+
+    const { data } = response;
+    client["_events"].emit("sync", { req, data });
+
+    // Resolve the live doc before starting the asynchronous provider work. The
+    // history itself is exported only in the synchronous final section below.
+    const historySource = await resolveHistorySourceForPotentialReplacement(
+      client,
+      {
+        docId,
+        hasServerSnapshot: data.serializedDoc !== null,
+        hasConcurrentOperations:
+          data.operations.length > 0 && operations.length > 0,
+      },
+    );
+    const preparedReconciliation = await prepareSyncReconciliation(client, {
+      provider,
+      docId,
+      operationsBatches,
+      localOperations: operations,
+      data,
     });
+
+    // Keep this section synchronous. Exporting DocNode history force-commits a
+    // pending edit, finalize then applies that operation to the replacement,
+    // and replacement imports the matching history before another user event
+    // can run.
+    const batchBeforeExport = client["_localOpsBatchState"].get(docId)?.data;
+    const exportedHistory =
+      preparedReconciliation.replacementDoc &&
+      preparedReconciliation.shouldReplaceDoc
+        ? exportHistoryFromCurrentSource(client, docId, historySource)
+        : undefined;
+    const reconcileResult = finalizeSyncReconciliation(client, {
+      docId,
+      prepared: preparedReconciliation,
+      requestLocalVersion,
+      pendingMemoryOperations: resolvePendingMemoryOperations(
+        client,
+        docId,
+        batchBeforeExport,
+      ),
+    });
+
+    if (reconcileResult.type === "replaceDoc") {
+      replaceDocInCache(client, {
+        docId,
+        doc: reconcileResult.doc,
+        ...(exportedHistory && { exportedHistory }),
+      });
+      dispatchLocalDocFound(client, docId, { doc: reconcileResult.doc, docId });
+      broadcastServerOperations(client, { docId, operations: data.operations });
+    } else if (reconcileResult.type === "applyServerOperations") {
+      await applyServerOperations(client, {
+        docId,
+        operations: reconcileResult.operations,
+      });
+      broadcastServerOperations(client, {
+        docId,
+        operations: reconcileResult.operations,
+      });
+    }
+
+    const currentStatus = pushStatusByDocId.get(docId);
+    const shouldRetry = currentStatus === "pushing-with-pending";
     pushStatusByDocId.set(docId, "idle");
-    void handleSync(client, docId);
-    return;
-  }
+    if (shouldRetry) {
+      void handleSync(client, docId);
+      return;
+    }
+    const latestCacheEntry = client["_docsCache"].get(docId);
+    if (!latestCacheEntry) return;
+    if (latestCacheEntry.queryResult.fetchStatus === "idle") return;
 
-  if ("error" in response && response.error) {
-    client["_events"].emit("sync", { req, error: response.error });
+    if (
+      latestCacheEntry.queryResult.status === "success" &&
+      latestCacheEntry.queryResult.data !== undefined
+    ) {
+      dispatchNetworkDocFound(client, docId, latestCacheEntry.queryResult.data);
+      return;
+    }
+
+    dispatchNetworkDocNotFound(client, docId, {
+      createIfMissing: latestCacheEntry.localLoadMode === "loadOrCreate",
+    });
+  } catch (error) {
     pushStatusByDocId.set(docId, "idle");
-    void handleSync(client, docId);
-    return;
+    throw error;
   }
-
-  const { data } = response;
-  client["_events"].emit("sync", { req, data });
-
-  // Resolve the live doc before starting the asynchronous provider work. The
-  // history itself is exported only in the synchronous final section below.
-  const historySource = await resolveHistorySourceForPotentialReplacement(
-    client,
-    {
-      docId,
-      hasServerSnapshot: data.serializedDoc !== null,
-      hasConcurrentOperations:
-        data.operations.length > 0 && operations.length > 0,
-    },
-  );
-  const preparedReconciliation = await prepareSyncReconciliation(client, {
-    provider,
-    docId,
-    operationsBatches,
-    localOperations: operations,
-    data,
-  });
-
-  // Keep this section synchronous. Exporting DocNode history force-commits a
-  // pending edit, finalize then reads that operation from the memory batch,
-  // and replacement imports the matching history before another user event
-  // can run.
-  const exportedHistory =
-    preparedReconciliation.replacementDoc &&
-    preparedReconciliation.shouldReplaceDoc
-      ? exportHistoryFromCurrentSource(client, docId, historySource)
-      : undefined;
-  const reconcileResult = finalizeSyncReconciliation(client, {
-    docId,
-    prepared: preparedReconciliation,
-    requestLocalVersion,
-  });
-
-  if (reconcileResult.type === "replaceDoc") {
-    replaceDocInCache(client, {
-      docId,
-      doc: reconcileResult.doc,
-      ...(exportedHistory && { exportedHistory }),
-    });
-    dispatchLocalDocFound(client, docId, { doc: reconcileResult.doc, docId });
-    broadcastServerOperations(client, { docId, operations: data.operations });
-  } else if (reconcileResult.type === "applyServerOperations") {
-    await applyServerOperations(client, {
-      docId,
-      operations: reconcileResult.operations,
-    });
-    broadcastServerOperations(client, {
-      docId,
-      operations: reconcileResult.operations,
-    });
-  }
-
-  const currentStatus = pushStatusByDocId.get(docId);
-  const shouldRetry = currentStatus === "pushing-with-pending";
-  pushStatusByDocId.set(docId, "idle");
-  if (shouldRetry) {
-    void handleSync(client, docId);
-    return;
-  }
-  const latestCacheEntry = client["_docsCache"].get(docId);
-  if (!latestCacheEntry) return;
-  if (latestCacheEntry.queryResult.fetchStatus === "idle") return;
-
-  if (
-    latestCacheEntry.queryResult.status === "success" &&
-    latestCacheEntry.queryResult.data !== undefined
-  ) {
-    dispatchNetworkDocFound(client, docId, latestCacheEntry.queryResult.data);
-    return;
-  }
-
-  dispatchNetworkDocNotFound(client, docId, {
-    createIfMissing: latestCacheEntry.localLoadMode === "loadOrCreate",
-  });
 };

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -45,18 +45,23 @@ function replaceDocInCache<
     doc: D;
     exportedHistory?: { promisedDoc: Promise<D | undefined>; value: unknown };
   },
-): void {
+) {
   const cacheEntry = client["_docsCache"].get(args.docId);
   if (!cacheEntry) return;
 
   const previousPromisedDoc = cacheEntry.promisedDoc;
   const nextPromisedDoc = Promise.resolve(args.doc);
   const docBinding = client["_docBinding"];
+  let historyImportError: { historyImportError: unknown } | undefined;
   if (
     args.exportedHistory?.promisedDoc === previousPromisedDoc &&
     docBinding.importHistory
   ) {
-    docBinding.importHistory(args.doc, args.exportedHistory.value);
+    try {
+      docBinding.importHistory(args.doc, args.exportedHistory.value);
+    } catch (error) {
+      historyImportError = { historyImportError: error };
+    }
   }
   setupDocChangeListener(client, args);
 
@@ -86,6 +91,8 @@ function replaceDocInCache<
       }
     })
     .catch(() => undefined);
+
+  return historyImportError;
 }
 
 type HistorySource<D extends object> = {
@@ -324,13 +331,17 @@ export const handleSync = async <
     });
 
     if (reconcileResult.type === "replaceDoc") {
-      replaceDocInCache(client, {
+      const replaceResult = replaceDocInCache(client, {
         docId,
         doc: reconcileResult.doc,
         ...(exportedHistory && { exportedHistory }),
       });
       dispatchLocalDocFound(client, docId, { doc: reconcileResult.doc, docId });
       broadcastServerOperations(client, { docId, operations: data.operations });
+      // IndexedDB was already reconciled before the history import. Finish the
+      // cache swap first so persistent and visible content cannot diverge, then
+      // keep the binding failure loud for the caller.
+      if (replaceResult) throw replaceResult.historyImportError;
     } else if (reconcileResult.type === "applyServerOperations") {
       await applyServerOperations(client, {
         docId,

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -505,6 +505,10 @@ export class DocSyncClient<
     );
   }
 
+  protected _sync(docId: string) {
+    return handleSync(this, docId);
+  }
+
   protected async _flushLocalOperations(
     docId: string,
     options?: { sync?: boolean },

--- a/packages/docsync/src/shared/types.ts
+++ b/packages/docsync/src/shared/types.ts
@@ -12,11 +12,18 @@ import type { UnsubscribeDocHandler } from "../server/handlers/unsubscribe.js";
  */
 
 // TO-DECIDE: should params in fn's be objects?
-export interface DocBinding<
+type DocBindingHistory<D extends object> =
+  | {
+      exportHistory(doc: D): unknown;
+      importHistory(doc: D, history: unknown): void;
+    }
+  | { exportHistory?: never; importHistory?: never };
+
+export type DocBinding<
   D extends object = object,
   S extends object = object,
   O extends object = object,
-> {
+> = {
   // method syntax is required to avoid type errors
   create(type: string, id?: string): { doc: D; docId: string };
   deserialize(serializedDoc: S): D;
@@ -27,7 +34,7 @@ export interface DocBinding<
   ): void;
   applyOperations(doc: D, operations: O, flags?: TransactionFlags): void;
   dispose(doc: D): void;
-}
+} & DocBindingHistory<D>;
 
 // Keep this local instead of importing from @docukit/docnode because DocNode is
 // an optional peer dependency of @docukit/docsync.

--- a/tests/docnode-lexical/syncLexicalToDocNode.test.ts
+++ b/tests/docnode-lexical/syncLexicalToDocNode.test.ts
@@ -127,6 +127,87 @@ describe("docnode to lexical", () => {
 });
 
 describe("lexical to docnode sync", () => {
+  test("does not create operations for dirty but semantically unchanged nodes", () => {
+    const doc = createLexicalDoc();
+    const paragraph = doc.createNode(LexicalDocNode);
+    const text = doc.createNode(LexicalDocNode);
+
+    // Deliberately use a different object-key order than Lexical's exportJSON.
+    // These values describe the same nodes and must not become local changes
+    // when Lexical marks them dirty during plugin initialization.
+    paragraph.state.j.set({
+      version: 1,
+      type: "paragraph",
+      textStyle: "",
+      textFormat: 0,
+      indent: 0,
+      format: "",
+      direction: null,
+      children: [],
+    });
+    text.state.j.set({
+      version: 1,
+      type: "text",
+      text: "Initial",
+      style: "",
+      mode: "normal",
+      format: 0,
+      detail: 0,
+    });
+    paragraph.append(text);
+    doc.root.append(paragraph);
+    doc.forceCommit();
+
+    const editor = createEditor({
+      namespace: "MyEditor",
+      onError: (error) => {
+        console.error(error);
+      },
+    });
+    syncLexicalWithDoc(editor, doc);
+
+    let changeCount = 0;
+    const unregister = doc.onChange(() => {
+      changeCount++;
+    });
+
+    editor.update(
+      () => {
+        const lexicalParagraph = $getRoot().getFirstChild() as
+          | ParagraphNode
+          | undefined;
+        const lexicalText = lexicalParagraph?.getFirstChild() as
+          | TextNode
+          | undefined;
+        lexicalParagraph?.getWritable();
+        lexicalText?.getWritable();
+      },
+      { discrete: true },
+    );
+
+    expect(changeCount).toBe(0);
+
+    editor.update(
+      () => {
+        const lexicalParagraph = $getRoot().getFirstChild() as
+          | ParagraphNode
+          | undefined;
+        const lexicalText = lexicalParagraph?.getFirstChild() as
+          | TextNode
+          | undefined;
+        lexicalText?.setTextContent("Updated");
+      },
+      { discrete: true },
+    );
+
+    expect(changeCount).toBe(1);
+    expect(
+      (doc.root.first?.first as DocNode<typeof LexicalDocNode>).state.j.get()
+        .text,
+    ).toBe("Updated");
+    unregister();
+  });
+
   test("add paragraph to empty editor", () => {
     const editor = createEditor({
       namespace: "MyEditor",

--- a/tests/docnode/transactions.test.ts
+++ b/tests/docnode/transactions.test.ts
@@ -5,6 +5,7 @@ import {
   mergeOperations,
   type Operations,
   type TransactionFlags,
+  type UndoHistory,
 } from "@docukit/docnode";
 import {
   assertDoc,
@@ -421,6 +422,74 @@ describe("undoManager", () => {
     expect(() => otherDoc.undoManager.importHistory(history)).toThrowError(
       "Undo history belongs to a different document",
     );
+  });
+
+  test("exportHistory and importHistory clone move operations", () => {
+    const doc = createTextDocWithUndo();
+    const history: UndoHistory = {
+      ...doc.undoManager.exportHistory(),
+      undoStack: [{ operations: [[[2, "start", 0, 0, 0, 0]], {}], meta: {} }],
+    };
+
+    doc.undoManager.importHistory(history);
+
+    expect(doc.undoManager.exportHistory().undoStack).toStrictEqual(
+      history.undoStack,
+    );
+  });
+
+  test("importHistory rejects malformed exported history paths", () => {
+    const doc = createTextDocWithUndo();
+    const valid = doc.undoManager.exportHistory();
+    const withOperations = (operations: unknown): unknown => ({
+      ...valid,
+      undoStack: [{ operations, meta: {} }],
+    });
+
+    const malformedHistories: unknown[] = [
+      null,
+      [],
+      new Date(),
+      { ...valid, docId: 1 },
+      { ...valid, docType: 1 },
+      { ...valid, undoStack: null },
+      { ...valid, undoStack: [null] },
+      { ...valid, undoStack: [{ operations: [[], {}], meta: [] }] },
+      { ...valid, redoStack: null },
+      { ...valid, lastUpdate: "now" },
+      { ...valid, lastUpdate: Number.NaN },
+      withOperations(null),
+      withOperations([]),
+      withOperations([[]]),
+      withOperations([[null], {}]),
+      withOperations([[[0]], {}]),
+      withOperations([[[0, {}, 0, 0, 0]], {}]),
+      withOperations([[[0, [null], 0, 0, 0]], {}]),
+      withOperations([[[0, [["id"]], 0, 0, 0]], {}]),
+      withOperations([[[0, [["id", 1]], 0, 0, 0]], {}]),
+      withOperations([[[0, [["id", "type"]], null, 0, 0]], {}]),
+      withOperations([[[0, [["id", "type"]], 0, null, 0]], {}]),
+      withOperations([[[0, [["id", "type"]], 0, 0, null]], {}]),
+      withOperations([[[1]], {}]),
+      withOperations([[[1, 1, 0]], {}]),
+      withOperations([[[1, "start", null]], {}]),
+      withOperations([[[2]], {}]),
+      withOperations([[[2, 1, 0, 0, 0, 0]], {}]),
+      withOperations([[[2, "start", null, 0, 0, 0]], {}]),
+      withOperations([[[2, "start", 0, null, 0, 0]], {}]),
+      withOperations([[[2, "start", 0, 0, null, 0]], {}]),
+      withOperations([[[2, "start", 0, 0, 0, null]], {}]),
+      withOperations([[[3]], {}]),
+      withOperations([[], []]),
+      withOperations([[], { node: [] }]),
+      withOperations([[], { node: { value: 1 } }]),
+    ];
+
+    for (const malformed of malformedHistories) {
+      expect(() => doc.undoManager.importHistory(malformed)).toThrowError(
+        "Invalid undo history",
+      );
+    }
   });
 
   test("maxUndoSteps 0 disables undo history", () => {

--- a/tests/docnode/transactions.test.ts
+++ b/tests/docnode/transactions.test.ts
@@ -327,6 +327,102 @@ describe("undoManager", () => {
     });
   });
 
+  test("exportHistory and importHistory preserve undo, redo, and metadata", () => {
+    const source = createTextDocWithUndo();
+    let token = 0;
+    source.undoManager.onPush(({ meta }) => {
+      meta.set("selection", { token: token++ });
+    });
+
+    source.root.append(...text(source, "1"));
+    source.forceCommit();
+    source.root.append(...text(source, "2"));
+    source.forceCommit();
+    source.undoManager.undo();
+    assertDoc(source, ["1"]);
+
+    const history = source.undoManager.exportHistory();
+    expect(history.undoStack[0]?.meta).toStrictEqual({
+      selection: { token: 0 },
+    });
+    expect(history.redoStack[0]?.meta).toStrictEqual({
+      selection: { token: 2 },
+    });
+
+    const replacement = Doc.fromJSON(
+      {
+        type: "root",
+        extensions: [TextExtension],
+        undoManager: { maxUndoSteps: 10, mergeInterval: 0 },
+      },
+      source.toJSON({ unsafe: true }),
+    );
+    replacement.forceCommit();
+    replacement.undoManager.importHistory(history);
+
+    const restoredMetadata: unknown[] = [];
+    replacement.undoManager.onPop(({ meta }) => {
+      restoredMetadata.push(meta.get("selection"));
+    });
+
+    replacement.undoManager.redo();
+    assertDoc(replacement, ["1", "2"]);
+    replacement.undoManager.undo();
+    assertDoc(replacement, ["1"]);
+    replacement.undoManager.undo();
+    assertDoc(replacement, []);
+    expect(restoredMetadata).toStrictEqual([
+      { token: 2 },
+      undefined,
+      { token: 0 },
+    ]);
+  });
+
+  test("importHistory preserves the merge interval timestamp", () => {
+    withMockedDateNow((setNow) => {
+      const source = createTextDocWithUndo(10, 500);
+      setNow(1000);
+      source.root.append(...text(source, "a"));
+      source.forceCommit();
+
+      const history = source.undoManager.exportHistory();
+      expect(history.lastUpdate).toBe(1000);
+
+      const replacement = Doc.fromJSON(
+        {
+          type: "root",
+          extensions: [TextExtension],
+          undoManager: { maxUndoSteps: 10, mergeInterval: 500 },
+        },
+        source.toJSON({ unsafe: true }),
+      );
+      replacement.forceCommit();
+      replacement.undoManager.importHistory(history);
+
+      setNow(1200);
+      replacement.root.append(...text(replacement, "b"));
+      replacement.forceCommit();
+      replacement.undoManager.undo();
+      assertDoc(replacement, []);
+    });
+  });
+
+  test("importHistory validates the history and document identity", () => {
+    const source = createTextDocWithUndo();
+    source.root.append(...text(source, "1"));
+    source.forceCommit();
+    const history = source.undoManager.exportHistory();
+
+    expect(() => source.undoManager.importHistory({})).toThrowError(
+      "Invalid undo history",
+    );
+
+    const otherDoc = createTextDocWithUndo();
+    expect(() => otherDoc.undoManager.importHistory(history)).toThrowError(
+      "Undo history belongs to a different document",
+    );
+  });
+
   test("maxUndoSteps 0 disables undo history", () => {
     const doc = new Doc({ type: "root", extensions: [TextExtension] });
     const undoManager = doc.undoManager;

--- a/tests/docsync/int/index.browser.test.ts
+++ b/tests/docsync/int/index.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import { emptyIDB, testWrapper, waitForLocalBroadcast } from "./utils.js";
 
 describe("Local-First", () => {
@@ -173,26 +173,91 @@ describe("Local-First", () => {
       reference.doc?.forceCommit();
       otherDevice.doc?.forceCommit();
 
+      reference.addChild("Earlier");
+      reference.doc?.forceCommit();
+      await reference.assertIDBDoc({ doc: ["Earlier"], ops: [] });
+      await otherDevice.assertMemoryDoc(["Earlier"]);
+
       reference.disconnect();
 
       reference.addChild("Local");
       reference.doc?.forceCommit();
-      await reference.assertIDBDoc({ doc: [], ops: ["Local"] });
+      await reference.assertIDBDoc({ doc: ["Earlier"], ops: ["Local"] });
       await reference.assertCanUndo(true);
       const liveDoc = reference.doc;
 
       otherDevice.addChild("Remote");
       otherDevice.doc?.forceCommit();
-      await otherDevice.assertIDBDoc({ doc: ["Remote"], ops: [] });
+      await otherDevice.assertIDBDoc({ doc: ["Earlier", "Remote"], ops: [] });
 
       reference.connect();
 
-      await reference.assertMemoryDoc(["Remote", "Local"]);
+      await reference.assertMemoryDoc(["Earlier", "Local", "Remote"]);
       expect(reference.doc).not.toBe(liveDoc);
       await reference.assertCanUndo(true);
 
       reference.doc?.undoManager.undo();
+      await reference.assertMemoryDoc(["Earlier", "Remote"]);
+      await reference.assertCanUndo(true);
+
+      reference.doc?.undoManager.undo();
       await reference.assertMemoryDoc(["Remote"]);
+    });
+  });
+
+  test("reconnect preserves an edit made during asynchronous reconciliation", async () => {
+    await testWrapper(async ({ reference, otherDevice }) => {
+      await reference.loadDoc();
+      await otherDevice.loadDoc();
+      reference.doc?.forceCommit();
+      otherDevice.doc?.forceCommit();
+
+      reference.disconnect();
+      reference.addChild("Local");
+      reference.doc?.forceCommit();
+      await reference.assertIDBDoc({ doc: [], ops: ["Local"] });
+
+      otherDevice.addChild("Remote");
+      otherDevice.doc?.forceCommit();
+      await otherDevice.assertIDBDoc({ doc: ["Remote"], ops: [] });
+
+      const local = await reference.client["_localPromise"];
+      const provider = local.provider;
+      const transaction = provider.transaction.bind(provider);
+      let injectEdit = true;
+      const transactionSpy = vi
+        .spyOn(provider, "transaction")
+        .mockImplementation((mode, callback) => {
+          if (mode !== "readwrite" || !injectEdit) {
+            return transaction(mode, callback);
+          }
+          injectEdit = false;
+          return transaction(mode, async (ctx) => {
+            const result = callback(ctx);
+            reference.addChild("During reconciliation");
+            reference.doc?.forceCommit();
+            return result;
+          });
+        });
+
+      const liveDoc = reference.doc;
+      try {
+        reference.connect();
+
+        await reference.assertMemoryDoc([
+          "Remote",
+          "Local",
+          "During reconciliation",
+        ]);
+        expect(reference.doc).not.toBe(liveDoc);
+
+        reference.doc?.undoManager.undo();
+        await reference.assertMemoryDoc(["Remote", "Local"]);
+        reference.doc?.undoManager.undo();
+        await reference.assertMemoryDoc(["Remote"]);
+      } finally {
+        transactionSpy.mockRestore();
+      }
     });
   });
 

--- a/tests/docsync/int/index.browser.test.ts
+++ b/tests/docsync/int/index.browser.test.ts
@@ -166,6 +166,36 @@ describe("Local-First", () => {
     });
   });
 
+  test("reconnect preserves undo when concurrent operations replace the doc", async () => {
+    await testWrapper(async ({ reference, otherDevice }) => {
+      await reference.loadDoc();
+      await otherDevice.loadDoc();
+      reference.doc?.forceCommit();
+      otherDevice.doc?.forceCommit();
+
+      reference.disconnect();
+
+      reference.addChild("Local");
+      reference.doc?.forceCommit();
+      await reference.assertIDBDoc({ doc: [], ops: ["Local"] });
+      await reference.assertCanUndo(true);
+      const liveDoc = reference.doc;
+
+      otherDevice.addChild("Remote");
+      otherDevice.doc?.forceCommit();
+      await otherDevice.assertIDBDoc({ doc: ["Remote"], ops: [] });
+
+      reference.connect();
+
+      await reference.assertMemoryDoc(["Remote", "Local"]);
+      expect(reference.doc).not.toBe(liveDoc);
+      await reference.assertCanUndo(true);
+
+      reference.doc?.undoManager.undo();
+      await reference.assertMemoryDoc(["Remote"]);
+    });
+  });
+
   test("local broadcast changes are undoable by the same user in another tab", async () => {
     await testWrapper(async ({ reference, otherTab }) => {
       await reference.loadDoc();

--- a/tests/docsync/int/utils.ts
+++ b/tests/docsync/int/utils.ts
@@ -105,7 +105,9 @@ const ChildNode = defineNode({ type: "child", state: { value: string("") } });
 export const testDocConfig = {
   type: "test",
   extensions: [{ nodes: [ChildNode] }],
-  undoManager: { maxUndoSteps: 10 },
+  // Integration tests assert individual undo steps, so do not merge adjacent
+  // edits based on wall-clock timing.
+  undoManager: { maxUndoSteps: 10, mergeInterval: 0 },
 };
 
 // ============================================================================

--- a/tests/docsync/unit/client2/index.browser.test.ts
+++ b/tests/docsync/unit/client2/index.browser.test.ts
@@ -13,6 +13,7 @@ import {
   s,
   spyOnRequest,
   triggerSync,
+  cacheDoc,
 } from "./utils.js";
 import type { Operations } from "@docukit/docnode";
 
@@ -359,6 +360,54 @@ describe("Client 2", () => {
   // ──────────────────────────────────────────────────────────────────────────
 
   describe("handleSync - Success Path", () => {
+    test("keeps the replacement doc and resets status when history import throws", async () => {
+      const client = await createClient();
+      const docId = generateDocId();
+      const docBinding = client["_docBinding"];
+      const { doc: liveDoc } = await setupDocWithOperations(client, docId, {
+        operations: [],
+      });
+      cacheDoc(client, docId, liveDoc);
+
+      const { doc: serverDoc } = docBinding.create("test", docId);
+      serverDoc.root.append(serverDoc.createNode(ChildNode));
+      serverDoc.forceCommit();
+
+      const requestSpy = spyOnRequest(client);
+      requestSpy
+        .mockResolvedValueOnce({
+          data: s({
+            docId,
+            clock: 1,
+            serializedDoc: docBinding.serialize(serverDoc),
+          }),
+        })
+        .mockResolvedValue({ data: s({ docId, clock: 2 }) });
+
+      const importHistory = docBinding.importHistory;
+      if (!importHistory) throw new Error("Expected history support");
+      const importError = new Error("history import failed");
+      docBinding.importHistory = () => {
+        throw importError;
+      };
+
+      try {
+        await expect(client["_sync"](docId)).rejects.toBe(importError);
+      } finally {
+        docBinding.importHistory = importHistory;
+      }
+
+      expect(client["_pushStatusByDocId"].get(docId)).toBe("idle");
+      const replacementDoc = await client["_docsCache"].get(docId)?.promisedDoc;
+      expect(replacementDoc).toBeDefined();
+      expect(replacementDoc).not.toBe(liveDoc);
+      expect(replacementDoc?.root.first?.type).toBe("child");
+
+      await client["_sync"](docId);
+      expect(requestSpy).toHaveBeenCalledTimes(2);
+      expect(client["_pushStatusByDocId"].get(docId)).toBe("idle");
+    });
+
     test("should delete operations after successful push", async () => {
       const client = await createClient();
       const docId = generateDocId();

--- a/tests/docsync/unit/client2/utils.ts
+++ b/tests/docsync/unit/client2/utils.ts
@@ -184,6 +184,28 @@ export const getStoredClock = async (
   return stored?.clock;
 };
 
+export const cacheDoc = (
+  client: DocSyncClient<Doc, JsonDoc, Operations>,
+  docId: string,
+  doc = client["_docBinding"].create("test", docId).doc,
+) => {
+  client["_docsCache"].set(docId, {
+    promisedDoc: Promise.resolve(doc),
+    refCount: 1,
+    localVersion: 0,
+    type: "test",
+    queryResult: {
+      status: "success",
+      fetchStatus: "idle",
+      data: { doc, docId },
+    },
+    queryListeners: new Set(),
+    presence: {},
+    presenceListeners: new Set(),
+  });
+  return doc;
+};
+
 // ============================================================================
 // Sync Trigger (for tests)
 // ============================================================================
@@ -199,21 +221,7 @@ export const triggerSync = (
 ): void => {
   // Ensure a cache entry exists so handleSync can read the type
   if (!client["_docsCache"].has(docId)) {
-    const { doc } = client["_docBinding"].create("test", docId);
-    client["_docsCache"].set(docId, {
-      promisedDoc: Promise.resolve(doc),
-      refCount: 1,
-      localVersion: 0,
-      type: "test",
-      queryResult: {
-        status: "success",
-        fetchStatus: "idle",
-        data: { doc, docId },
-      },
-      queryListeners: new Set(),
-      presence: {},
-      presenceListeners: new Set(),
-    });
+    cacheDoc(client, docId);
   }
 
   const socket = client["_socket"] as unknown as {


### PR DESCRIPTION
## Summary

- add exportHistory/importHistory to DocNode UndoManager and expose the optional pair through DocBinding
- transfer undo/redo history when DocSync must replace a live document during snapshot or concurrent-operation reconciliation
- avoid redundant Lexical state operations for dirty nodes whose serialized JSON is structurally unchanged
- cover history validation, merge timing, concurrent replacement, and Lexical normalization regressions

## Why

DocSync sometimes must rebuild and replace a document to preserve canonical operation ordering. The replacement previously discarded undo/redo history. Separately, Lexical plugin initialization could emit a semantically unchanged local state operation; during stale-while-revalidate that stale operation could overwrite newer server content.

## Verification

- pnpm test:once (663 passed, 1 skipped, 7 todo)
- changed files pass Prettier, ESLint, and TypeScript checks
- regression test was verified to fail when the structural-equality guard was temporarily disabled

The repository-wide pnpm check still reports existing unresolved-type ESLint errors in docs/src; no changed source or test file has lint/type errors.