### PR TITLE
feat(docsync)!: reserve fetchStatus for document availability

### DIFF
--- a/docs/content/docs/docsync/auth.mdx
+++ b/docs/content/docs/docsync/auth.mdx
@@ -81,7 +81,9 @@ Token auth is a good fit for tests, workers, mobile apps, server-to-server sync,
 API keys, and short-lived scoped document grants.
 
 `getToken` runs when the socket connects or reconnects. It should read existing
-auth state. It should not perform a full login flow.
+auth state. It should not perform a full login flow. If it throws or returns a
+rejected promise, loaded queries receive a `ConnectionError` and pause until
+the application starts another connection attempt.
 
 ## Server Auth Input
 

--- a/docs/content/docs/docsync/client.mdx
+++ b/docs/content/docs/docsync/client.mdx
@@ -142,6 +142,17 @@ unsubscribe();
 the contract expected by external-store integrations such as React's
 `useSyncExternalStore`; `useDoc` uses this observer internally.
 
+`getSnapshot()` reports the state of the document itself, not of this observer.
+A document is shared by every consumer in the client, so an observer that has
+not subscribed yet already reports whatever another consumer has loaded for the
+same `id` — which is what lets a second component render a loaded document on
+its very first render instead of flashing `pending`. The same rule applies
+after `unsubscribe()`: the snapshot keeps reporting the document while another
+consumer holds it, and reports the last value it saw once nobody does. Only
+while at least one subscriber is active is the snapshot guaranteed to track a
+document that is still loaded, so read it outside a subscription for display
+only, and subscribe before using `data.doc`.
+
 ---
 
 ## useDoc
@@ -198,26 +209,62 @@ const result = useDoc({ type: "notes", id: "doc-123", createIfMissing: true });
     },
     fetchStatus: {
       description:
-        "Network activity for the document. Fetching means a connection or sync attempt is active or waiting for its scheduled retry, paused means it cannot continue until the connection returns, and idle means no network work is scheduled or running.",
+        "Whether the query can serve the authoritative document. Fetching means not yet, because it is loading for the first time or resynchronising after a reconnect. Paused means it cannot until the connection returns. Idle means it can, and is up to date. Routine background syncs and their retries do not change it.",
       type: '"fetching" | "paused" | "idle"',
       required: true,
     },
   }}
 />
 
-`status` describes the available result. `fetchStatus` independently describes
-network work, so local or stale data can remain available while synchronization
+`status` describes the available result. `fetchStatus` answers a different
+question: can the query serve the authoritative document right now? Because the
+two are independent, local or stale data stays available while synchronization
 is paused or a later sync has failed.
 
-| Situation                                          | `status`                         | `fetchStatus`      | Result                                                                                     |
-| -------------------------------------------------- | -------------------------------- | ------------------ | ------------------------------------------------------------------------------------------ |
-| Initial connection, reconnect, or active sync      | `pending`, `success`, or `error` | `fetching`         | Existing local data and errors are preserved                                               |
-| Temporarily offline or manually disconnected       | `pending`, `success`, or `error` | `paused`           | Existing local data and errors are preserved                                               |
-| Sync completed                                     | `success`                        | `idle`             | Server result is available, including `undefined` when an optional document does not exist |
-| Local storage failed                               | `error`                          | `idle` or `paused` | `error` contains the local failure; a disconnected query remains paused                    |
-| Authentication or permanent connection rejection   | `error`                          | `paused`           | `error` contains the connection failure                                                    |
-| Server permanently rejected a sync                 | `error`                          | `idle`             | Existing data is preserved and `error` contains the authorization or validation failure    |
-| Network or database attempt failed and is retrying | unchanged                        | `fetching`         | The query result remains unchanged while DocSync retries                                   |
+| Situation                                                  | `status`                         | `fetchStatus`      | Result                                                                                     |
+| ---------------------------------------------------------- | -------------------------------- | ------------------ | ------------------------------------------------------------------------------------------ |
+| Loading for the first time, or resyncing after a reconnect | `pending`, `success`, or `error` | `fetching`         | Existing local data and errors are preserved                                               |
+| Temporarily offline or manually disconnected               | `pending`, `success`, or `error` | `paused`           | Existing local data and errors are preserved                                               |
+| Document available and up to date                          | `success`                        | `idle`             | Server result is available, including `undefined` when an optional document does not exist |
+| A routine background sync is in flight                     | unchanged                        | unchanged          | Nothing is emitted: the document on screen is already correct                              |
+| Local storage failed                                       | `error`                          | `idle` or `paused` | `error` contains the local failure; a disconnected query remains paused                    |
+| Authentication or permanent connection rejection           | `error`                          | `paused`           | `error` contains the connection failure                                                    |
+| Server permanently rejected a sync                         | `error`                          | `idle`             | Existing data is preserved and `error` contains the authorization or validation failure    |
+| Network or database attempt failed and is retrying         | unchanged                        | unchanged          | The query result remains unchanged while DocSync retries                                   |
+
+### Background syncs do not report `fetching`
+
+DocSync is realtime over a persistent socket and applies your edits
+optimistically, so while a push travels to the server the document you are
+rendering is already correct. Remote operations coming back from other clients
+are applied to the same live document instance. Neither produces a new query
+result, so a document that is loaded and connected simply stays
+`success` / `idle` through all of it. Only a wholesale document replacement
+changes `data`, and that is rare.
+
+The alternative was considered and rejected: reporting every push as
+`idle → fetching → idle`, the way TanStack Query reports a background refetch.
+It overloads `fetchStatus` with a second meaning applications cannot act on,
+and it emits two new query results per sync — at the 50ms collaborative
+debounce, roughly 40 re-renders per second of everything under `useDoc`, for a
+document that never changed.
+
+**Want a "Saving…" indicator** like Google Docs? Build it from the client's
+`sync` event, which fires once per sync with the request and its outcome. That
+is the signal such an indicator actually needs, and keeping it out of
+`fetchStatus` costs nothing to applications that do not want one.
+
+```tsx
+const [saving, setSaving] = useState(false);
+
+useEffect(() => {
+  if (!client) return;
+  return client.on("sync", ({ error }) => {
+    setSaving(false);
+    if (error) console.warn("sync failed", error);
+  });
+}, []);
+```
 
 Because `data` and a terminal `error` can exist at the same time, applications
 should keep rendering usable data and show the later error separately. A paused
@@ -227,14 +274,15 @@ avoid a flash during short interruptions.
 Retries are not unlimited. While the current socket connection remains active,
 a failed sync request or a `DatabaseError` response is retried with exponential
 backoff for about 24 seconds. Failed attempts during that backoff do not change
-the query result. After the retry budget is exhausted, the query settles on
-`error` with `fetchStatus: "idle"` and keeps its data. At that point `error`
-means DocSync has stopped trying on its own.
+the query result at all. After the retry budget is exhausted, the query reports
+`error` and keeps its data. At that point `error` means DocSync has stopped
+trying on its own.
 
 A transport disconnect cancels that per-document retry and moves the query to
 `paused`. Socket.IO then owns reconnecting the transport. When the connection
-returns, DocSync resumes the document sync with a fresh retry budget. A later
-local edit also starts a fresh sync attempt after a bounded retry chain ends.
+returns, DocSync resumes the document sync. The retry budget covers one episode
+of failure, so a later edit gets its own bounded chain rather than failing on
+its first attempt.
 The package README contains the complete
 [error and retry policy](https://github.com/docukit/docukit/tree/main/packages/docsync#error-and-retry-policy),
 including permanent connection failures and errors raised by configured local

--- a/docs/content/docs/docsync/client.mdx
+++ b/docs/content/docs/docsync/client.mdx
@@ -163,8 +163,33 @@ const result = useDoc({ type: "notes", id: "doc-123", createIfMissing: true });
       description: "Error information when status is 'error'.",
       type: "Error",
     },
+    fetchStatus: {
+      description:
+        "Network activity for the document. Fetching means a sync is active, paused means it cannot continue until the connection returns, and idle means no network work is running.",
+      type: '"fetching" | "paused" | "idle"',
+      required: true,
+    },
   }}
 />
+
+`status` describes the available result. `fetchStatus` independently describes
+network work, so local or stale data can remain available while synchronization
+is paused or a later sync has failed.
+
+| Situation                                          | `status`                         | `fetchStatus`        | Result                                                                                     |
+| -------------------------------------------------- | -------------------------------- | -------------------- | ------------------------------------------------------------------------------------------ |
+| Initial connection or active sync                  | `pending`, `success`, or `error` | `fetching`           | Existing local data and errors are preserved                                               |
+| Temporarily offline or manually disconnected       | `pending`, `success`, or `error` | `paused`             | Existing local data and errors are preserved                                               |
+| Sync completed                                     | `success`                        | `idle`               | Server result is available, including `undefined` when an optional document does not exist |
+| Local storage failed                               | `error`                          | Current fetch status | `error` contains the local failure                                                         |
+| Authentication or permanent connection rejection   | `error`                          | `paused`             | `error` contains the connection failure                                                    |
+| Server permanently rejected a sync                 | `error`                          | `idle`               | Existing data is preserved and `error` contains the authorization or validation failure    |
+| Network or database attempt failed and is retrying | `error`                          | `fetching`           | Existing data and the latest error are preserved until a retry succeeds                    |
+
+Because `data` and `error` can exist at the same time, applications should keep
+rendering usable data and show the later error separately. A paused state is
+often transient, so applications may delay a connectivity notice to avoid a
+flash during short interruptions.
 
 ---
 

--- a/docs/content/docs/docsync/client.mdx
+++ b/docs/content/docs/docsync/client.mdx
@@ -192,6 +192,12 @@ rendering usable data and show the later error separately. A paused state is
 often transient, so applications may delay a connectivity notice to avoid a
 flash during short interruptions.
 
+Retries are not unlimited. A network or database failure is retried with
+exponential backoff for about 24 seconds; after that the query settles on
+`error` with `fetchStatus: "idle"` and keeps its data, so `error` together with
+`idle` means DocSync has stopped trying on its own. Any later edit or reconnect
+starts a fresh attempt.
+
 ---
 
 ## usePresence

--- a/docs/content/docs/docsync/client.mdx
+++ b/docs/content/docs/docsync/client.mdx
@@ -193,7 +193,7 @@ const result = useDoc({ type: "notes", id: "doc-123", createIfMissing: true });
     },
     error: {
       description:
-        "The failure that produced the current state. DocSync's own failures are DocSyncError instances, whose type field ('AuthorizationError', 'ConnectionError', 'DatabaseError', 'NetworkError' or 'ValidationError') can be branched on without matching the message.",
+        "The terminal failure that produced an error state. DocSync's own failures are DocSyncError instances, whose type field ('AuthorizationError', 'ConnectionError', 'DatabaseError', 'NetworkError' or 'ValidationError') can be branched on without matching the message.",
       type: "Error",
     },
     fetchStatus: {
@@ -217,23 +217,28 @@ is paused or a later sync has failed.
 | Local storage failed                               | `error`                          | `idle` or `paused` | `error` contains the local failure; a disconnected query remains paused                    |
 | Authentication or permanent connection rejection   | `error`                          | `paused`           | `error` contains the connection failure                                                    |
 | Server permanently rejected a sync                 | `error`                          | `idle`             | Existing data is preserved and `error` contains the authorization or validation failure    |
-| Network or database attempt failed and is retrying | `error`                          | `fetching`         | Existing data and the latest error are preserved until a retry succeeds                    |
+| Network or database attempt failed and is retrying | unchanged                        | `fetching`         | The query result remains unchanged while DocSync retries                                   |
 
-Because `data` and `error` can exist at the same time, applications should keep
-rendering usable data and show the later error separately. A paused state is
-often transient, so applications may delay a connectivity notice to avoid a
-flash during short interruptions.
+Because `data` and a terminal `error` can exist at the same time, applications
+should keep rendering usable data and show the later error separately. A paused
+state is often transient, so applications may delay a connectivity notice to
+avoid a flash during short interruptions.
 
 Retries are not unlimited. While the current socket connection remains active,
 a failed sync request or a `DatabaseError` response is retried with exponential
-backoff for about 24 seconds. After that the query settles on `error` with
-`fetchStatus: "idle"` and keeps its data, so `error` together with `idle` means
-DocSync has stopped trying on its own.
+backoff for about 24 seconds. Failed attempts during that backoff do not change
+the query result. After the retry budget is exhausted, the query settles on
+`error` with `fetchStatus: "idle"` and keeps its data. At that point `error`
+means DocSync has stopped trying on its own.
 
 A transport disconnect cancels that per-document retry and moves the query to
 `paused`. Socket.IO then owns reconnecting the transport. When the connection
 returns, DocSync resumes the document sync with a fresh retry budget. A later
 local edit also starts a fresh sync attempt after a bounded retry chain ends.
+The package README contains the complete
+[error and retry policy](https://github.com/docukit/docukit/tree/main/packages/docsync#error-and-retry-policy),
+including permanent connection failures and errors raised by configured local
+providers or document bindings.
 
 ---
 

--- a/docs/content/docs/docsync/client.mdx
+++ b/docs/content/docs/docsync/client.mdx
@@ -94,7 +94,7 @@ document grants.
   type={{
     client: {
       description:
-        "The underlying DocSyncClient instance. May be undefined during SSR. Its getDocResult({ id }) returns the QueryResult a subscription would report right now without subscribing; useDoc uses it to render a correct first frame.",
+        "The underlying DocSyncClient instance. May be undefined during SSR. Use getDocObserver(args) for imperative access to a stable QueryResult snapshot and later updates.",
       type: "DocSyncClient | undefined",
     },
     useDoc: {
@@ -109,6 +109,38 @@ document grants.
     },
   }}
 />
+
+---
+
+## getDocObserver
+
+Creates a lazy observer for imperative code. Calling `getSnapshot()` does not
+load the document. The first subscriber starts the query, and removing the last
+subscriber releases it. One observer can have multiple subscribers while using
+only one underlying document subscription.
+
+```ts
+const observer = client.getDocObserver({
+  type: "notes",
+  id: "doc-123",
+  createIfMissing: true,
+});
+
+const render = () => {
+  const result = observer.getSnapshot();
+  if (result.status === "success") console.log(result.data.doc);
+};
+
+const unsubscribe = observer.subscribe(render);
+render();
+
+// Later, when this consumer no longer needs the document:
+unsubscribe();
+```
+
+`getSnapshot()` returns the same object until the query state changes. This is
+the contract expected by external-store integrations such as React's
+`useSyncExternalStore`; `useDoc` uses this observer internally.
 
 ---
 

--- a/docs/content/docs/docsync/client.mdx
+++ b/docs/content/docs/docsync/client.mdx
@@ -156,11 +156,12 @@ const result = useDoc({ type: "notes", id: "doc-123", createIfMissing: true });
     },
     data: {
       description:
-        "The document data when status is 'success'. Contains doc (the DocNode instance) and id (document ID). Undefined if document not found.",
-      type: "{ doc: D; id: string } | undefined",
+        "The document data: doc (the DocNode instance) and docId (document ID). Undefined when the document was not found, and still present when a later sync fails, so stale content stays renderable alongside an error.",
+      type: "{ doc: D; docId: string } | undefined",
     },
     error: {
-      description: "Error information when status is 'error'.",
+      description:
+        "The failure that produced the current state. DocSync's own failures are DocSyncError instances, whose type field ('AuthorizationError', 'ConnectionError', 'DatabaseError', 'NetworkError' or 'ValidationError') can be branched on without matching the message.",
       type: "Error",
     },
     fetchStatus: {

--- a/docs/content/docs/docsync/client.mdx
+++ b/docs/content/docs/docsync/client.mdx
@@ -278,6 +278,12 @@ the query result at all. After the retry budget is exhausted, the query reports
 `error` and keeps its data. At that point `error` means DocSync has stopped
 trying on its own.
 
+That means a loaded document whose background syncs start failing keeps
+reporting `success` for up to 24 seconds before the failure reaches
+`QueryResult`. Nothing is lost — the edits were already written to local
+storage — but if you want to react sooner, listen to the `sync` event, which
+fires on every attempt including the failed ones.
+
 A transport disconnect cancels that per-document retry and moves the query to
 `paused`. Socket.IO then owns reconnecting the transport. When the connection
 returns, DocSync resumes the document sync. The retry budget covers one episode

--- a/docs/content/docs/docsync/client.mdx
+++ b/docs/content/docs/docsync/client.mdx
@@ -166,7 +166,7 @@ const result = useDoc({ type: "notes", id: "doc-123", createIfMissing: true });
     },
     fetchStatus: {
       description:
-        "Network activity for the document. Fetching means a sync is active, paused means it cannot continue until the connection returns, and idle means no network work is running.",
+        "Network activity for the document. Fetching means a connection or sync attempt is active or waiting for its scheduled retry, paused means it cannot continue until the connection returns, and idle means no network work is scheduled or running.",
       type: '"fetching" | "paused" | "idle"',
       required: true,
     },
@@ -177,26 +177,31 @@ const result = useDoc({ type: "notes", id: "doc-123", createIfMissing: true });
 network work, so local or stale data can remain available while synchronization
 is paused or a later sync has failed.
 
-| Situation                                          | `status`                         | `fetchStatus`        | Result                                                                                     |
-| -------------------------------------------------- | -------------------------------- | -------------------- | ------------------------------------------------------------------------------------------ |
-| Initial connection or active sync                  | `pending`, `success`, or `error` | `fetching`           | Existing local data and errors are preserved                                               |
-| Temporarily offline or manually disconnected       | `pending`, `success`, or `error` | `paused`             | Existing local data and errors are preserved                                               |
-| Sync completed                                     | `success`                        | `idle`               | Server result is available, including `undefined` when an optional document does not exist |
-| Local storage failed                               | `error`                          | Current fetch status | `error` contains the local failure                                                         |
-| Authentication or permanent connection rejection   | `error`                          | `paused`             | `error` contains the connection failure                                                    |
-| Server permanently rejected a sync                 | `error`                          | `idle`               | Existing data is preserved and `error` contains the authorization or validation failure    |
-| Network or database attempt failed and is retrying | `error`                          | `fetching`           | Existing data and the latest error are preserved until a retry succeeds                    |
+| Situation                                          | `status`                         | `fetchStatus`      | Result                                                                                     |
+| -------------------------------------------------- | -------------------------------- | ------------------ | ------------------------------------------------------------------------------------------ |
+| Initial connection, reconnect, or active sync      | `pending`, `success`, or `error` | `fetching`         | Existing local data and errors are preserved                                               |
+| Temporarily offline or manually disconnected       | `pending`, `success`, or `error` | `paused`           | Existing local data and errors are preserved                                               |
+| Sync completed                                     | `success`                        | `idle`             | Server result is available, including `undefined` when an optional document does not exist |
+| Local storage failed                               | `error`                          | `idle` or `paused` | `error` contains the local failure; a disconnected query remains paused                    |
+| Authentication or permanent connection rejection   | `error`                          | `paused`           | `error` contains the connection failure                                                    |
+| Server permanently rejected a sync                 | `error`                          | `idle`             | Existing data is preserved and `error` contains the authorization or validation failure    |
+| Network or database attempt failed and is retrying | `error`                          | `fetching`         | Existing data and the latest error are preserved until a retry succeeds                    |
 
 Because `data` and `error` can exist at the same time, applications should keep
 rendering usable data and show the later error separately. A paused state is
 often transient, so applications may delay a connectivity notice to avoid a
 flash during short interruptions.
 
-Retries are not unlimited. A network or database failure is retried with
-exponential backoff for about 24 seconds; after that the query settles on
-`error` with `fetchStatus: "idle"` and keeps its data, so `error` together with
-`idle` means DocSync has stopped trying on its own. Any later edit or reconnect
-starts a fresh attempt.
+Retries are not unlimited. While the current socket connection remains active,
+a failed sync request or a `DatabaseError` response is retried with exponential
+backoff for about 24 seconds. After that the query settles on `error` with
+`fetchStatus: "idle"` and keeps its data, so `error` together with `idle` means
+DocSync has stopped trying on its own.
+
+A transport disconnect cancels that per-document retry and moves the query to
+`paused`. Socket.IO then owns reconnecting the transport. When the connection
+returns, DocSync resumes the document sync with a fresh retry budget. A later
+local edit also starts a fresh sync attempt after a bounded retry chain ends.
 
 ---
 

--- a/docs/content/docs/docsync/client.mdx
+++ b/docs/content/docs/docsync/client.mdx
@@ -94,7 +94,7 @@ document grants.
   type={{
     client: {
       description:
-        "The underlying DocSyncClient instance. May be undefined during SSR.",
+        "The underlying DocSyncClient instance. May be undefined during SSR. Its getDocResult({ id }) returns the QueryResult a subscription would report right now without subscribing; useDoc uses it to render a correct first frame.",
       type: "DocSyncClient | undefined",
     },
     useDoc: {

--- a/docs/src/components/examples/editor/EditorExample.tsx
+++ b/docs/src/components/examples/editor/EditorExample.tsx
@@ -237,9 +237,12 @@ function EditorContent({
     createIfMissing: true,
   });
   const [presence, setPresence] = usePresenceHook({ docId });
-  const isReady = status === "success" && data.docId === docId;
+  // `data` and `error` can coexist: a sync failure does not invalidate the doc
+  // already loaded from local storage, so keep editing available and report the
+  // failure next to it instead of replacing the editor with an error screen.
+  const isReady = data?.docId === docId;
 
-  if (status === "error") {
+  if (!isReady && status === "error") {
     return <div className="text-destructive">Error: {error.message}</div>;
   }
 
@@ -248,6 +251,14 @@ function EditorContent({
       ariaLabel={isReady ? undefined : "Loading editor"}
       isLoading={!isReady}
     >
+      {status === "error" ? (
+        <div
+          data-testid="query-error"
+          className="text-destructive px-2 py-1 text-sm"
+        >
+          {error.message}
+        </div>
+      ) : null}
       {isReady ? (
         <EditorPanel
           key={`${clientId}:${docId}`}

--- a/docs/src/components/examples/subdocs/SubdocsExample.tsx
+++ b/docs/src/components/examples/subdocs/SubdocsExample.tsx
@@ -190,7 +190,10 @@ function SubDocContent({
   return (
     <SubdocsPanelFrame isLoading={!isReady}>
       {status === "error" ? (
-        <div className="text-destructive px-2 py-1 text-sm">
+        <div
+          data-testid="query-error"
+          className="text-destructive px-2 py-1 text-sm"
+        >
           {error.message}
         </div>
       ) : null}
@@ -207,14 +210,20 @@ function SubDocContent({
           {secondaryDoc ? (
             <div className="secondary-doc flex-1">
               {secondaryResult.status === "error" ? (
-                <div className="text-destructive px-2 py-1 text-sm">
+                <div
+                  data-testid="query-error"
+                  className="text-destructive px-2 py-1 text-sm"
+                >
                   {secondaryResult.error.message}
                 </div>
               ) : null}
               <IndexDoc doc={secondaryDoc} />
             </div>
           ) : activeDoc && secondaryResult.status === "error" ? (
-            <div className="text-destructive secondary-doc flex-1 px-2 py-1 text-sm">
+            <div
+              data-testid="query-error"
+              className="text-destructive secondary-doc flex-1 px-2 py-1 text-sm"
+            >
               {secondaryResult.error.message}
             </div>
           ) : activeDoc ? (

--- a/docs/src/components/examples/subdocs/SubdocsExample.tsx
+++ b/docs/src/components/examples/subdocs/SubdocsExample.tsx
@@ -158,10 +158,10 @@ function SubDocContent({
     createIfMissing: true,
   });
   const secondaryDocReady =
-    activeDoc &&
-    secondaryResult.status === "success" &&
-    secondaryResult.data.docId === activeDoc;
-  const secondaryDoc = secondaryDocReady ? secondaryResult.data.doc : undefined;
+    activeDoc && secondaryResult.data?.docId === activeDoc;
+  const secondaryDoc = secondaryDocReady
+    ? secondaryResult.data?.doc
+    : undefined;
 
   useEffect(() => {
     if (!shouldInitialize) return;
@@ -180,15 +180,20 @@ function SubDocContent({
     );
   }, [data, shouldInitialize]);
 
-  const isReady = status === "success" && data.docId === docId;
-  const indexDoc = isReady ? data.doc : undefined;
+  const isReady = data?.docId === docId;
+  const indexDoc = isReady ? data?.doc : undefined;
 
-  if (status === "error") {
+  if (!isReady && status === "error") {
     return <div className="text-destructive">Error: {error.message}</div>;
   }
 
   return (
     <SubdocsPanelFrame isLoading={!isReady}>
+      {status === "error" ? (
+        <div className="text-destructive px-2 py-1 text-sm">
+          {error.message}
+        </div>
+      ) : null}
       {indexDoc ? (
         <div className="flex gap-3" id={clientId} key={`${clientId}:${docId}`}>
           <div className="main-doc flex-1">
@@ -201,7 +206,16 @@ function SubDocContent({
           <div className="bg-fd-border w-px" />
           {secondaryDoc ? (
             <div className="secondary-doc flex-1">
+              {secondaryResult.status === "error" ? (
+                <div className="text-destructive px-2 py-1 text-sm">
+                  {secondaryResult.error.message}
+                </div>
+              ) : null}
               <IndexDoc doc={secondaryDoc} />
+            </div>
+          ) : activeDoc && secondaryResult.status === "error" ? (
+            <div className="text-destructive secondary-doc flex-1 px-2 py-1 text-sm">
+              {secondaryResult.error.message}
             </div>
           ) : activeDoc ? (
             <SecondaryDocLoading />

--- a/docs/src/components/examples/utils/createMultiClients.tsx
+++ b/docs/src/components/examples/utils/createMultiClients.tsx
@@ -14,9 +14,16 @@ const createClientForUser = (
   deviceId: string,
   docConfigs: DocConfig[],
 ) => {
-  // Force specific deviceId in localStorage before creating client
+  // This demo fakes several users inside a single browser origin, which DocSync
+  // does not support on its own: it keeps one local identity per origin, so the
+  // first client to be authenticated would make every later client claim that
+  // same user and the server would reject the mismatched ones. Pinning both
+  // keys before constructing each client keeps every synthetic user claiming
+  // the user its token actually authenticates as. Real applications have one
+  // user per origin and never need this.
   if (typeof window !== "undefined") {
     localStorage.setItem("docsync:deviceId", deviceId);
+    localStorage.setItem("docsync:localUserId", userId);
   }
 
   return createDocSyncClient({

--- a/packages/docsync-react/src/index.tsx
+++ b/packages/docsync-react/src/index.tsx
@@ -51,16 +51,24 @@ export function createDocSyncClient<T extends ClientConfig<any, any, any>>(
     createIfMissing?: boolean;
   }): QueryResult<DocData | undefined>;
   function useDoc(args: GetDocArgs): QueryResult<DocData | undefined> {
-    const [result, setResult] = useState<QueryResult<DocData | undefined>>({
-      status: "pending",
-      fetchStatus: "fetching",
-    });
     const id = args.id;
     const createIfMissing = "createIfMissing" in args && args.createIfMissing;
     const type = args.type;
     const getDocArgs = useMemo<GetDocArgs>(
       () => ({ type, id, createIfMissing }),
       [id, type, createIfMissing],
+    );
+    // The subscription only starts in the effect below. Reading the client's
+    // current result first keeps the first frame consistent with every other
+    // subscription instead of always claiming `pending` + `fetching`. During
+    // SSR there is no client, so the same fallback the client would report for
+    // a fresh connection is used.
+    const [result, setResult] = useState<QueryResult<DocData | undefined>>(
+      () =>
+        client?.getDocResult({ id }) ?? {
+          status: "pending",
+          fetchStatus: "fetching",
+        },
     );
 
     useEffect(() => {

--- a/packages/docsync-react/src/index.tsx
+++ b/packages/docsync-react/src/index.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import {
   DocSyncClient,
   type ClientConfig,
@@ -39,6 +45,12 @@ export function createDocSyncClient<T extends ClientConfig<any, any, any>>(
       : undefined;
 
   type DocData = { doc: D; docId: string };
+  const serverSnapshot: QueryResult<DocData | undefined> = {
+    status: "pending",
+    fetchStatus: "fetching",
+  };
+  const getServerSnapshot = () => serverSnapshot;
+  const subscribeWithoutClient = () => () => undefined;
 
   function useDoc(args: {
     type: string;
@@ -58,25 +70,20 @@ export function createDocSyncClient<T extends ClientConfig<any, any, any>>(
       () => ({ type, id, createIfMissing }),
       [id, type, createIfMissing],
     );
-    // The subscription only starts in the effect below. Reading the client's
-    // current result first keeps the first frame consistent with every other
-    // subscription instead of always claiming `pending` + `fetching`. During
-    // SSR there is no client, so the same fallback the client would report for
-    // a fresh connection is used.
-    const [result, setResult] = useState<QueryResult<DocData | undefined>>(
-      () =>
-        client?.getDocResult({ id }) ?? {
-          status: "pending",
-          fetchStatus: "fetching",
-        },
+    const observer = useMemo(
+      () => client?.getDocObserver(getDocArgs),
+      [getDocArgs],
     );
 
-    useEffect(() => {
-      if (!client) return;
-      return client.getDoc(getDocArgs, setResult);
-    }, [getDocArgs]);
-
-    return result;
+    // One snapshot source is used for both the first client render and every
+    // later update. This prevents a changed id from briefly rendering the
+    // previous document and gives React the consistency checks it needs for an
+    // external store. SSR uses a stable pending snapshot until hydration.
+    return useSyncExternalStore(
+      observer?.subscribe ?? subscribeWithoutClient,
+      observer?.getSnapshot ?? getServerSnapshot,
+      getServerSnapshot,
+    );
   }
 
   function usePresence(args: { docId: string | undefined }) {

--- a/packages/docsync/README.md
+++ b/packages/docsync/README.md
@@ -28,6 +28,13 @@ so a later edit gets its own bounded chain. If a newer sync was queued while an
 attempt was in flight, the queued sync runs before the failed attempt can
 become a terminal query error.
 
+A loaded document whose background syncs start failing therefore keeps
+reporting `success` for as long as the retry chain lasts — up to about 24
+seconds — before `error` appears on the query. The edits are already in local
+storage, so nothing is lost, but an application that wants to react sooner
+should listen to the `sync` event, which fires on every attempt including the
+failed ones.
+
 For user interfaces, treat `error` as actionable and `paused` as potentially
 temporary. An application can keep rendering stale data alongside an error and
 may delay a connectivity notice to avoid flashing warnings during brief

--- a/packages/docsync/README.md
+++ b/packages/docsync/README.md
@@ -8,28 +8,70 @@ meaning: it is set only when DocSync cannot make progress automatically. A
 failed attempt does not change the query result while a retry or a newer queued
 sync can still succeed.
 
-| Failure or situation                                                        | Automatic policy                                                             | Query result exposed to applications                                                                 |
-| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Server returns `AuthorizationError`                                         | Do not retry because the same request will be rejected again                 | Set `status: "error"` immediately and preserve existing data                                         |
-| Server returns `ValidationError`                                            | Do not retry because the request must change first                           | Set `status: "error"` immediately and preserve existing data                                         |
-| Server returns `DatabaseError`                                              | Retry eight times with exponential backoff for about 24 seconds              | Keep the current result with `fetchStatus: "fetching"`; set `error` only after retries are exhausted |
-| A sync request fails at the transport level                                 | Convert it to `NetworkError` and use the same bounded retry policy           | Keep the current result with `fetchStatus: "fetching"`; set `error` only after retries are exhausted |
-| Local storage or a configured local provider throws                         | Do not retry automatically                                                   | Set `status: "error"` immediately; the original error is preserved                                   |
-| A document binding throws during sync                                       | Do not retry automatically; rethrow so the programming failure stays visible | Set `status: "error"` immediately unless a newer sync is already queued                              |
-| Getting an authentication token fails                                       | Stop the connection attempt                                                  | Set `ConnectionError` immediately with `fetchStatus: "paused"`                                       |
-| The server permanently rejects or ends the connection                       | Stop reconnecting automatically                                              | Set `ConnectionError` immediately with `fetchStatus: "paused"`                                       |
-| The transport disconnects temporarily while Socket.IO is still reconnecting | Let Socket.IO reconnect; cancel document retry timers until it does          | Preserve `status`, `data`, and any existing `error`; set `fetchStatus: "paused"`                     |
-| The application disconnects manually                                        | Do not treat an intentional action as a failure                              | Preserve the result without adding an error; set `fetchStatus: "paused"`                             |
+| Failure or situation                                                        | Automatic policy                                                             | Query result exposed to applications                                             |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Server returns `AuthorizationError`                                         | Do not retry because the same request will be rejected again                 | Set `status: "error"` immediately and preserve existing data                     |
+| Server returns `ValidationError`                                            | Do not retry because the request must change first                           | Set `status: "error"` immediately and preserve existing data                     |
+| Server returns `DatabaseError`                                              | Retry eight times with exponential backoff for about 24 seconds              | Leave the current result untouched; set `error` only after retries are exhausted |
+| A sync request fails at the transport level                                 | Convert it to `NetworkError` and use the same bounded retry policy           | Leave the current result untouched; set `error` only after retries are exhausted |
+| Local storage or a configured local provider throws                         | Do not retry automatically                                                   | Set `status: "error"` immediately; the original error is preserved               |
+| A document binding throws during sync                                       | Do not retry automatically; rethrow so the programming failure stays visible | Set `status: "error"` immediately unless a newer sync is already queued          |
+| Getting an authentication token fails                                       | Stop the connection attempt                                                  | Set `ConnectionError` immediately with `fetchStatus: "paused"`                   |
+| The server permanently rejects or ends the connection                       | Stop reconnecting automatically                                              | Set `ConnectionError` immediately with `fetchStatus: "paused"`                   |
+| The transport disconnects temporarily while Socket.IO is still reconnecting | Let Socket.IO reconnect; cancel document retry timers until it does          | Preserve `status`, `data`, and any existing `error`; set `fetchStatus: "paused"` |
+| The application disconnects manually                                        | Do not treat an intentional action as a failure                              | Preserve the result without adding an error; set `fetchStatus: "paused"`         |
 
 The document retry delays are approximately `300ms`, `600ms`, `1.2s`, `2.4s`,
-`4.8s`, then `5s` three times. A successful sync or transport reconnect resets
-the retry budget. If a newer sync was queued while an attempt was in flight,
-the queued sync runs before the failed attempt can become a terminal query
-error.
+`4.8s`, then `5s` three times. The budget covers one episode of failure: a
+successful sync, a transport reconnect, and exhausting the budget all reset it,
+so a later edit gets its own bounded chain. If a newer sync was queued while an
+attempt was in flight, the queued sync runs before the failed attempt can
+become a terminal query error.
 
 For user interfaces, treat `error` as actionable and `paused` as potentially
 temporary. An application can keep rendering stale data alongside an error and
 may delay a connectivity notice to avoid flashing warnings during brief
-interruptions. `fetchStatus: "fetching"` means work is active or waiting for a
-scheduled retry; it does not by itself distinguish an ordinary sync from a
-retry.
+interruptions.
+
+## What `fetchStatus` does and does not mean
+
+`fetchStatus` answers exactly one question: can this query serve the
+authoritative document right now?
+
+- `fetching` — not yet. It is loading for the first time, resynchronising after
+  a reconnect, or waiting on a scheduled retry.
+- `idle` — yes, and it is up to date.
+- `paused` — no, and it will not be until the connection returns.
+
+A routine background sync does **not** change that answer, and therefore does
+not change the query result at all. DocSync is realtime over a persistent
+socket and applies local edits optimistically, so while a push is in flight the
+document the user is reading is already correct. Remote operations arriving
+from other clients are applied to the same live document instance rather than
+replacing it. Only a wholesale document replacement changes `data`, and that is
+rare.
+
+### The alternative that was rejected
+
+Flipping `idle → fetching → idle` around every sync — the way TanStack Query
+reports a background refetch — was considered and deliberately not adopted. It
+overloads `fetchStatus` with a second, unrelated meaning ("a push is in
+flight") that applications cannot act on, and it emits two new query results
+per sync. At the 50ms collaborative debounce that is roughly 40 re-renders per
+second of everything rendered under `useDoc`, for a document whose identity
+never changed. Measured on the current test client: 5 background syncs emit 0
+query results, against 10 under the rejected design.
+
+### Building a "Saving…" indicator
+
+If you want a Google Docs style save indicator, build it from the `sync` event
+rather than from `fetchStatus`. It fires once per sync with the request and its
+outcome, which is the signal such an indicator needs, and keeping it out of the
+query result costs nothing to applications that do not want one.
+
+```ts
+client.on("sync", ({ req, data, error }) => {
+  // `req` is the outgoing sync request, `data` the server result,
+  // `error` the failure when the sync did not succeed.
+});
+```

--- a/packages/docsync/README.md
+++ b/packages/docsync/README.md
@@ -1,1 +1,35 @@
 Visit [our website](https://docukit.dev) for documentation and more.
+
+## Error and retry policy
+
+DocSync reports every server response or transport-level request failure
+immediately through the `sync` event. `QueryResult.error` has a narrower
+meaning: it is set only when DocSync cannot make progress automatically. A
+failed attempt does not change the query result while a retry or a newer queued
+sync can still succeed.
+
+| Failure or situation                                                        | Automatic policy                                                             | Query result exposed to applications                                                                 |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Server returns `AuthorizationError`                                         | Do not retry because the same request will be rejected again                 | Set `status: "error"` immediately and preserve existing data                                         |
+| Server returns `ValidationError`                                            | Do not retry because the request must change first                           | Set `status: "error"` immediately and preserve existing data                                         |
+| Server returns `DatabaseError`                                              | Retry eight times with exponential backoff for about 24 seconds              | Keep the current result with `fetchStatus: "fetching"`; set `error` only after retries are exhausted |
+| A sync request fails at the transport level                                 | Convert it to `NetworkError` and use the same bounded retry policy           | Keep the current result with `fetchStatus: "fetching"`; set `error` only after retries are exhausted |
+| Local storage or a configured local provider throws                         | Do not retry automatically                                                   | Set `status: "error"` immediately; the original error is preserved                                   |
+| A document binding throws during sync                                       | Do not retry automatically; rethrow so the programming failure stays visible | Set `status: "error"` immediately unless a newer sync is already queued                              |
+| Getting an authentication token fails                                       | Stop the connection attempt                                                  | Set `ConnectionError` immediately with `fetchStatus: "paused"`                                       |
+| The server permanently rejects or ends the connection                       | Stop reconnecting automatically                                              | Set `ConnectionError` immediately with `fetchStatus: "paused"`                                       |
+| The transport disconnects temporarily while Socket.IO is still reconnecting | Let Socket.IO reconnect; cancel document retry timers until it does          | Preserve `status`, `data`, and any existing `error`; set `fetchStatus: "paused"`                     |
+| The application disconnects manually                                        | Do not treat an intentional action as a failure                              | Preserve the result without adding an error; set `fetchStatus: "paused"`                             |
+
+The document retry delays are approximately `300ms`, `600ms`, `1.2s`, `2.4s`,
+`4.8s`, then `5s` three times. A successful sync or transport reconnect resets
+the retry budget. If a newer sync was queued while an attempt was in flight,
+the queued sync runs before the failed attempt can become a terminal query
+error.
+
+For user interfaces, treat `error` as actionable and `paused` as potentially
+temporary. An application can keep rendering stale data alongside an error and
+may delay a connectivity notice to avoid flashing warnings during brief
+interruptions. `fetchStatus: "fetching"` means work is active or waiting for a
+scheduled retry; it does not by itself distinguish an ordinary sync from a
+retry.

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
@@ -46,16 +46,26 @@ export async function prepareSyncReconciliation<
     operationsBatches: O[][];
     localOperations: O[];
     data: Extract<SyncResponse<S, O>, { data: unknown }>["data"];
+    isCurrent: () => boolean;
   },
 ): Promise<PreparedSyncReconciliation<D, O>> {
-  const { provider, docId, operationsBatches, localOperations, data } = args;
+  const {
+    provider,
+    docId,
+    operationsBatches,
+    localOperations,
+    data,
+    isCurrent,
+  } = args;
   const hasServerSnapshot = data.serializedDoc !== null;
   let didConsolidate = false;
   let pendingProviderOperations: O[] = [];
   let replacementDoc: D | undefined;
 
   await provider.transaction("readwrite", async (ctx) => {
+    if (!isCurrent()) return;
     const stored = await ctx.getSerializedDoc({ docId });
+    if (!isCurrent()) return;
     // A newer sync already updated IndexedDB; this response must not rewind it.
     if (stored !== undefined && stored.clock > data.clock) {
       return;
@@ -83,6 +93,7 @@ export async function prepareSyncReconciliation<
     }
 
     const currentOperationsBatches = await ctx.getOperations({ docId });
+    if (!isCurrent()) return;
     pendingProviderOperations = currentOperationsBatches
       .slice(operationsBatches.length)
       .flat();
@@ -93,9 +104,14 @@ export async function prepareSyncReconciliation<
     const serializedDoc = client["_docBinding"].serialize(doc);
 
     const recheckStored = await ctx.getSerializedDoc({ docId });
+    if (!isCurrent()) return;
     if (stored !== undefined && recheckStored?.clock !== stored.clock) return;
     if (stored === undefined && recheckStored !== undefined) return;
 
+    // Once the snapshot write starts, finish the matching operation cleanup in
+    // this transaction even if the connection changes. Returning between the
+    // two writes could commit a snapshot that already contains the operations
+    // while leaving those same operations queued to be applied a second time.
     await ctx.saveSerializedDoc({ serializedDoc, docId, clock: data.clock });
     if (operationsBatches.length > 0) {
       await ctx.deleteOperations({ docId, count: operationsBatches.length });

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -1,7 +1,6 @@
 import type { SyncRequest, SyncResponse } from "../../../../shared/types.js";
 import type { DocSyncClient } from "../../../index.js";
 import {
-  dispatchDocQueryFetchStarted,
   dispatchLocalDocFound,
   dispatchNetworkDocFound,
   dispatchNetworkDocNotFound,
@@ -325,7 +324,6 @@ export const handleSync = async <
   // syncing until a reload. Reset the status and rethrow so the failure stays
   // loud.
   try {
-    dispatchDocQueryFetchStarted(client, docId);
     if (client["_localOpsBatchState"].has(docId)) {
       await client["_flushLocalOperations"](docId, { sync: false });
     }
@@ -513,12 +511,16 @@ export const handleSync = async <
     });
   } catch (error) {
     if (didFinishSyncAttempt) throw error;
-    // A superseded attempt has no state left to protect and no authority to
-    // surface failures. The current attempt still reports and rethrows so a
-    // provider or binding bug remains loud.
     const hasPendingSync =
       pushStatusByDocId.get(docId) === "pushing-with-pending";
-    if (!finishSyncAttempt(client, docId, syncAttempt)) return;
+    // A superseded attempt loses the right to report on the query — a newer
+    // attempt owns it now — but not the failure itself, which is just as real
+    // whichever attempt hit it. So it skips the dispatch and still rethrows,
+    // exactly like the current attempt does below. Callers use
+    // `void handleSync(...)`, so both paths surface as an unhandled rejection:
+    // loud in the console, and a failing test under Vitest, which is what a
+    // provider or binding bug has to be.
+    if (!finishSyncAttempt(client, docId, syncAttempt)) throw error;
     if (!hasPendingSync) {
       try {
         dispatchNetworkQueryError(

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -255,8 +255,8 @@ function finishFailedSyncAttempt<
 
 /**
  * Reports a finished attempt once. A scheduled retry or a sync queued during
- * the failed request keeps the query on `fetching`; the queued sync starts here
- * only when no retry already covers it.
+ * the failed request keeps the existing query result unchanged; the queued
+ * sync starts here only when no retry already covers it.
  */
 function reportFinishedSyncError<
   D extends object,
@@ -270,12 +270,9 @@ function reportFinishedSyncError<
 ): void {
   const { hasPendingSync, retrying } = continuation;
   try {
-    dispatchNetworkQueryError(
-      client,
-      docId,
-      error,
-      retrying || hasPendingSync ? "fetching" : undefined,
-    );
+    if (!retrying && !hasPendingSync) {
+      dispatchNetworkQueryError(client, docId, error);
+    }
   } finally {
     if (
       hasPendingSync &&
@@ -522,16 +519,17 @@ export const handleSync = async <
     const hasPendingSync =
       pushStatusByDocId.get(docId) === "pushing-with-pending";
     if (!finishSyncAttempt(client, docId, syncAttempt)) return;
-    try {
-      dispatchNetworkQueryError(
-        client,
-        docId,
-        error instanceof Error ? error : new Error(String(error)),
-        hasPendingSync ? "fetching" : undefined,
-      );
-    } catch {
-      // Reporting the failure on the query must never replace the failure
-      // itself — the rethrow below is what keeps it loud.
+    if (!hasPendingSync) {
+      try {
+        dispatchNetworkQueryError(
+          client,
+          docId,
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      } catch {
+        // Reporting the failure on the query must never replace the failure
+        // itself — the rethrow below is what keeps it loud.
+      }
     }
     if (hasPendingSync && pushStatusByDocId.get(docId) === "idle") {
       void handleSync(client, docId);

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -12,7 +12,11 @@ import { getOwnPresencePatch } from "../../../utils/getOwnPresencePatch.js";
 import { getLocalDocVersion } from "../../../utils/localDocVersion.js";
 import { request } from "../../../utils/request.js";
 import { setupDocChangeListener } from "../../../utils/setupDocChangeListener.js";
-import { clearSyncRetry, scheduleSyncRetry } from "../../../utils/syncRetry.js";
+import {
+  cancelPendingSyncRetry,
+  clearSyncRetry,
+  scheduleSyncRetry,
+} from "../../../utils/syncRetry.js";
 import {
   finalizeSyncReconciliation,
   prepareSyncReconciliation,
@@ -25,13 +29,17 @@ async function applyServerOperations<
   O extends object,
 >(
   client: DocSyncClient<D, S, O>,
-  args: { docId: string; operations: O[] },
+  args: { docId: string; operations: O[]; syncAttempt: symbol },
 ): Promise<void> {
   const cacheEntry = client["_docsCache"].get(args.docId);
-  if (!cacheEntry) return;
+  if (cacheEntry?.activeSyncAttempt !== args.syncAttempt) return;
 
   const doc = await cacheEntry.promisedDoc;
   if (!doc) return;
+  if (
+    client["_docsCache"].get(args.docId)?.activeSyncAttempt !== args.syncAttempt
+  )
+    return;
 
   for (const op of args.operations) {
     client["_applyOperationsFrom"]("network", doc, op, { skipUndo: true });
@@ -71,6 +79,9 @@ function replaceDocInCache<
 
   client["_docsCache"].set(args.docId, {
     promisedDoc: nextPromisedDoc,
+    ...(cacheEntry.activeSyncAttempt && {
+      activeSyncAttempt: cacheEntry.activeSyncAttempt,
+    }),
     refCount: cacheEntry.refCount,
     localVersion: cacheEntry.localVersion,
     type: cacheEntry.type,
@@ -201,21 +212,81 @@ function broadcastServerOperations<
   }
 }
 
-/**
- * Schedules a retry for a failed sync and keeps the query on `fetching` while
- * the backoff is pending. A scheduled retry is still network work, so reporting
- * `idle` would tell the application nothing is happening while DocSync is in
- * fact waiting to try again. Once the attempts are exhausted the query settles,
- * keeping the error visible.
- */
-function retryOrSettle<D extends object, S extends object, O extends object>(
+function isCurrentSyncAttempt<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string, syncAttempt: symbol): boolean {
+  return client["_docsCache"].get(docId)?.activeSyncAttempt === syncAttempt;
+}
+
+/** Releases flow control only when this is still the newest sync attempt. */
+function finishSyncAttempt<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string, syncAttempt: symbol): boolean {
+  const cacheEntry = client["_docsCache"].get(docId);
+  if (cacheEntry?.activeSyncAttempt !== syncAttempt) return false;
+  delete cacheEntry.activeSyncAttempt;
+  client["_pushStatusByDocId"].set(docId, "idle");
+  return true;
+}
+
+function finishFailedSyncAttempt<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
   client: DocSyncClient<D, S, O>,
   docId: string,
+  syncAttempt: symbol,
+  shouldRetry: boolean,
+): { hasPendingSync: boolean; retrying: boolean } | undefined {
+  const hasPendingSync =
+    client["_pushStatusByDocId"].get(docId) === "pushing-with-pending";
+  if (!finishSyncAttempt(client, docId, syncAttempt)) return;
+
+  const retrying =
+    shouldRetry &&
+    scheduleSyncRetry(client, docId, () => {
+      void handleSync(client, docId);
+    });
+  return { hasPendingSync, retrying };
+}
+
+/**
+ * Reports a finished attempt once. A scheduled retry or a sync queued during
+ * the failed request keeps the query on `fetching`; the queued sync starts here
+ * only when no retry already covers it.
+ */
+function reportFinishedSyncError<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
+  client: DocSyncClient<D, S, O>,
+  docId: string,
+  error: Error,
+  continuation: { hasPendingSync: boolean; retrying: boolean },
 ): void {
-  const retrying = scheduleSyncRetry(client, docId, () => {
-    void handleSync(client, docId);
-  });
-  if (retrying) dispatchDocQueryFetchStarted(client, docId);
+  const { hasPendingSync, retrying } = continuation;
+  try {
+    dispatchNetworkQueryError(
+      client,
+      docId,
+      error,
+      retrying || hasPendingSync ? "fetching" : undefined,
+    );
+  } finally {
+    if (
+      hasPendingSync &&
+      !retrying &&
+      client["_pushStatusByDocId"].get(docId) === "idle"
+    ) {
+      void handleSync(client, docId);
+    }
+  }
 }
 
 /**
@@ -243,18 +314,29 @@ export const handleSync = async <
     return;
   }
   pushStatusByDocId.set(docId, "pushing");
-  dispatchDocQueryFetchStarted(client, docId);
+  const initialCacheEntry = client["_docsCache"].get(docId);
+  if (!initialCacheEntry) {
+    pushStatusByDocId.set(docId, "idle");
+    return;
+  }
+  cancelPendingSyncRetry(client, docId);
+  const syncAttempt = Symbol(docId);
+  initialCacheEntry.activeSyncAttempt = syncAttempt;
+  let didFinishSyncAttempt = false;
   // Any throw below would leave the push status stuck on "pushing", and every
   // later handleSync call would early-return on it — the document would stop
   // syncing until a reload. Reset the status and rethrow so the failure stays
   // loud.
   try {
+    dispatchDocQueryFetchStarted(client, docId);
     if (client["_localOpsBatchState"].has(docId)) {
       await client["_flushLocalOperations"](docId, { sync: false });
     }
+    if (!isCurrentSyncAttempt(client, docId, syncAttempt)) return;
     const requestLocalVersion = getLocalDocVersion(client, docId);
 
     const { provider } = await client["_localPromise"];
+    if (!isCurrentSyncAttempt(client, docId, syncAttempt)) return;
     const socket = client["_socket"];
 
     // Prepare payload: read operations and clock from provider.
@@ -267,6 +349,7 @@ export const handleSync = async <
         ]);
       },
     );
+    if (!isCurrentSyncAttempt(client, docId, syncAttempt)) return;
     const operations = operationsBatches.flat();
     const clientClock = stored?.clock ?? 0;
 
@@ -290,6 +373,7 @@ export const handleSync = async <
     try {
       response = await request(socket, "sync", payload);
     } catch (error) {
+      if (!isCurrentSyncAttempt(client, docId, syncAttempt)) return;
       const queryError = new DocSyncError(
         "NetworkError",
         error instanceof Error ? error.message : String(error),
@@ -299,24 +383,40 @@ export const handleSync = async <
         req,
         error: { type: "NetworkError", message: queryError.message },
       });
-      dispatchNetworkQueryError(client, docId, queryError);
-      pushStatusByDocId.set(docId, "idle");
-      retryOrSettle(client, docId);
+      if (!isCurrentSyncAttempt(client, docId, syncAttempt)) return;
+      const continuation = finishFailedSyncAttempt(
+        client,
+        docId,
+        syncAttempt,
+        true,
+      );
+      if (!continuation) return;
+      didFinishSyncAttempt = true;
+      reportFinishedSyncError(client, docId, queryError, continuation);
       return;
     }
 
+    if (!isCurrentSyncAttempt(client, docId, syncAttempt)) return;
+
     if ("error" in response && response.error) {
       client["_events"].emit("sync", { req, error: response.error });
+      if (!isCurrentSyncAttempt(client, docId, syncAttempt)) return;
       const queryError = new DocSyncError(
         response.error.type,
         response.error.message,
       );
-      dispatchNetworkQueryError(client, docId, queryError);
-      pushStatusByDocId.set(docId, "idle");
       // Only a DatabaseError is transient. Authorization and validation
       // failures would be rejected identically on every retry, so retrying
       // them is a loop that can never converge.
-      if (response.error.type === "DatabaseError") retryOrSettle(client, docId);
+      const continuation = finishFailedSyncAttempt(
+        client,
+        docId,
+        syncAttempt,
+        response.error.type === "DatabaseError",
+      );
+      if (!continuation) return;
+      didFinishSyncAttempt = true;
+      reportFinishedSyncError(client, docId, queryError, continuation);
       return;
     }
 
@@ -335,13 +435,16 @@ export const handleSync = async <
           data.operations.length > 0 && operations.length > 0,
       },
     );
+    if (!isCurrentSyncAttempt(client, docId, syncAttempt)) return;
     const preparedReconciliation = await prepareSyncReconciliation(client, {
       provider,
       docId,
       operationsBatches,
       localOperations: operations,
       data,
+      isCurrent: () => isCurrentSyncAttempt(client, docId, syncAttempt),
     });
+    if (!isCurrentSyncAttempt(client, docId, syncAttempt)) return;
 
     // Keep this section synchronous. Exporting DocNode history force-commits a
     // pending edit, finalize then applies that operation to the replacement,
@@ -380,7 +483,9 @@ export const handleSync = async <
       await applyServerOperations(client, {
         docId,
         operations: reconcileResult.operations,
+        syncAttempt,
       });
+      if (!isCurrentSyncAttempt(client, docId, syncAttempt)) return;
       broadcastServerOperations(client, {
         docId,
         operations: reconcileResult.operations,
@@ -389,7 +494,8 @@ export const handleSync = async <
 
     const currentStatus = pushStatusByDocId.get(docId);
     const shouldRetry = currentStatus === "pushing-with-pending";
-    pushStatusByDocId.set(docId, "idle");
+    if (!finishSyncAttempt(client, docId, syncAttempt)) return;
+    didFinishSyncAttempt = true;
     if (shouldRetry) {
       void handleSync(client, docId);
       return;
@@ -409,16 +515,26 @@ export const handleSync = async <
       createIfMissing: latestCacheEntry.localLoadMode === "loadOrCreate",
     });
   } catch (error) {
-    pushStatusByDocId.set(docId, "idle");
+    if (didFinishSyncAttempt) throw error;
+    // A superseded attempt has no state left to protect and no authority to
+    // surface failures. The current attempt still reports and rethrows so a
+    // provider or binding bug remains loud.
+    const hasPendingSync =
+      pushStatusByDocId.get(docId) === "pushing-with-pending";
+    if (!finishSyncAttempt(client, docId, syncAttempt)) return;
     try {
       dispatchNetworkQueryError(
         client,
         docId,
         error instanceof Error ? error : new Error(String(error)),
+        hasPendingSync ? "fetching" : undefined,
       );
     } catch {
       // Reporting the failure on the query must never replace the failure
       // itself — the rethrow below is what keeps it loud.
+    }
+    if (hasPendingSync && pushStatusByDocId.get(docId) === "idle") {
+      void handleSync(client, docId);
     }
     throw error;
   }

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -202,6 +202,23 @@ function broadcastServerOperations<
 }
 
 /**
+ * Schedules a retry for a failed sync and keeps the query on `fetching` while
+ * the backoff is pending. A scheduled retry is still network work, so reporting
+ * `idle` would tell the application nothing is happening while DocSync is in
+ * fact waiting to try again. Once the attempts are exhausted the query settles,
+ * keeping the error visible.
+ */
+function retryOrSettle<D extends object, S extends object, O extends object>(
+  client: DocSyncClient<D, S, O>,
+  docId: string,
+): void {
+  const retrying = scheduleSyncRetry(client, docId, () => {
+    void handleSync(client, docId);
+  });
+  if (retrying) dispatchDocQueryFetchStarted(client, docId);
+}
+
+/**
  * Sync (push) a document to the server. Queues if already pushing (sets
  * pushing-with-pending), otherwise sets pushing and runs the sync.
  */
@@ -284,7 +301,7 @@ export const handleSync = async <
       });
       dispatchNetworkQueryError(client, docId, queryError);
       pushStatusByDocId.set(docId, "idle");
-      scheduleSyncRetry(client, docId, () => void handleSync(client, docId));
+      retryOrSettle(client, docId);
       return;
     }
 
@@ -299,9 +316,7 @@ export const handleSync = async <
       // Only a DatabaseError is transient. Authorization and validation
       // failures would be rejected identically on every retry, so retrying
       // them is a loop that can never converge.
-      if (response.error.type === "DatabaseError") {
-        scheduleSyncRetry(client, docId, () => void handleSync(client, docId));
-      }
+      if (response.error.type === "DatabaseError") retryOrSettle(client, docId);
       return;
     }
 

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -79,9 +79,7 @@ function replaceDocInCache<
 
   client["_docsCache"].set(args.docId, {
     promisedDoc: nextPromisedDoc,
-    ...(cacheEntry.activeSyncAttempt && {
-      activeSyncAttempt: cacheEntry.activeSyncAttempt,
-    }),
+    activeSyncAttempt: cacheEntry.activeSyncAttempt,
     refCount: cacheEntry.refCount,
     localVersion: cacheEntry.localVersion,
     type: cacheEntry.type,
@@ -228,7 +226,7 @@ function finishSyncAttempt<
 >(client: DocSyncClient<D, S, O>, docId: string, syncAttempt: symbol): boolean {
   const cacheEntry = client["_docsCache"].get(docId);
   if (cacheEntry?.activeSyncAttempt !== syncAttempt) return false;
-  delete cacheEntry.activeSyncAttempt;
+  cacheEntry.activeSyncAttempt = undefined;
   client["_pushStatusByDocId"].set(docId, "idle");
   return true;
 }
@@ -316,7 +314,9 @@ export const handleSync = async <
   pushStatusByDocId.set(docId, "pushing");
   const initialCacheEntry = client["_docsCache"].get(docId);
   if (!initialCacheEntry) {
-    pushStatusByDocId.set(docId, "idle");
+    // The document was unloaded; a missing entry already reads as idle, and
+    // nothing would ever delete an entry created here.
+    pushStatusByDocId.delete(docId);
     return;
   }
   cancelPendingSyncRetry(client, docId);

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -1,9 +1,11 @@
 import type { SyncRequest, SyncResponse } from "../../../../shared/types.js";
 import type { DocSyncClient } from "../../../index.js";
 import {
+  dispatchDocQueryFetchStarted,
   dispatchLocalDocFound,
   dispatchNetworkDocFound,
   dispatchNetworkDocNotFound,
+  dispatchNetworkQueryError,
 } from "../../../utils/dispatchDocQueryAction.js";
 import { getOwnPresencePatch } from "../../../utils/getOwnPresencePatch.js";
 import { getLocalDocVersion } from "../../../utils/localDocVersion.js";
@@ -222,6 +224,7 @@ export const handleSync = async <
     return;
   }
   pushStatusByDocId.set(docId, "pushing");
+  dispatchDocQueryFetchStarted(client, docId);
   // Any throw below would leave the push status stuck on "pushing", and every
   // later handleSync call would early-return on it — the document would stop
   // syncing until a reload. Reset the status and rethrow so the failure stays
@@ -268,13 +271,13 @@ export const handleSync = async <
     try {
       response = await request(socket, "sync", payload);
     } catch (error) {
+      const queryError =
+        error instanceof Error ? error : new Error(String(error));
       client["_events"].emit("sync", {
         req,
-        error: {
-          type: "NetworkError",
-          message: error instanceof Error ? error.message : String(error),
-        },
+        error: { type: "NetworkError", message: queryError.message },
       });
+      dispatchNetworkQueryError(client, docId, queryError);
       pushStatusByDocId.set(docId, "idle");
       void handleSync(client, docId);
       return;
@@ -282,8 +285,13 @@ export const handleSync = async <
 
     if ("error" in response && response.error) {
       client["_events"].emit("sync", { req, error: response.error });
+      const queryError = new Error(response.error.message);
+      queryError.name = response.error.type;
+      dispatchNetworkQueryError(client, docId, queryError);
       pushStatusByDocId.set(docId, "idle");
-      void handleSync(client, docId);
+      if (response.error.type === "DatabaseError") {
+        void handleSync(client, docId);
+      }
       return;
     }
 
@@ -377,6 +385,11 @@ export const handleSync = async <
     });
   } catch (error) {
     pushStatusByDocId.set(docId, "idle");
+    dispatchNetworkQueryError(
+      client,
+      docId,
+      error instanceof Error ? error : new Error(String(error)),
+    );
     throw error;
   }
 };

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/sync.ts
@@ -7,10 +7,12 @@ import {
   dispatchNetworkDocNotFound,
   dispatchNetworkQueryError,
 } from "../../../utils/dispatchDocQueryAction.js";
+import { DocSyncError } from "../../../utils/DocSyncError.js";
 import { getOwnPresencePatch } from "../../../utils/getOwnPresencePatch.js";
 import { getLocalDocVersion } from "../../../utils/localDocVersion.js";
 import { request } from "../../../utils/request.js";
 import { setupDocChangeListener } from "../../../utils/setupDocChangeListener.js";
+import { clearSyncRetry, scheduleSyncRetry } from "../../../utils/syncRetry.js";
 import {
   finalizeSyncReconciliation,
   prepareSyncReconciliation,
@@ -271,30 +273,39 @@ export const handleSync = async <
     try {
       response = await request(socket, "sync", payload);
     } catch (error) {
-      const queryError =
-        error instanceof Error ? error : new Error(String(error));
+      const queryError = new DocSyncError(
+        "NetworkError",
+        error instanceof Error ? error.message : String(error),
+        { cause: error },
+      );
       client["_events"].emit("sync", {
         req,
         error: { type: "NetworkError", message: queryError.message },
       });
       dispatchNetworkQueryError(client, docId, queryError);
       pushStatusByDocId.set(docId, "idle");
-      void handleSync(client, docId);
+      scheduleSyncRetry(client, docId, () => void handleSync(client, docId));
       return;
     }
 
     if ("error" in response && response.error) {
       client["_events"].emit("sync", { req, error: response.error });
-      const queryError = new Error(response.error.message);
-      queryError.name = response.error.type;
+      const queryError = new DocSyncError(
+        response.error.type,
+        response.error.message,
+      );
       dispatchNetworkQueryError(client, docId, queryError);
       pushStatusByDocId.set(docId, "idle");
+      // Only a DatabaseError is transient. Authorization and validation
+      // failures would be rejected identically on every retry, so retrying
+      // them is a loop that can never converge.
       if (response.error.type === "DatabaseError") {
-        void handleSync(client, docId);
+        scheduleSyncRetry(client, docId, () => void handleSync(client, docId));
       }
       return;
     }
 
+    clearSyncRetry(client, docId);
     const { data } = response;
     client["_events"].emit("sync", { req, data });
 
@@ -370,7 +381,6 @@ export const handleSync = async <
     }
     const latestCacheEntry = client["_docsCache"].get(docId);
     if (!latestCacheEntry) return;
-    if (latestCacheEntry.queryResult.fetchStatus === "idle") return;
 
     if (
       latestCacheEntry.queryResult.status === "success" &&
@@ -385,11 +395,16 @@ export const handleSync = async <
     });
   } catch (error) {
     pushStatusByDocId.set(docId, "idle");
-    dispatchNetworkQueryError(
-      client,
-      docId,
-      error instanceof Error ? error : new Error(String(error)),
-    );
+    try {
+      dispatchNetworkQueryError(
+        client,
+        docId,
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    } catch {
+      // Reporting the failure on the query must never replace the failure
+      // itself — the rethrow below is what keeps it loud.
+    }
     throw error;
   }
 };

--- a/packages/docsync/src/client/handlers/connection/connect.ts
+++ b/packages/docsync/src/client/handlers/connection/connect.ts
@@ -8,8 +8,15 @@ export function handleConnect<
   O extends object = object,
 >({ client }: { client: DocSyncClient<D, S, O> }): void {
   client["_socket"].on("connect", () => {
+    delete client["_connectionAttempt"];
     client["_connectionError"] = undefined;
     client["_connectionFetchStatus"] = "fetching";
+    // Resume every loaded query before notifying connect listeners or awaiting
+    // local flushes. Otherwise old subscriptions can still report `paused`
+    // while subscriptions created by a connect listener report `fetching`.
+    for (const docId of client["_docsCache"].keys()) {
+      dispatchDocQueryConnected(client, docId);
+    }
     client["_events"].emit("connect");
     void (async () => {
       const syncedDocIds = new Set<string>();
@@ -26,7 +33,6 @@ export function handleConnect<
       );
 
       for (const docId of client["_docsCache"].keys()) {
-        dispatchDocQueryConnected(client, docId);
         const pushStatus = client["_pushStatusByDocId"].get(docId) ?? "idle";
         if (!syncedDocIds.has(docId) && pushStatus === "idle") {
           void handleSync(client, docId);

--- a/packages/docsync/src/client/handlers/connection/connect.ts
+++ b/packages/docsync/src/client/handlers/connection/connect.ts
@@ -9,6 +9,7 @@ export function handleConnect<
 >({ client }: { client: DocSyncClient<D, S, O> }): void {
   client["_socket"].on("connect", () => {
     client["_connectionError"] = undefined;
+    client["_connectionFetchStatus"] = "fetching";
     client["_events"].emit("connect");
     void (async () => {
       const syncedDocIds = new Set<string>();

--- a/packages/docsync/src/client/handlers/connection/connect.ts
+++ b/packages/docsync/src/client/handlers/connection/connect.ts
@@ -1,5 +1,5 @@
 import type { DocSyncClient } from "../../index.js";
-import { dispatchDocQueryConnected } from "../../utils/dispatchDocQueryAction.js";
+import { dispatchAllDocQueriesConnected } from "../../utils/dispatchDocQueryAction.js";
 import { handleSync } from "../clientInitiated/sync/sync.js";
 
 export function handleConnect<
@@ -14,9 +14,7 @@ export function handleConnect<
     // Resume every loaded query before notifying connect listeners or awaiting
     // local flushes. Otherwise old subscriptions can still report `paused`
     // while subscriptions created by a connect listener report `fetching`.
-    for (const docId of client["_docsCache"].keys()) {
-      dispatchDocQueryConnected(client, docId);
-    }
+    dispatchAllDocQueriesConnected(client);
     client["_events"].emit("connect");
     void (async () => {
       const syncedDocIds = new Set<string>();

--- a/packages/docsync/src/client/handlers/connection/connect.ts
+++ b/packages/docsync/src/client/handlers/connection/connect.ts
@@ -8,6 +8,7 @@ export function handleConnect<
   O extends object = object,
 >({ client }: { client: DocSyncClient<D, S, O> }): void {
   client["_socket"].on("connect", () => {
+    client["_connectionError"] = undefined;
     client["_events"].emit("connect");
     void (async () => {
       const syncedDocIds = new Set<string>();

--- a/packages/docsync/src/client/handlers/connection/disconnect.ts
+++ b/packages/docsync/src/client/handlers/connection/disconnect.ts
@@ -12,7 +12,11 @@ import { clearAllSyncRetries } from "../../utils/syncRetry.js";
  * still retrying, so that flag is what separates a temporary interruption from
  * a rejection the client will never recover from on its own.
  */
-function pauseQueries<D extends object, S extends object, O extends object>(
+export function pauseQueries<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
   client: DocSyncClient<D, S, O>,
   connectionError: DocSyncError | undefined,
 ): void {
@@ -48,15 +52,13 @@ export function handleDisconnect<
   O extends object = object,
 >({ client }: { client: DocSyncClient<D, S, O> }): void {
   client["_socket"].on("disconnect", (reason) => {
-    // TODO: clearing every push lock lets a sync that is still awaiting its ack
-    // run concurrently with the one `handleConnect` starts on reconnect. The
-    // superseded sync settles last, so its result — success or failure — would
-    // overwrite a newer one. `isSettled` in queryResultReducer.ts only stops it
-    // from doing damage; the race itself is still there. The real fix is a
-    // generation counter per document: `handleSync` captures it before awaiting
-    // and discards its own result if the document advanced meanwhile. Simply
-    // not clearing the map is not an option — an in-flight sync that never
-    // resolves would leave the document stuck on "pushing" until a reload.
+    delete client["_connectionAttempt"];
+    // Invalidate in-flight syncs before releasing their push locks. A reconnect
+    // may start a newer attempt while an abandoned Socket.IO ack still arrives;
+    // the attempt token prevents that old response from mutating current state.
+    for (const cacheEntry of client["_docsCache"].values()) {
+      delete cacheEntry.activeSyncAttempt;
+    }
     client["_pushStatusByDocId"].clear();
     client["_collabDocIds"].clear();
     clearAllSyncRetries(client);
@@ -77,6 +79,7 @@ export function handleDisconnect<
     client["_events"].emit("disconnect", { reason });
   });
   client["_socket"].on("connect_error", (err) => {
+    delete client["_connectionAttempt"];
     const connectionError = client["_socket"].active
       ? undefined
       : new DocSyncError("ConnectionError", err.message, { cause: err });

--- a/packages/docsync/src/client/handlers/connection/disconnect.ts
+++ b/packages/docsync/src/client/handlers/connection/disconnect.ts
@@ -15,7 +15,6 @@ import { clearAllSyncRetries } from "../../utils/syncRetry.js";
 function pauseQueries<D extends object, S extends object, O extends object>(
   client: DocSyncClient<D, S, O>,
   connectionError: DocSyncError | undefined,
-  onDoc?: (docId: string) => void,
 ): void {
   client["_connectionFetchStatus"] = "paused";
   if (connectionError) client["_connectionError"] = connectionError;
@@ -25,7 +24,21 @@ function pauseQueries<D extends object, S extends object, O extends object>(
     } else {
       dispatchDocQueryDisconnected(client, docId);
     }
-    onDoc?.(docId);
+  }
+}
+
+/** Tells the other tabs this client is gone from every document it had open. */
+function broadcastPresenceLeft<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>): void {
+  for (const docId of client["_docsCache"].keys()) {
+    client["_bcHelper"]?.broadcast({
+      type: "PRESENCE",
+      docId,
+      presence: { [client["_clientId"]]: null },
+    });
   }
 }
 
@@ -59,13 +72,8 @@ export function handleDisconnect<
             `The server disconnected the DocSync client (${reason})`,
           )
         : undefined;
-    pauseQueries(client, connectionError, (docId) => {
-      client["_bcHelper"]?.broadcast({
-        type: "PRESENCE",
-        docId,
-        presence: { [client["_clientId"]]: null },
-      });
-    });
+    pauseQueries(client, connectionError);
+    broadcastPresenceLeft(client);
     client["_events"].emit("disconnect", { reason });
   });
   client["_socket"].on("connect_error", (err) => {

--- a/packages/docsync/src/client/handlers/connection/disconnect.ts
+++ b/packages/docsync/src/client/handlers/connection/disconnect.ts
@@ -1,35 +1,7 @@
 import type { DocSyncClient } from "../../index.js";
 import { DocSyncError } from "../../utils/DocSyncError.js";
-import {
-  dispatchDocQueryConnectionError,
-  dispatchDocQueryDisconnected,
-} from "../../utils/dispatchDocQueryAction.js";
+import { pauseQueries } from "../../utils/pauseQueries.js";
 import { clearAllSyncRetries } from "../../utils/syncRetry.js";
-
-/**
- * Moves every loaded query to `paused`, and to `error + paused` when the
- * connection failed permanently. Socket.IO keeps `active === true` while it is
- * still retrying, so that flag is what separates a temporary interruption from
- * a rejection the client will never recover from on its own.
- */
-export function pauseQueries<
-  D extends object,
-  S extends object,
-  O extends object,
->(
-  client: DocSyncClient<D, S, O>,
-  connectionError: DocSyncError | undefined,
-): void {
-  client["_connectionFetchStatus"] = "paused";
-  if (connectionError) client["_connectionError"] = connectionError;
-  for (const docId of client["_docsCache"].keys()) {
-    if (connectionError) {
-      dispatchDocQueryConnectionError(client, docId, connectionError);
-    } else {
-      dispatchDocQueryDisconnected(client, docId);
-    }
-  }
-}
 
 /** Tells the other tabs this client is gone from every document it had open. */
 function broadcastPresenceLeft<

--- a/packages/docsync/src/client/handlers/connection/disconnect.ts
+++ b/packages/docsync/src/client/handlers/connection/disconnect.ts
@@ -1,8 +1,33 @@
 import type { DocSyncClient } from "../../index.js";
+import { DocSyncError } from "../../utils/DocSyncError.js";
 import {
+  dispatchDocQueryConnectionError,
   dispatchDocQueryDisconnected,
-  dispatchLocalQueryError,
 } from "../../utils/dispatchDocQueryAction.js";
+import { clearAllSyncRetries } from "../../utils/syncRetry.js";
+
+/**
+ * Moves every loaded query to `paused`, and to `error + paused` when the
+ * connection failed permanently. Socket.IO keeps `active === true` while it is
+ * still retrying, so that flag is what separates a temporary interruption from
+ * a rejection the client will never recover from on its own.
+ */
+function pauseQueries<D extends object, S extends object, O extends object>(
+  client: DocSyncClient<D, S, O>,
+  connectionError: DocSyncError | undefined,
+  onDoc?: (docId: string) => void,
+): void {
+  client["_connectionFetchStatus"] = "paused";
+  if (connectionError) client["_connectionError"] = connectionError;
+  for (const docId of client["_docsCache"].keys()) {
+    if (connectionError) {
+      dispatchDocQueryConnectionError(client, docId, connectionError);
+    } else {
+      dispatchDocQueryDisconnected(client, docId);
+    }
+    onDoc?.(docId);
+  }
+}
 
 export function handleDisconnect<
   D extends object = object,
@@ -10,40 +35,44 @@ export function handleDisconnect<
   O extends object = object,
 >({ client }: { client: DocSyncClient<D, S, O> }): void {
   client["_socket"].on("disconnect", (reason) => {
+    // TODO: clearing every push lock lets a sync that is still awaiting its ack
+    // run concurrently with the one `handleConnect` starts on reconnect. The
+    // superseded sync settles last, so its result — success or failure — would
+    // overwrite a newer one. `isSettled` in queryResultReducer.ts only stops it
+    // from doing damage; the race itself is still there. The real fix is a
+    // generation counter per document: `handleSync` captures it before awaiting
+    // and discards its own result if the document advanced meanwhile. Simply
+    // not clearing the map is not an option — an in-flight sync that never
+    // resolves would leave the document stuck on "pushing" until a reload.
     client["_pushStatusByDocId"].clear();
     client["_collabDocIds"].clear();
+    clearAllSyncRetries(client);
     for (const state of client["_presenceDebounceState"].values()) {
       clearTimeout(state.timeout);
       delete state.timeout;
     }
+    // A manual disconnect is not a failure, so it pauses without an error.
     const connectionError =
       !client["_socket"].active && reason !== "io client disconnect"
-        ? new Error("The server disconnected the DocSync client")
+        ? new DocSyncError(
+            "ConnectionError",
+            `The server disconnected the DocSync client (${reason})`,
+          )
         : undefined;
-    if (connectionError) client["_connectionError"] = connectionError;
-    for (const docId of client["_docsCache"].keys()) {
-      dispatchDocQueryDisconnected(client, docId);
-      if (connectionError) {
-        dispatchLocalQueryError(client, docId, connectionError);
-      }
+    pauseQueries(client, connectionError, (docId) => {
       client["_bcHelper"]?.broadcast({
         type: "PRESENCE",
         docId,
         presence: { [client["_clientId"]]: null },
       });
-    }
+    });
     client["_events"].emit("disconnect", { reason });
   });
   client["_socket"].on("connect_error", (err) => {
-    if (!client["_socket"].active) {
-      client["_connectionError"] = err;
-    }
-    for (const docId of client["_docsCache"].keys()) {
-      dispatchDocQueryDisconnected(client, docId);
-      if (!client["_socket"].active) {
-        dispatchLocalQueryError(client, docId, err);
-      }
-    }
+    const connectionError = client["_socket"].active
+      ? undefined
+      : new DocSyncError("ConnectionError", err.message, { cause: err });
+    pauseQueries(client, connectionError);
     client["_events"].emit("disconnect", { reason: err.message });
   });
 }

--- a/packages/docsync/src/client/handlers/connection/disconnect.ts
+++ b/packages/docsync/src/client/handlers/connection/disconnect.ts
@@ -46,16 +46,27 @@ export function handleDisconnect<
             `The server disconnected the DocSync client (${reason})`,
           )
         : undefined;
-    pauseQueries(client, connectionError);
-    broadcastPresenceLeft(client);
-    client["_events"].emit("disconnect", { reason });
+    // Pausing notifies query listeners, and a listener that throws must not
+    // strand the rest of the teardown: without the broadcast the other tabs
+    // keep rendering this client's presence forever, and without the event the
+    // application never learns it went offline. Run both, then let the
+    // listener failure keep propagating.
+    try {
+      pauseQueries(client, connectionError);
+    } finally {
+      broadcastPresenceLeft(client);
+      client["_events"].emit("disconnect", { reason });
+    }
   });
   client["_socket"].on("connect_error", (err) => {
     delete client["_connectionAttempt"];
     const connectionError = client["_socket"].active
       ? undefined
       : new DocSyncError("ConnectionError", err.message, { cause: err });
-    pauseQueries(client, connectionError);
-    client["_events"].emit("disconnect", { reason: err.message });
+    try {
+      pauseQueries(client, connectionError);
+    } finally {
+      client["_events"].emit("disconnect", { reason: err.message });
+    }
   });
 }

--- a/packages/docsync/src/client/handlers/connection/disconnect.ts
+++ b/packages/docsync/src/client/handlers/connection/disconnect.ts
@@ -1,5 +1,8 @@
 import type { DocSyncClient } from "../../index.js";
-import { dispatchDocQueryDisconnected } from "../../utils/dispatchDocQueryAction.js";
+import {
+  dispatchDocQueryDisconnected,
+  dispatchLocalQueryError,
+} from "../../utils/dispatchDocQueryAction.js";
 
 export function handleDisconnect<
   D extends object = object,
@@ -13,8 +16,16 @@ export function handleDisconnect<
       clearTimeout(state.timeout);
       delete state.timeout;
     }
+    const connectionError =
+      !client["_socket"].active && reason !== "io client disconnect"
+        ? new Error("The server disconnected the DocSync client")
+        : undefined;
+    if (connectionError) client["_connectionError"] = connectionError;
     for (const docId of client["_docsCache"].keys()) {
       dispatchDocQueryDisconnected(client, docId);
+      if (connectionError) {
+        dispatchLocalQueryError(client, docId, connectionError);
+      }
       client["_bcHelper"]?.broadcast({
         type: "PRESENCE",
         docId,
@@ -24,8 +35,14 @@ export function handleDisconnect<
     client["_events"].emit("disconnect", { reason });
   });
   client["_socket"].on("connect_error", (err) => {
+    if (!client["_socket"].active) {
+      client["_connectionError"] = err;
+    }
     for (const docId of client["_docsCache"].keys()) {
       dispatchDocQueryDisconnected(client, docId);
+      if (!client["_socket"].active) {
+        dispatchLocalQueryError(client, docId, err);
+      }
     }
     client["_events"].emit("disconnect", { reason: err.message });
   });

--- a/packages/docsync/src/client/handlers/connection/disconnect.ts
+++ b/packages/docsync/src/client/handlers/connection/disconnect.ts
@@ -29,7 +29,7 @@ export function handleDisconnect<
     // may start a newer attempt while an abandoned Socket.IO ack still arrives;
     // the attempt token prevents that old response from mutating current state.
     for (const cacheEntry of client["_docsCache"].values()) {
-      delete cacheEntry.activeSyncAttempt;
+      cacheEntry.activeSyncAttempt = undefined;
     }
     client["_pushStatusByDocId"].clear();
     client["_collabDocIds"].clear();

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -28,6 +28,7 @@ import { handleUnsubscribe } from "./handlers/clientInitiated/unsubscribe.js";
 import { handleIdentity } from "./handlers/serverInitiated/identity.js";
 import type { BCHelper } from "./utils/BCHelper.js";
 import {
+  dispatchDocQueryDisconnected,
   dispatchLocalDocFound,
   dispatchLocalQueryError,
 } from "./utils/dispatchDocQueryAction.js";
@@ -38,6 +39,7 @@ import {
 } from "./utils/localIdentity.js";
 import { setupDocChangeListener } from "./utils/setupDocChangeListener.js";
 import { setupLocalPromise } from "./utils/setupLocalPromise.js";
+import { clearSyncRetry, type SyncRetryState } from "./utils/syncRetry.js";
 
 // TODO: review this type!
 type LocalResolved<S extends object, O extends object> = {
@@ -86,6 +88,13 @@ export class DocSyncClient<
   protected _bcHelper?: BCHelper<D, S, O>;
   protected _socket: ClientSocket<S, O>;
   protected _connectionError: Error | undefined;
+  /**
+   * Single source of truth for the network state new subscriptions start from.
+   * Reading it off the socket at subscription time would report `fetching` to a
+   * query created right after a failed connection attempt, while every query
+   * created before it sits on `paused`.
+   */
+  protected _connectionFetchStatus: "fetching" | "paused" = "fetching";
   protected _changeOrigin: ChangeOrigin = "local";
 
   // Flow control state (batching, debouncing, push queueing)
@@ -96,6 +105,7 @@ export class DocSyncClient<
   protected _collabDocIds = new Set<string>();
   protected _presenceDebounceState = new Map<string, DeferredState<unknown>>();
   protected _pushStatusByDocId = new Map<string, PushStatus>();
+  protected _syncRetryState = new Map<string, SyncRetryState>();
 
   /** Typed as unknown so DocSyncClient remains covariant in O, S (assignable to DocSyncClient base). */
   protected _events = createClientEventEmitter();
@@ -137,6 +147,8 @@ export class DocSyncClient<
       transports: ["websocket"], // Skip polling, go straight to WebSocket
     });
 
+    this._connectionFetchStatus = this._socket.active ? "fetching" : "paused";
+
     this._localPromise = setupLocalPromise({
       client: this,
       providerFactory: local.provider,
@@ -152,11 +164,25 @@ export class DocSyncClient<
   }
 
   connect() {
+    // A new attempt supersedes the failure that ended the previous one, so a
+    // subscription created while connecting must not inherit a stale error.
+    this._connectionError = undefined;
+    this._connectionFetchStatus = "fetching";
     this._socket.connect();
   }
 
   disconnect() {
+    const wasConnected = this._socket.connected;
     this._socket.disconnect();
+    this._connectionFetchStatus = "paused";
+    // Socket.IO only emits "disconnect" for a socket that had connected.
+    // Disconnecting mid-handshake would otherwise leave every query on
+    // "fetching" forever, because no listener ever runs.
+    if (!wasConnected) {
+      for (const docId of this._docsCache.keys()) {
+        dispatchDocQueryDisconnected(this, docId);
+      }
+    }
   }
 
   clearLocalIdentity() {
@@ -208,7 +234,7 @@ export class DocSyncClient<
       "createIfMissing" in args && args.createIfMissing === true;
     const localLoadMode = createIfMissing ? "loadOrCreate" : "load";
     const listener = onChange as QueryListener;
-    const initialFetchStatus = this._socket.active ? "fetching" : "paused";
+    const initialFetchStatus = this._connectionFetchStatus;
 
     const existingCacheEntry = this._docsCache.get(docId);
     if (existingCacheEntry) {
@@ -216,9 +242,10 @@ export class DocSyncClient<
       existingCacheEntry.queryListeners.add(listener);
       listener(existingCacheEntry.queryResult);
 
-      const hasDoc =
-        existingCacheEntry.queryResult.status === "success" &&
-        existingCacheEntry.queryResult.data !== undefined;
+      // Deliberately not gated on `status === "success"`: a query can hold data
+      // together with a later error, and treating that as "no document" would
+      // reload the doc and swap out the live instance the caller is editing.
+      const hasDoc = existingCacheEntry.queryResult.data !== undefined;
 
       if (
         createIfMissing &&
@@ -442,6 +469,7 @@ export class DocSyncClient<
         clearTimeout(presenceState?.timeout);
         this._presenceDebounceState.delete(docId);
         this._collabDocIds.delete(docId);
+        clearSyncRetry(this, docId);
         if (doc) {
           await handleUnsubscribe(this._socket, { docId });
           this._docBinding.dispose(doc);

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -65,7 +65,8 @@ type LocalLoadMode = "load" | "loadOrCreate";
 type QueryListener = (result: QueryResult<DocData<object> | undefined>) => void;
 type DocCacheEntry<D> = {
   promisedDoc: Promise<D | undefined>;
-  activeSyncAttempt?: symbol;
+  /** Token of the sync in flight; `undefined` when none is running. */
+  activeSyncAttempt: symbol | undefined;
   refCount: number;
   localVersion: number;
   type: string;
@@ -224,6 +225,25 @@ export class DocSyncClient<
   }
 
   /**
+   * The result `getDoc` would report for a document right now, without
+   * subscribing: the cached result for a loaded document, otherwise the state a
+   * new subscription starts from. Lets UI code render a correct first frame
+   * instead of guessing `pending` + `fetching` before its subscription runs.
+   */
+  getDocResult(args: { id: string }): QueryResult<DocData<D> | undefined> {
+    return (
+      this._docsCache.get(args.id)?.queryResult ?? this._initialQueryResult()
+    );
+  }
+
+  private _initialQueryResult(): QueryResult<DocData<D> | undefined> {
+    const fetchStatus = this._connectionFetchStatus;
+    return this._connectionError
+      ? { status: "error", fetchStatus, error: this._connectionError }
+      : { status: "pending", fetchStatus };
+  }
+
+  /**
    * Subscribe to a document with reactive state updates.
    *
    * The behavior depends on which fields are provided:
@@ -268,7 +288,6 @@ export class DocSyncClient<
       "createIfMissing" in args && args.createIfMissing === true;
     const localLoadMode = createIfMissing ? "loadOrCreate" : "load";
     const listener = onChange as QueryListener;
-    const initialFetchStatus = this._connectionFetchStatus;
 
     const existingCacheEntry = this._docsCache.get(docId);
     if (existingCacheEntry) {
@@ -297,16 +316,10 @@ export class DocSyncClient<
         docId,
         createIfMissing ? type : undefined,
       );
-      const queryResult: QueryResult<DocData<D> | undefined> = this
-        ._connectionError
-        ? {
-            status: "error",
-            fetchStatus: initialFetchStatus,
-            error: this._connectionError,
-          }
-        : { status: "pending", fetchStatus: initialFetchStatus };
+      const queryResult = this._initialQueryResult();
       this._docsCache.set(docId, {
         promisedDoc,
+        activeSyncAttempt: undefined,
         refCount: 1,
         localVersion: 0,
         type,

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -85,6 +85,7 @@ export class DocSyncClient<
   protected _clientId: string;
   protected _bcHelper?: BCHelper<D, S, O>;
   protected _socket: ClientSocket<S, O>;
+  protected _connectionError: Error | undefined;
   protected _changeOrigin: ChangeOrigin = "local";
 
   // Flow control state (batching, debouncing, push queueing)
@@ -207,7 +208,7 @@ export class DocSyncClient<
       "createIfMissing" in args && args.createIfMissing === true;
     const localLoadMode = createIfMissing ? "loadOrCreate" : "load";
     const listener = onChange as QueryListener;
-    const initialFetchStatus = this._socket.connected ? "fetching" : "paused";
+    const initialFetchStatus = this._socket.active ? "fetching" : "paused";
 
     const existingCacheEntry = this._docsCache.get(docId);
     if (existingCacheEntry) {
@@ -235,10 +236,14 @@ export class DocSyncClient<
         docId,
         createIfMissing ? type : undefined,
       );
-      const queryResult: QueryResult<DocData<D> | undefined> = {
-        status: "pending",
-        fetchStatus: initialFetchStatus,
-      };
+      const queryResult: QueryResult<DocData<D> | undefined> = this
+        ._connectionError
+        ? {
+            status: "error",
+            fetchStatus: "paused",
+            error: this._connectionError,
+          }
+        : { status: "pending", fetchStatus: initialFetchStatus };
       this._docsCache.set(docId, {
         promisedDoc,
         refCount: 1,

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -28,6 +28,7 @@ import { handleUnsubscribe } from "./handlers/clientInitiated/unsubscribe.js";
 import { handleIdentity } from "./handlers/serverInitiated/identity.js";
 import type { BCHelper } from "./utils/BCHelper.js";
 import {
+  dispatchDocQueryConnected,
   dispatchDocQueryDisconnected,
   dispatchLocalDocFound,
   dispatchLocalQueryError,
@@ -94,7 +95,7 @@ export class DocSyncClient<
    * query created right after a failed connection attempt, while every query
    * created before it sits on `paused`.
    */
-  protected _connectionFetchStatus: "fetching" | "paused" = "fetching";
+  protected _connectionFetchStatus: "fetching" | "paused";
   protected _changeOrigin: ChangeOrigin = "local";
 
   // Flow control state (batching, debouncing, push queueing)
@@ -168,6 +169,12 @@ export class DocSyncClient<
     // subscription created while connecting must not inherit a stale error.
     this._connectionError = undefined;
     this._connectionFetchStatus = "fetching";
+    // Loaded queries have to follow, or a document subscribed before the
+    // reconnect would report `paused` while one subscribed after it reports
+    // `fetching`, for the same client and the same socket.
+    for (const docId of this._docsCache.keys()) {
+      dispatchDocQueryConnected(this, docId);
+    }
     this._socket.connect();
   }
 

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -18,10 +18,7 @@ import type { ClientEventMap, ClientEventName } from "./utils/events.js";
 import { createClientEventEmitter } from "./utils/events.js";
 import { handleConnect } from "./handlers/connection/connect.js";
 import { handleDeleteDoc } from "./handlers/clientInitiated/deleteDoc.js";
-import {
-  handleDisconnect,
-  pauseQueries,
-} from "./handlers/connection/disconnect.js";
+import { handleDisconnect } from "./handlers/connection/disconnect.js";
 import { handleCollaboration } from "./handlers/serverInitiated/collaboration.js";
 import { handleDirty } from "./handlers/serverInitiated/dirty.js";
 import { handlePresence } from "./handlers/clientInitiated/presence.js";
@@ -42,6 +39,7 @@ import {
   readLocalIdentity,
 } from "./utils/localIdentity.js";
 import { setupDocChangeListener } from "./utils/setupDocChangeListener.js";
+import { pauseQueries } from "./utils/pauseQueries.js";
 import { setupLocalPromise } from "./utils/setupLocalPromise.js";
 import { clearSyncRetry, type SyncRetryState } from "./utils/syncRetry.js";
 import { DocSyncError } from "./utils/DocSyncError.js";

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -10,6 +10,7 @@ import type {
   ClientSocket,
   DeferredState,
   DocData,
+  DocObserver,
   GetDocArgs,
   Identity,
   QueryResult,
@@ -28,8 +29,8 @@ import { handleUnsubscribe } from "./handlers/clientInitiated/unsubscribe.js";
 import { handleIdentity } from "./handlers/serverInitiated/identity.js";
 import type { BCHelper } from "./utils/BCHelper.js";
 import {
-  dispatchDocQueryConnected,
-  dispatchDocQueryDisconnected,
+  dispatchAllDocQueriesConnected,
+  dispatchAllDocQueriesDisconnected,
   dispatchLocalDocFound,
   dispatchLocalQueryError,
 } from "./utils/dispatchDocQueryAction.js";
@@ -192,17 +193,17 @@ export class DocSyncClient<
   }
 
   connect() {
+    if (this._socket.connected) return;
+
     // Keep the last connection error visible while recovery is only an
     // attempt. The successful `connect` event clears the client-wide error;
     // each loaded query clears its own error after its sync succeeds.
-    this._connectionFetchStatus = "fetching";
     // Loaded queries have to follow, or a document subscribed before the
     // reconnect would report `paused` while one subscribed after it reports
     // `fetching`, for the same client and the same socket.
-    for (const docId of this._docsCache.keys()) {
-      dispatchDocQueryConnected(this, docId);
-    }
     this._socket.connect();
+    this._connectionFetchStatus = "fetching";
+    dispatchAllDocQueriesConnected(this);
   }
 
   disconnect() {
@@ -214,26 +215,12 @@ export class DocSyncClient<
     // Disconnecting mid-handshake would otherwise leave every query on
     // "fetching" forever, because no listener ever runs.
     if (!wasConnected) {
-      for (const docId of this._docsCache.keys()) {
-        dispatchDocQueryDisconnected(this, docId);
-      }
+      dispatchAllDocQueriesDisconnected(this);
     }
   }
 
   clearLocalIdentity() {
     clearStoredLocalIdentity();
-  }
-
-  /**
-   * The result `getDoc` would report for a document right now, without
-   * subscribing: the cached result for a loaded document, otherwise the state a
-   * new subscription starts from. Lets UI code render a correct first frame
-   * instead of guessing `pending` + `fetching` before its subscription runs.
-   */
-  getDocResult(args: { id: string }): QueryResult<DocData<D> | undefined> {
-    return (
-      this._docsCache.get(args.id)?.queryResult ?? this._initialQueryResult()
-    );
   }
 
   private _initialQueryResult(): QueryResult<DocData<D> | undefined> {
@@ -244,13 +231,13 @@ export class DocSyncClient<
   }
 
   /**
-   * Subscribe to a document with reactive state updates.
+   * Observe a document query with a stable snapshot and reactive updates.
    *
    * The behavior depends on which fields are provided:
    * - `{ type, id }` → Try to get an existing doc. Returns `undefined` if not found.
    * - `{ type, id, createIfMissing: true }` → Get existing doc or create it if not found.
    *
-   * The callback will be invoked with state updates:
+   * `getSnapshot()` returns one of these states:
    * 1. `{ status: "pending" }` - Initial state while fetching
    * 2. `{ status: "success", data: { doc, docId } }` - Document loaded successfully
    * 3. `{ status: "error", error }` - Failed to load document
@@ -259,28 +246,76 @@ export class DocSyncClient<
    *
    * @example
    * ```ts
-   * const unsubscribe = client.getDoc(
-   *   { type: "notes", id: "abc123" },
-   *   (result) => {
-   *     if (result.status === "pending") console.log("Pending...");
-   *     if (result.status === "success") console.log("Doc:", result.data.doc);
-   *     if (result.status === "error") console.error(result.error);
-   *   }
-   * );
+   * const observer = client.getDocObserver({ type: "notes", id: "abc123" });
+   * const render = () => {
+   *   const result = observer.getSnapshot();
+   *   if (result.status === "pending") console.log("Pending...");
+   *   if (result.status === "success") console.log("Doc:", result.data?.doc);
+   *   if (result.status === "error") console.error(result.error);
+   * };
+   * const unsubscribe = observer.subscribe(render);
+   * render();
    *
    * // Clean up when done
    * unsubscribe();
    * ```
    */
-  getDoc<T extends GetDocArgs>(
+  getDocObserver<T extends GetDocArgs>(
     args: T,
-    onChange: (
-      result: QueryResult<
-        T extends { createIfMissing: true }
-          ? DocData<D>
-          : DocData<D> | undefined
-      >,
-    ) => void,
+  ): DocObserver<
+    T extends { createIfMissing: true } ? DocData<D> : DocData<D> | undefined
+  > {
+    type ObserverData = T extends { createIfMissing: true }
+      ? DocData<D>
+      : DocData<D> | undefined;
+
+    let currentResult = (this._docsCache.get(args.id)?.queryResult ??
+      this._initialQueryResult()) as QueryResult<ObserverData>;
+    const listeners = new Set<() => void>();
+    let unsubscribeFromDoc: (() => void) | undefined;
+
+    const getSnapshot = () =>
+      (this._docsCache.get(args.id)?.queryResult ??
+        currentResult) as QueryResult<ObserverData>;
+    const subscribe = (listener: () => void) => {
+      listeners.add(listener);
+
+      if (!unsubscribeFromDoc) {
+        let isStartingSubscription = true;
+        unsubscribeFromDoc = this._subscribeDoc(args, (nextResult) => {
+          if (nextResult === currentResult) return;
+          currentResult = nextResult as QueryResult<ObserverData>;
+          // External-store consumers read the snapshot again immediately after
+          // subscribing, so the initial synchronous update needs no callback.
+          if (isStartingSubscription) return;
+          let firstError: { value: unknown } | undefined;
+          for (const currentListener of [...listeners]) {
+            try {
+              currentListener();
+            } catch (error: unknown) {
+              firstError ??= { value: error };
+            }
+          }
+          if (firstError) throw firstError.value;
+        });
+        isStartingSubscription = false;
+      }
+
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size > 0 || !unsubscribeFromDoc) return;
+        const unsubscribe = unsubscribeFromDoc;
+        unsubscribeFromDoc = undefined;
+        unsubscribe();
+      };
+    };
+
+    return { getSnapshot, subscribe };
+  }
+
+  private _subscribeDoc(
+    args: GetDocArgs,
+    onChange: (result: QueryResult<DocData<D> | undefined>) => void,
   ): () => void {
     const type = args.type;
     const docId = args.id;
@@ -343,13 +378,40 @@ export class DocSyncClient<
     docId: string,
     result: QueryResult<DocData<D> | undefined>,
   ): void {
-    const cacheEntry = this._docsCache.get(docId);
-    if (!cacheEntry) return;
+    this._emitQueryResults([{ docId, result }]);
+  }
 
-    cacheEntry.queryResult = result;
-    for (const listener of cacheEntry.queryListeners) {
-      listener(result);
+  protected _emitQueryResults(
+    updates: ReadonlyArray<{
+      docId: string;
+      result: QueryResult<DocData<D> | undefined>;
+    }>,
+  ): void {
+    const notifications: Array<{
+      listeners: QueryListener[];
+      result: QueryResult<DocData<D> | undefined>;
+    }> = [];
+
+    // Commit every snapshot before calling user code. A listener that reads a
+    // different document must never see a half-applied connection transition.
+    for (const { docId, result } of updates) {
+      const cacheEntry = this._docsCache.get(docId);
+      if (!cacheEntry || result === cacheEntry.queryResult) continue;
+      cacheEntry.queryResult = result;
+      notifications.push({ listeners: [...cacheEntry.queryListeners], result });
     }
+
+    let firstError: { value: unknown } | undefined;
+    for (const { listeners, result } of notifications) {
+      for (const listener of listeners) {
+        try {
+          listener(result);
+        } catch (error: unknown) {
+          firstError ??= { value: error };
+        }
+      }
+    }
+    if (firstError) throw firstError.value;
   }
 
   private _observePromisedDoc(

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -18,7 +18,10 @@ import type { ClientEventMap, ClientEventName } from "./utils/events.js";
 import { createClientEventEmitter } from "./utils/events.js";
 import { handleConnect } from "./handlers/connection/connect.js";
 import { handleDeleteDoc } from "./handlers/clientInitiated/deleteDoc.js";
-import { handleDisconnect } from "./handlers/connection/disconnect.js";
+import {
+  handleDisconnect,
+  pauseQueries,
+} from "./handlers/connection/disconnect.js";
 import { handleCollaboration } from "./handlers/serverInitiated/collaboration.js";
 import { handleDirty } from "./handlers/serverInitiated/dirty.js";
 import { handlePresence } from "./handlers/clientInitiated/presence.js";
@@ -41,6 +44,7 @@ import {
 import { setupDocChangeListener } from "./utils/setupDocChangeListener.js";
 import { setupLocalPromise } from "./utils/setupLocalPromise.js";
 import { clearSyncRetry, type SyncRetryState } from "./utils/syncRetry.js";
+import { DocSyncError } from "./utils/DocSyncError.js";
 
 // TODO: review this type!
 type LocalResolved<S extends object, O extends object> = {
@@ -63,6 +67,7 @@ type LocalLoadMode = "load" | "loadOrCreate";
 type QueryListener = (result: QueryResult<DocData<object> | undefined>) => void;
 type DocCacheEntry<D> = {
   promisedDoc: Promise<D | undefined>;
+  activeSyncAttempt?: symbol;
   refCount: number;
   localVersion: number;
   type: string;
@@ -89,6 +94,7 @@ export class DocSyncClient<
   protected _bcHelper?: BCHelper<D, S, O>;
   protected _socket: ClientSocket<S, O>;
   protected _connectionError: Error | undefined;
+  protected _connectionAttempt?: symbol;
   /**
    * Single source of truth for the network state new subscriptions start from.
    * Reading it off the socket at subscription time would report `fetching` to a
@@ -138,10 +144,32 @@ export class DocSyncClient<
           cb(authPayload);
           return;
         }
+        const getToken = config.server.auth.getToken;
+        const connectionAttempt = Symbol();
+        this._connectionAttempt = connectionAttempt;
 
-        void Promise.resolve(config.server.auth.getToken()).then((token) => {
-          cb({ ...authPayload, token });
-        });
+        // Start with a resolved promise so both a synchronous throw and a
+        // rejected token promise follow the same connection-error path.
+        void Promise.resolve()
+          .then(() => getToken())
+          .then((token) => {
+            if (this._connectionAttempt !== connectionAttempt) return;
+            cb({ ...authPayload, token });
+          })
+          .catch((error: unknown) => {
+            if (this._connectionAttempt !== connectionAttempt) return;
+            delete this._connectionAttempt;
+            const connectionError = new DocSyncError(
+              "ConnectionError",
+              error instanceof Error ? error.message : String(error),
+              { cause: error },
+            );
+            this._socket.disconnect();
+            pauseQueries(this, connectionError);
+            this._events.emit("disconnect", {
+              reason: connectionError.message,
+            });
+          });
       },
       withCredentials: config.server.auth.mode === "request",
       // Performance optimizations for testing
@@ -165,9 +193,9 @@ export class DocSyncClient<
   }
 
   connect() {
-    // A new attempt supersedes the failure that ended the previous one, so a
-    // subscription created while connecting must not inherit a stale error.
-    this._connectionError = undefined;
+    // Keep the last connection error visible while recovery is only an
+    // attempt. The successful `connect` event clears the client-wide error;
+    // each loaded query clears its own error after its sync succeeds.
     this._connectionFetchStatus = "fetching";
     // Loaded queries have to follow, or a document subscribed before the
     // reconnect would report `paused` while one subscribed after it reports
@@ -180,6 +208,7 @@ export class DocSyncClient<
 
   disconnect() {
     const wasConnected = this._socket.connected;
+    delete this._connectionAttempt;
     this._socket.disconnect();
     this._connectionFetchStatus = "paused";
     // Socket.IO only emits "disconnect" for a socket that had connected.
@@ -274,7 +303,7 @@ export class DocSyncClient<
         ._connectionError
         ? {
             status: "error",
-            fetchStatus: "paused",
+            fetchStatus: initialFetchStatus,
             error: this._connectionError,
           }
         : { status: "pending", fetchStatus: initialFetchStatus };
@@ -476,6 +505,7 @@ export class DocSyncClient<
         clearTimeout(presenceState?.timeout);
         this._presenceDebounceState.delete(docId);
         this._collabDocIds.delete(docId);
+        this._pushStatusByDocId.delete(docId);
         clearSyncRetry(this, docId);
         if (doc) {
           await handleUnsubscribe(this._socket, { docId });

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -211,6 +211,12 @@ export class DocSyncClient<
     delete this._connectionAttempt;
     this._socket.disconnect();
     this._connectionFetchStatus = "paused";
+    // `_connectionError` is deliberately left in place. Disconnecting on
+    // purpose adds no error, but it does not undo one either: if the previous
+    // connection was rejected permanently, that rejection is still the last
+    // thing that happened, and hiding it here would make a query created after
+    // this call report a clean `pending` while every query loaded before it
+    // still reports the error. Only a successful `connect` clears it.
     // Socket.IO only emits "disconnect" for a socket that had connected.
     // Disconnecting mid-handshake would otherwise leave every query on
     // "fetching" forever, because no listener ever runs.

--- a/packages/docsync/src/client/types.ts
+++ b/packages/docsync/src/client/types.ts
@@ -23,7 +23,7 @@ export type QueryResult<D, E = Error> =
     };
 
 /**
- * Arguments for {@link DocSyncClient["getDoc"]}.
+ * Arguments for {@link DocSyncClient["getDocObserver"]}.
  */
 export type GetDocArgs = {
   type: string;
@@ -32,6 +32,15 @@ export type GetDocArgs = {
 };
 
 export type DocData<D> = { doc: D; docId: string };
+
+/**
+ * Observable document query state. Read the current value with `getSnapshot`
+ * and subscribe to later changes with `subscribe`.
+ */
+export type DocObserver<T> = {
+  getSnapshot: () => QueryResult<T>;
+  subscribe: (listener: () => void) => () => void;
+};
 
 // ============================================================================
 // Client State & Config

--- a/packages/docsync/src/client/utils/DocSyncError.ts
+++ b/packages/docsync/src/client/utils/DocSyncError.ts
@@ -1,0 +1,25 @@
+/** Machine-readable discriminant for errors DocSync itself produces. */
+export type DocSyncErrorType =
+  | "AuthorizationError"
+  | "ConnectionError"
+  | "DatabaseError"
+  | "NetworkError"
+  | "ValidationError";
+
+/**
+ * Error raised by DocSync, carrying a `type` so applications can branch on the
+ * failure without matching on `message`.
+ *
+ * Failures thrown by application-provided code (the local provider, the doc
+ * binding) are surfaced unchanged so their original stack survives. Narrow with
+ * `instanceof DocSyncError` before reading `type`.
+ */
+export class DocSyncError extends Error {
+  readonly type: DocSyncErrorType;
+
+  constructor(type: DocSyncErrorType, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = type;
+    this.type = type;
+  }
+}

--- a/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
+++ b/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
@@ -47,6 +47,21 @@ export function dispatchDocQueryConnected<
   if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
 }
 
+export function dispatchDocQueryFetchStarted<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string): void {
+  const cacheEntry = client["_docsCache"].get(docId);
+  if (!cacheEntry) return;
+
+  const reducer = createQueryResultReducer({
+    initialState: cacheEntry.queryResult,
+  });
+  const next = reducer.action.fetchStarted(undefined);
+  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
+}
+
 export function dispatchDocQueryDisconnected<
   D extends object,
   S extends object,
@@ -93,5 +108,23 @@ export function dispatchNetworkDocNotFound<
     initialState: cacheEntry.queryResult,
   });
   const next = reducer.action.networkDocNotFound(payload);
+  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
+}
+
+export function dispatchNetworkQueryError<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string, error: Error): void {
+  const cacheEntry = client["_docsCache"].get(docId);
+  if (!cacheEntry) return;
+
+  const reducer = createQueryResultReducer({
+    initialState: cacheEntry.queryResult,
+  });
+  const next = reducer.action.networkQueryError({
+    error,
+    fetchStatus: client["_socket"].connected ? "idle" : "paused",
+  });
   if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
 }

--- a/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
+++ b/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
@@ -2,6 +2,34 @@ import type { DocSyncClient } from "../index.js";
 import type { DocData } from "../types.js";
 import { createQueryResultReducer } from "./queryResultReducer.js";
 
+/**
+ * Terminal network actions are dispatched by the sync attempt that just
+ * released the document, so `activeSyncAttempt` must still be clear. If a newer
+ * attempt has already claimed it, this dispatch belongs to a superseded one and
+ * would overwrite the newer result.
+ *
+ * `fetchStatus` used to carry this guarantee: while every sync flipped the
+ * query to `fetching`, an `idle` query meant "no attempt in flight". A routine
+ * background push no longer touches `fetchStatus` (see `queryResultReducer`),
+ * so the invariant is anchored to the attempt token itself, which is the only
+ * thing that actually knows.
+ *
+ * This throws rather than returning quietly. The window it protects is
+ * synchronous today, so reaching it means an `await` was added between
+ * `finishSyncAttempt` and the dispatch — an ordering bug that would otherwise
+ * surface as an update that silently disappears, which no test can catch.
+ */
+function assertNoNewerSyncAttempt<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string, actionType: string): void {
+  if (client["_docsCache"].get(docId)?.activeSyncAttempt === undefined) return;
+  throw new Error(
+    `Cannot apply ${actionType}: a newer sync attempt for "${docId}" is already running`,
+  );
+}
+
 export function dispatchLocalDocFound<
   D extends object,
   S extends object,
@@ -46,21 +74,6 @@ export function dispatchAllDocQueriesConnected<
   client["_emitQueryResults"](updates);
 }
 
-export function dispatchDocQueryFetchStarted<
-  D extends object,
-  S extends object,
-  O extends object,
->(client: DocSyncClient<D, S, O>, docId: string): void {
-  const cacheEntry = client["_docsCache"].get(docId);
-  if (!cacheEntry) return;
-
-  const reducer = createQueryResultReducer({
-    initialState: cacheEntry.queryResult,
-  });
-  const next = reducer.action.fetchStarted(undefined);
-  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
-}
-
 export function dispatchAllDocQueriesConnectionError<
   D extends object,
   S extends object,
@@ -96,6 +109,7 @@ export function dispatchNetworkDocFound<
 >(client: DocSyncClient<D, S, O>, docId: string, data: DocData<D>): void {
   const cacheEntry = client["_docsCache"].get(docId);
   if (!cacheEntry) return;
+  assertNoNewerSyncAttempt(client, docId, "networkDocFound");
 
   const reducer = createQueryResultReducer({
     initialState: cacheEntry.queryResult,
@@ -115,6 +129,7 @@ export function dispatchNetworkDocNotFound<
 ): void {
   const cacheEntry = client["_docsCache"].get(docId);
   if (!cacheEntry) return;
+  assertNoNewerSyncAttempt(client, docId, "networkDocNotFound");
 
   const reducer = createQueryResultReducer({
     initialState: cacheEntry.queryResult,
@@ -130,6 +145,7 @@ export function dispatchNetworkQueryError<
 >(client: DocSyncClient<D, S, O>, docId: string, error: Error): void {
   const cacheEntry = client["_docsCache"].get(docId);
   if (!cacheEntry) return;
+  assertNoNewerSyncAttempt(client, docId, "networkQueryError");
 
   const reducer = createQueryResultReducer({
     initialState: cacheEntry.queryResult,

--- a/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
+++ b/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
@@ -1,5 +1,5 @@
 import type { DocSyncClient } from "../index.js";
-import type { DocData } from "../types.js";
+import type { DocData, FetchStatus } from "../types.js";
 import { createQueryResultReducer } from "./queryResultReducer.js";
 
 export function dispatchLocalDocFound<
@@ -130,13 +130,20 @@ export function dispatchNetworkQueryError<
   D extends object,
   S extends object,
   O extends object,
->(client: DocSyncClient<D, S, O>, docId: string, error: Error): void {
+>(
+  client: DocSyncClient<D, S, O>,
+  docId: string,
+  error: Error,
+  fetchStatus?: FetchStatus,
+): void {
   const cacheEntry = client["_docsCache"].get(docId);
   if (!cacheEntry) return;
 
   const reducer = createQueryResultReducer({
     initialState: cacheEntry.queryResult,
   });
-  const next = reducer.action.networkQueryError({ error });
+  const next = reducer.action.networkQueryError(
+    fetchStatus === undefined ? { error } : { error, fetchStatus },
+  );
   if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
 }

--- a/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
+++ b/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
@@ -127,20 +127,13 @@ export function dispatchNetworkQueryError<
   D extends object,
   S extends object,
   O extends object,
->(
-  client: DocSyncClient<D, S, O>,
-  docId: string,
-  error: Error,
-  fetchStatus?: "fetching",
-): void {
+>(client: DocSyncClient<D, S, O>, docId: string, error: Error): void {
   const cacheEntry = client["_docsCache"].get(docId);
   if (!cacheEntry) return;
 
   const reducer = createQueryResultReducer({
     initialState: cacheEntry.queryResult,
   });
-  const next = reducer.action.networkQueryError(
-    fetchStatus === undefined ? { error } : { error, fetchStatus },
-  );
+  const next = reducer.action.networkQueryError({ error });
   if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
 }

--- a/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
+++ b/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
@@ -1,5 +1,5 @@
 import type { DocSyncClient } from "../index.js";
-import type { DocData, FetchStatus } from "../types.js";
+import type { DocData } from "../types.js";
 import { createQueryResultReducer } from "./queryResultReducer.js";
 
 export function dispatchLocalDocFound<
@@ -134,7 +134,7 @@ export function dispatchNetworkQueryError<
   client: DocSyncClient<D, S, O>,
   docId: string,
   error: Error,
-  fetchStatus?: FetchStatus,
+  fetchStatus?: "fetching",
 ): void {
   const cacheEntry = client["_docsCache"].get(docId);
   if (!cacheEntry) return;

--- a/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
+++ b/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
@@ -62,6 +62,21 @@ export function dispatchDocQueryFetchStarted<
   if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
 }
 
+export function dispatchDocQueryConnectionError<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string, error: Error): void {
+  const cacheEntry = client["_docsCache"].get(docId);
+  if (!cacheEntry) return;
+
+  const reducer = createQueryResultReducer({
+    initialState: cacheEntry.queryResult,
+  });
+  const next = reducer.action.connectionError({ error });
+  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
+}
+
 export function dispatchDocQueryDisconnected<
   D extends object,
   S extends object,
@@ -122,9 +137,6 @@ export function dispatchNetworkQueryError<
   const reducer = createQueryResultReducer({
     initialState: cacheEntry.queryResult,
   });
-  const next = reducer.action.networkQueryError({
-    error,
-    fetchStatus: client["_socket"].connected ? "idle" : "paused",
-  });
+  const next = reducer.action.networkQueryError({ error });
   if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
 }

--- a/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
+++ b/packages/docsync/src/client/utils/dispatchDocQueryAction.ts
@@ -32,19 +32,18 @@ export function dispatchLocalQueryError<
   if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
 }
 
-export function dispatchDocQueryConnected<
+export function dispatchAllDocQueriesConnected<
   D extends object,
   S extends object,
   O extends object,
->(client: DocSyncClient<D, S, O>, docId: string): void {
-  const cacheEntry = client["_docsCache"].get(docId);
-  if (!cacheEntry) return;
-
-  const reducer = createQueryResultReducer({
-    initialState: cacheEntry.queryResult,
-  });
-  const next = reducer.action.connected(undefined);
-  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
+>(client: DocSyncClient<D, S, O>): void {
+  const updates = [...client["_docsCache"]].map(([docId, cacheEntry]) => ({
+    docId,
+    result: createQueryResultReducer({
+      initialState: cacheEntry.queryResult,
+    }).action.connected(undefined),
+  }));
+  client["_emitQueryResults"](updates);
 }
 
 export function dispatchDocQueryFetchStarted<
@@ -62,34 +61,32 @@ export function dispatchDocQueryFetchStarted<
   if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
 }
 
-export function dispatchDocQueryConnectionError<
+export function dispatchAllDocQueriesConnectionError<
   D extends object,
   S extends object,
   O extends object,
->(client: DocSyncClient<D, S, O>, docId: string, error: Error): void {
-  const cacheEntry = client["_docsCache"].get(docId);
-  if (!cacheEntry) return;
-
-  const reducer = createQueryResultReducer({
-    initialState: cacheEntry.queryResult,
-  });
-  const next = reducer.action.connectionError({ error });
-  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
+>(client: DocSyncClient<D, S, O>, error: Error): void {
+  const updates = [...client["_docsCache"]].map(([docId, cacheEntry]) => ({
+    docId,
+    result: createQueryResultReducer({
+      initialState: cacheEntry.queryResult,
+    }).action.connectionError({ error }),
+  }));
+  client["_emitQueryResults"](updates);
 }
 
-export function dispatchDocQueryDisconnected<
+export function dispatchAllDocQueriesDisconnected<
   D extends object,
   S extends object,
   O extends object,
->(client: DocSyncClient<D, S, O>, docId: string): void {
-  const cacheEntry = client["_docsCache"].get(docId);
-  if (!cacheEntry) return;
-
-  const reducer = createQueryResultReducer({
-    initialState: cacheEntry.queryResult,
-  });
-  const next = reducer.action.disconnected(undefined);
-  if (next !== cacheEntry.queryResult) client["_emitQueryResult"](docId, next);
+>(client: DocSyncClient<D, S, O>): void {
+  const updates = [...client["_docsCache"]].map(([docId, cacheEntry]) => ({
+    docId,
+    result: createQueryResultReducer({
+      initialState: cacheEntry.queryResult,
+    }).action.disconnected(undefined),
+  }));
+  client["_emitQueryResults"](updates);
 }
 
 export function dispatchNetworkDocFound<

--- a/packages/docsync/src/client/utils/pauseQueries.ts
+++ b/packages/docsync/src/client/utils/pauseQueries.ts
@@ -1,0 +1,31 @@
+import type { DocSyncClient } from "../index.js";
+import type { DocSyncError } from "./DocSyncError.js";
+import {
+  dispatchDocQueryConnectionError,
+  dispatchDocQueryDisconnected,
+} from "./dispatchDocQueryAction.js";
+
+/**
+ * Moves every loaded query to `paused`, and to `error + paused` when the
+ * connection failed permanently. Socket.IO keeps `active === true` while it is
+ * still retrying, so that flag is what separates a temporary interruption from
+ * a rejection the client will never recover from on its own.
+ */
+export function pauseQueries<
+  D extends object,
+  S extends object,
+  O extends object,
+>(
+  client: DocSyncClient<D, S, O>,
+  connectionError: DocSyncError | undefined,
+): void {
+  client["_connectionFetchStatus"] = "paused";
+  if (connectionError) client["_connectionError"] = connectionError;
+  for (const docId of client["_docsCache"].keys()) {
+    if (connectionError) {
+      dispatchDocQueryConnectionError(client, docId, connectionError);
+    } else {
+      dispatchDocQueryDisconnected(client, docId);
+    }
+  }
+}

--- a/packages/docsync/src/client/utils/pauseQueries.ts
+++ b/packages/docsync/src/client/utils/pauseQueries.ts
@@ -1,8 +1,8 @@
 import type { DocSyncClient } from "../index.js";
 import type { DocSyncError } from "./DocSyncError.js";
 import {
-  dispatchDocQueryConnectionError,
-  dispatchDocQueryDisconnected,
+  dispatchAllDocQueriesConnectionError,
+  dispatchAllDocQueriesDisconnected,
 } from "./dispatchDocQueryAction.js";
 
 /**
@@ -21,11 +21,9 @@ export function pauseQueries<
 ): void {
   client["_connectionFetchStatus"] = "paused";
   if (connectionError) client["_connectionError"] = connectionError;
-  for (const docId of client["_docsCache"].keys()) {
-    if (connectionError) {
-      dispatchDocQueryConnectionError(client, docId, connectionError);
-    } else {
-      dispatchDocQueryDisconnected(client, docId);
-    }
+  if (connectionError) {
+    dispatchAllDocQueriesConnectionError(client, connectionError);
+  } else {
+    dispatchAllDocQueriesDisconnected(client);
   }
 }

--- a/packages/docsync/src/client/utils/pauseQueries.ts
+++ b/packages/docsync/src/client/utils/pauseQueries.ts
@@ -20,8 +20,8 @@ export function pauseQueries<
   connectionError: DocSyncError | undefined,
 ): void {
   client["_connectionFetchStatus"] = "paused";
-  if (connectionError) client["_connectionError"] = connectionError;
   if (connectionError) {
+    client["_connectionError"] = connectionError;
     dispatchAllDocQueriesConnectionError(client, connectionError);
   } else {
     dispatchAllDocQueriesDisconnected(client);

--- a/packages/docsync/src/client/utils/queryResultReducer.ts
+++ b/packages/docsync/src/client/utils/queryResultReducer.ts
@@ -32,10 +32,15 @@ export function createQueryResultReducer<D>(config: {
     actions: {
       // localDocNotFound is not an action, because does not change the state
       localDocFound: (state: QueryResult<D>, payload: { data: D }) =>
-        success(payload.data, state.fetchStatus),
+        state.status === "error"
+          ? { ...state, data: payload.data }
+          : success(payload.data, state.fetchStatus),
 
       localQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
         error(state, state.fetchStatus, payload.error),
+
+      fetchStarted: (state: QueryResult<D>, _payload: undefined) =>
+        withFetchStatus(state, "fetching"),
 
       connected: (state: QueryResult<D>, _payload: undefined) => {
         if (state.fetchStatus !== "paused") return state;
@@ -43,7 +48,7 @@ export function createQueryResultReducer<D>(config: {
       },
 
       disconnected: (state: QueryResult<D>, _payload: undefined) => {
-        if (state.fetchStatus !== "fetching") return state;
+        if (state.fetchStatus === "paused") return state;
         return withFetchStatus(state, "paused");
       },
 
@@ -64,8 +69,10 @@ export function createQueryResultReducer<D>(config: {
         return success(undefined as D, "idle");
       },
 
-      networkQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
-        error(state, "idle", payload.error),
+      networkQueryError: (
+        state: QueryResult<D>,
+        payload: { error: Error; fetchStatus: "paused" | "idle" },
+      ) => error(state, payload.fetchStatus, payload.error),
     },
     beforeAction: (state, action) => {
       const terminalNetworkAction =

--- a/packages/docsync/src/client/utils/queryResultReducer.ts
+++ b/packages/docsync/src/client/utils/queryResultReducer.ts
@@ -1,6 +1,42 @@
 import type { FetchStatus, QueryResult } from "../types.js";
 import { createReducer } from "./reducer.js";
 
+/**
+ * `fetchStatus` answers one question: can this query hand you the authoritative
+ * document right now?
+ *
+ * - `fetching` — not yet. The document is being loaded for the first time, or
+ *   re-synchronised after the connection came back.
+ * - `idle` — yes, and it is up to date.
+ * - `paused` — no, and it will not be until the connection returns.
+ *
+ * A routine background sync does **not** change that answer. DocSync is
+ * realtime over a persistent socket and applies local edits optimistically, so
+ * while a push is in flight the document the user is reading is already
+ * correct. Remote operations arriving from the server are applied to the live
+ * document instance, which is why they do not produce a new query result
+ * either — only a wholesale document replacement does, and that is rare.
+ *
+ * ## Why not report every push as `fetching`
+ *
+ * The alternative — flipping `idle → fetching → idle` around every sync, the
+ * way TanStack Query reports a background refetch — was considered and
+ * rejected. It has two costs and no benefit this API needs:
+ *
+ * 1. It overloads `fetchStatus` with two unrelated meanings: "I cannot give
+ *    you the document" and "there is a push in flight". Applications care
+ *    about the first and can do nothing with the second.
+ * 2. Every sync would emit two new query results. With the 50ms collaborative
+ *    debounce that is roughly 40 re-renders per second of the whole subtree
+ *    under `useDoc`, for a document that never changed identity. Measured, not
+ *    estimated: 5 background syncs produced 10 distinct result objects and
+ *    exactly 1 distinct document.
+ *
+ * **If you want a "Saving…" indicator** like Google Docs, build it from the
+ * client's `sync` event rather than from `fetchStatus`: it fires once per sync
+ * with the request and its outcome, which is precisely the signal such an
+ * indicator needs, and it costs nothing to applications that do not want one.
+ */
 function withFetchStatus<D>(
   state: QueryResult<D>,
   fetchStatus: FetchStatus,
@@ -22,17 +58,6 @@ function error<D>(
 }
 
 /**
- * An `idle` query is settled: the newest sync attempt already produced its
- * result. The attempt token in `handleSync` is what stops a superseded attempt
- * from reaching this reducer at all; this check is the backstop for the day a
- * new `await` is added without its token check. Overwriting a settled query
- * with a stale result is never correct, so it is refused here regardless.
- */
-function isSettled<D>(state: QueryResult<D>): boolean {
-  return state.fetchStatus === "idle";
-}
-
-/**
  * Terminal network actions settle the query, but they must not claim the
  * connection is healthy. The socket can drop while a response is still being
  * reconciled, so a query that is already `paused` stays `paused` and the app
@@ -40,6 +65,27 @@ function isSettled<D>(state: QueryResult<D>): boolean {
  */
 function terminalFetchStatus<D>(state: QueryResult<D>): FetchStatus {
   return state.fetchStatus === "paused" ? "paused" : "idle";
+}
+
+/**
+ * A sync that confirms what the query already holds has nothing to report.
+ * Returning the current state keeps its identity, so React and other external
+ * stores treat it as no change at all — this is what keeps a settled document
+ * from re-rendering on every background push.
+ */
+function successOrUnchanged<D>(
+  state: QueryResult<D>,
+  data: D,
+  fetchStatus: FetchStatus,
+): QueryResult<D> {
+  if (
+    state.status === "success" &&
+    state.data === data &&
+    state.fetchStatus === fetchStatus
+  ) {
+    return state;
+  }
+  return success(data, fetchStatus);
 }
 
 /**
@@ -55,13 +101,10 @@ export function createQueryResultReducer<D>(config: {
       localDocFound: (state: QueryResult<D>, payload: { data: D }) =>
         state.status === "error"
           ? { ...state, data: payload.data }
-          : success(payload.data, state.fetchStatus),
+          : successOrUnchanged(state, payload.data, state.fetchStatus),
 
       localQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
         error(state, terminalFetchStatus(state), payload.error),
-
-      fetchStarted: (state: QueryResult<D>, _payload: undefined) =>
-        withFetchStatus(state, "fetching"),
 
       connected: (state: QueryResult<D>, _payload: undefined) => {
         if (state.fetchStatus !== "paused") return state;
@@ -81,17 +124,16 @@ export function createQueryResultReducer<D>(config: {
         error(state, "paused", payload.error),
 
       networkDocFound: (state: QueryResult<D>, payload: { data: D }) =>
-        isSettled(state)
-          ? state
-          : success(payload.data, terminalFetchStatus(state)),
+        successOrUnchanged(state, payload.data, terminalFetchStatus(state)),
 
       networkDocNotFound: (
         state: QueryResult<D>,
         payload: { createIfMissing: boolean },
       ): QueryResult<D> => {
-        if (isSettled(state)) return state;
         const fetchStatus = terminalFetchStatus(state);
-        if (state.status === "success") return success(state.data, fetchStatus);
+        if (state.status === "success") {
+          return successOrUnchanged(state, state.data, fetchStatus);
+        }
         if (state.status === "error" && state.data !== undefined) {
           return success(state.data, fetchStatus);
         }
@@ -102,9 +144,7 @@ export function createQueryResultReducer<D>(config: {
       },
 
       networkQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
-        isSettled(state)
-          ? state
-          : error(state, terminalFetchStatus(state), payload.error),
+        error(state, terminalFetchStatus(state), payload.error),
     },
   });
 }

--- a/packages/docsync/src/client/utils/queryResultReducer.ts
+++ b/packages/docsync/src/client/utils/queryResultReducer.ts
@@ -22,20 +22,6 @@ function error<D>(
 }
 
 /**
- * An `idle` query is settled: a newer sync already produced its result. A
- * terminal network action arriving afterwards belongs to a superseded attempt —
- * Socket.IO can drop and reconnect while a request is in flight, and the
- * abandoned one still settles later, after the retry already succeeded.
- * Applying it would overwrite a fresh result with a stale one.
- *
- * This contains the damage; see the TODO in handlers/connection/disconnect.ts
- * for the race that produces the superseded sync in the first place.
- */
-function isSettled<D>(state: QueryResult<D>): boolean {
-  return state.fetchStatus === "idle";
-}
-
-/**
  * Terminal network actions settle the query, but they must not claim the
  * connection is healthy. The socket can drop while a response is still being
  * reconciled, so a query that is already `paused` stays `paused` and the app
@@ -61,7 +47,7 @@ export function createQueryResultReducer<D>(config: {
           : success(payload.data, state.fetchStatus),
 
       localQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
-        error(state, state.fetchStatus, payload.error),
+        error(state, terminalFetchStatus(state), payload.error),
 
       fetchStarted: (state: QueryResult<D>, _payload: undefined) =>
         withFetchStatus(state, "fetching"),
@@ -84,15 +70,12 @@ export function createQueryResultReducer<D>(config: {
         error(state, "paused", payload.error),
 
       networkDocFound: (state: QueryResult<D>, payload: { data: D }) =>
-        isSettled(state)
-          ? state
-          : success(payload.data, terminalFetchStatus(state)),
+        success(payload.data, terminalFetchStatus(state)),
 
       networkDocNotFound: (
         state: QueryResult<D>,
         payload: { createIfMissing: boolean },
       ): QueryResult<D> => {
-        if (isSettled(state)) return state;
         const fetchStatus = terminalFetchStatus(state);
         if (state.status === "success") return success(state.data, fetchStatus);
         if (state.status === "error" && state.data !== undefined) {
@@ -104,10 +87,15 @@ export function createQueryResultReducer<D>(config: {
         return success(undefined as D, fetchStatus);
       },
 
-      networkQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
-        isSettled(state)
-          ? state
-          : error(state, terminalFetchStatus(state), payload.error),
+      networkQueryError: (
+        state: QueryResult<D>,
+        payload: { error: Error; fetchStatus?: FetchStatus },
+      ) =>
+        error(
+          state,
+          payload.fetchStatus ?? terminalFetchStatus(state),
+          payload.error,
+        ),
     },
   });
 }

--- a/packages/docsync/src/client/utils/queryResultReducer.ts
+++ b/packages/docsync/src/client/utils/queryResultReducer.ts
@@ -22,6 +22,30 @@ function error<D>(
 }
 
 /**
+ * An `idle` query is settled: a newer sync already produced its result. A
+ * terminal network action arriving afterwards belongs to a superseded attempt —
+ * Socket.IO can drop and reconnect while a request is in flight, and the
+ * abandoned one still settles later, after the retry already succeeded.
+ * Applying it would overwrite a fresh result with a stale one.
+ *
+ * This contains the damage; see the TODO in handlers/connection/disconnect.ts
+ * for the race that produces the superseded sync in the first place.
+ */
+function isSettled<D>(state: QueryResult<D>): boolean {
+  return state.fetchStatus === "idle";
+}
+
+/**
+ * Terminal network actions settle the query, but they must not claim the
+ * connection is healthy. The socket can drop while a response is still being
+ * reconciled, so a query that is already `paused` stays `paused` and the app
+ * keeps rendering its offline state.
+ */
+function terminalFetchStatus<D>(state: QueryResult<D>): FetchStatus {
+  return state.fetchStatus === "paused" ? "paused" : "idle";
+}
+
+/**
  * @internal - Do not use this function!
  */
 export function createQueryResultReducer<D>(config: {
@@ -52,37 +76,38 @@ export function createQueryResultReducer<D>(config: {
         return withFetchStatus(state, "paused");
       },
 
-      networkDocFound: (_state: QueryResult<D>, payload: { data: D }) =>
-        success(payload.data, "idle"),
+      /**
+       * A permanent connection failure: the query cannot progress until the
+       * client reconnects, so it pauses and surfaces the error in one step.
+       */
+      connectionError: (state: QueryResult<D>, payload: { error: Error }) =>
+        error(state, "paused", payload.error),
+
+      networkDocFound: (state: QueryResult<D>, payload: { data: D }) =>
+        isSettled(state)
+          ? state
+          : success(payload.data, terminalFetchStatus(state)),
 
       networkDocNotFound: (
         state: QueryResult<D>,
         payload: { createIfMissing: boolean },
       ): QueryResult<D> => {
-        if (state.status === "success") return success(state.data, "idle");
+        if (isSettled(state)) return state;
+        const fetchStatus = terminalFetchStatus(state);
+        if (state.status === "success") return success(state.data, fetchStatus);
         if (state.status === "error" && state.data !== undefined) {
-          return success(state.data, "idle");
+          return success(state.data, fetchStatus);
         }
         if (payload.createIfMissing) {
-          return { status: "pending", fetchStatus: "idle" };
+          return { status: "pending", fetchStatus };
         }
-        return success(undefined as D, "idle");
+        return success(undefined as D, fetchStatus);
       },
 
-      networkQueryError: (
-        state: QueryResult<D>,
-        payload: { error: Error; fetchStatus: "paused" | "idle" },
-      ) => error(state, payload.fetchStatus, payload.error),
-    },
-    beforeAction: (state, action) => {
-      const terminalNetworkAction =
-        action.type === "networkDocFound" ||
-        action.type === "networkDocNotFound" ||
-        action.type === "networkQueryError";
-
-      if (terminalNetworkAction && state.fetchStatus === "idle") {
-        throw new Error(`Cannot apply ${action.type} when fetchStatus is idle`);
-      }
+      networkQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
+        isSettled(state)
+          ? state
+          : error(state, terminalFetchStatus(state), payload.error),
     },
   });
 }

--- a/packages/docsync/src/client/utils/queryResultReducer.ts
+++ b/packages/docsync/src/client/utils/queryResultReducer.ts
@@ -101,22 +101,10 @@ export function createQueryResultReducer<D>(config: {
         return success(undefined as D, fetchStatus);
       },
 
-      /**
-       * `fetchStatus: "fetching"` reports the failure while a retry or a queued
-       * sync is still pending. It is the only override allowed: forcing `idle`
-       * or `paused` from a caller would bypass `terminalFetchStatus`.
-       */
-      networkQueryError: (
-        state: QueryResult<D>,
-        payload: { error: Error; fetchStatus?: "fetching" },
-      ) =>
+      networkQueryError: (state: QueryResult<D>, payload: { error: Error }) =>
         isSettled(state)
           ? state
-          : error(
-              state,
-              payload.fetchStatus ?? terminalFetchStatus(state),
-              payload.error,
-            ),
+          : error(state, terminalFetchStatus(state), payload.error),
     },
   });
 }

--- a/packages/docsync/src/client/utils/queryResultReducer.ts
+++ b/packages/docsync/src/client/utils/queryResultReducer.ts
@@ -22,6 +22,17 @@ function error<D>(
 }
 
 /**
+ * An `idle` query is settled: the newest sync attempt already produced its
+ * result. The attempt token in `handleSync` is what stops a superseded attempt
+ * from reaching this reducer at all; this check is the backstop for the day a
+ * new `await` is added without its token check. Overwriting a settled query
+ * with a stale result is never correct, so it is refused here regardless.
+ */
+function isSettled<D>(state: QueryResult<D>): boolean {
+  return state.fetchStatus === "idle";
+}
+
+/**
  * Terminal network actions settle the query, but they must not claim the
  * connection is healthy. The socket can drop while a response is still being
  * reconciled, so a query that is already `paused` stays `paused` and the app
@@ -70,12 +81,15 @@ export function createQueryResultReducer<D>(config: {
         error(state, "paused", payload.error),
 
       networkDocFound: (state: QueryResult<D>, payload: { data: D }) =>
-        success(payload.data, terminalFetchStatus(state)),
+        isSettled(state)
+          ? state
+          : success(payload.data, terminalFetchStatus(state)),
 
       networkDocNotFound: (
         state: QueryResult<D>,
         payload: { createIfMissing: boolean },
       ): QueryResult<D> => {
+        if (isSettled(state)) return state;
         const fetchStatus = terminalFetchStatus(state);
         if (state.status === "success") return success(state.data, fetchStatus);
         if (state.status === "error" && state.data !== undefined) {
@@ -87,15 +101,22 @@ export function createQueryResultReducer<D>(config: {
         return success(undefined as D, fetchStatus);
       },
 
+      /**
+       * `fetchStatus: "fetching"` reports the failure while a retry or a queued
+       * sync is still pending. It is the only override allowed: forcing `idle`
+       * or `paused` from a caller would bypass `terminalFetchStatus`.
+       */
       networkQueryError: (
         state: QueryResult<D>,
-        payload: { error: Error; fetchStatus?: FetchStatus },
+        payload: { error: Error; fetchStatus?: "fetching" },
       ) =>
-        error(
-          state,
-          payload.fetchStatus ?? terminalFetchStatus(state),
-          payload.error,
-        ),
+        isSettled(state)
+          ? state
+          : error(
+              state,
+              payload.fetchStatus ?? terminalFetchStatus(state),
+              payload.error,
+            ),
     },
   });
 }

--- a/packages/docsync/src/client/utils/syncRetry.ts
+++ b/packages/docsync/src/client/utils/syncRetry.ts
@@ -9,8 +9,14 @@ import type { DocSyncClient } from "../index.js";
  *
  * The attempts below span 300, 600, 1200, 2400, 4800 and then 5000ms three
  * times — roughly 24 seconds, long enough to ride out a server restart without
- * retrying a genuinely broken document forever. Any successful sync or
- * reconnect resets the counter, so a later edit starts over.
+ * retrying a genuinely broken document forever.
+ *
+ * The budget covers one episode of failure, not the document's whole lifetime:
+ * a successful sync, a reconnect, and exhausting the budget all reset it, so a
+ * later edit gets its own bounded chain. Keeping a spent counter around would
+ * be worse, not safer — every later edit would fail hard on its first attempt,
+ * which against a 50ms collab debounce is a higher sustained request rate than
+ * a backed-off chain.
  */
 const SYNC_RETRY_BASE_DELAY = 300;
 const SYNC_RETRY_MAX_DELAY = 5_000;
@@ -34,7 +40,14 @@ export function scheduleSyncRetry<
   const retryStates = client["_syncRetryState"];
   const previousState = retryStates.get(docId);
   const attempts = (previousState?.attempts ?? 0) + 1;
-  if (attempts > SYNC_RETRY_MAX_ATTEMPTS) return false;
+  if (attempts > SYNC_RETRY_MAX_ATTEMPTS) {
+    // Forget the spent budget instead of leaving it at the ceiling. Nothing is
+    // scheduled here, so the caller still settles the query and this cannot
+    // loop; it only means the next failure — from a user edit, a `dirty`
+    // event, or a reconnect — starts its own chain.
+    clearSyncRetry(client, docId);
+    return false;
+  }
 
   const delay = Math.min(
     SYNC_RETRY_BASE_DELAY * 2 ** (attempts - 1),

--- a/packages/docsync/src/client/utils/syncRetry.ts
+++ b/packages/docsync/src/client/utils/syncRetry.ts
@@ -1,0 +1,66 @@
+import type { DocSyncClient } from "../index.js";
+
+/**
+ * Transient sync failures (network drops, a server database hiccup) are worth
+ * retrying, but retrying them immediately turns an outage into a hot loop that
+ * hammers the server for as long as it stays down. Back off exponentially and
+ * give up after a handful of attempts, leaving the error visible on the query
+ * so the application can decide what to do.
+ */
+const SYNC_RETRY_BASE_DELAY = 300;
+const SYNC_RETRY_MAX_DELAY = 5_000;
+const SYNC_RETRY_MAX_ATTEMPTS = 5;
+
+export type SyncRetryState = {
+  attempts: number;
+  timeout?: ReturnType<typeof setTimeout>;
+};
+
+/**
+ * Schedules `retry` with exponential backoff. Returns `false` once the document
+ * has exhausted its attempts, so the caller can stop retrying.
+ */
+export function scheduleSyncRetry<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string, retry: () => void): boolean {
+  const retryStates = client["_syncRetryState"];
+  const attempts = (retryStates.get(docId)?.attempts ?? 0) + 1;
+  if (attempts > SYNC_RETRY_MAX_ATTEMPTS) return false;
+
+  const delay = Math.min(
+    SYNC_RETRY_BASE_DELAY * 2 ** (attempts - 1),
+    SYNC_RETRY_MAX_DELAY,
+  );
+  const timeout = setTimeout(() => {
+    delete retryStates.get(docId)?.timeout;
+    retry();
+  }, delay);
+  retryStates.set(docId, { attempts, timeout });
+  return true;
+}
+
+/** Forgets the backoff for a document, so the next failure starts over. */
+export function clearSyncRetry<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string): void {
+  const retryState = client["_syncRetryState"].get(docId);
+  if (!retryState) return;
+  clearTimeout(retryState.timeout);
+  client["_syncRetryState"].delete(docId);
+}
+
+/** Forgets every pending backoff, e.g. when the connection drops. */
+export function clearAllSyncRetries<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>): void {
+  for (const retryState of client["_syncRetryState"].values()) {
+    clearTimeout(retryState.timeout);
+  }
+  client["_syncRetryState"].clear();
+}

--- a/packages/docsync/src/client/utils/syncRetry.ts
+++ b/packages/docsync/src/client/utils/syncRetry.ts
@@ -3,13 +3,18 @@ import type { DocSyncClient } from "../index.js";
 /**
  * Transient sync failures (network drops, a server database hiccup) are worth
  * retrying, but retrying them immediately turns an outage into a hot loop that
- * hammers the server for as long as it stays down. Back off exponentially and
- * give up after a handful of attempts, leaving the error visible on the query
- * so the application can decide what to do.
+ * hammers the server for as long as it stays down. Back off exponentially up to
+ * a fixed ceiling, then give up, leaving the error visible on the query so the
+ * application can decide what to do.
+ *
+ * The attempts below span 300, 600, 1200, 2400, 4800 and then 5000ms three
+ * times — roughly 24 seconds, long enough to ride out a server restart without
+ * retrying a genuinely broken document forever. Any successful sync or
+ * reconnect resets the counter, so a later edit starts over.
  */
 const SYNC_RETRY_BASE_DELAY = 300;
 const SYNC_RETRY_MAX_DELAY = 5_000;
-const SYNC_RETRY_MAX_ATTEMPTS = 5;
+const SYNC_RETRY_MAX_ATTEMPTS = 8;
 
 export type SyncRetryState = {
   attempts: number;
@@ -17,8 +22,9 @@ export type SyncRetryState = {
 };
 
 /**
- * Schedules `retry` with exponential backoff. Returns `false` once the document
- * has exhausted its attempts, so the caller can stop retrying.
+ * Schedules `retry` with exponential backoff. Returns whether a retry was
+ * scheduled: `false` means the document exhausted its attempts, so the caller
+ * must settle the query instead of leaving it looking busy.
  */
 export function scheduleSyncRetry<
   D extends object,

--- a/packages/docsync/src/client/utils/syncRetry.ts
+++ b/packages/docsync/src/client/utils/syncRetry.ts
@@ -14,9 +14,10 @@ import type { DocSyncClient } from "../index.js";
  * The budget covers one episode of failure, not the document's whole lifetime:
  * a successful sync, a reconnect, and exhausting the budget all reset it, so a
  * later edit gets its own bounded chain. Keeping a spent counter around would
- * be worse, not safer — every later edit would fail hard on its first attempt,
- * which against a 50ms collab debounce is a higher sustained request rate than
- * a backed-off chain.
+ * be cheaper in requests — a document that burned its budget would never retry
+ * again while the socket stays up — but that is the worse failure mode: the
+ * document stops recovering on its own for the rest of the connection, and the
+ * user has no way to ask it to try again beyond reloading.
  */
 const SYNC_RETRY_BASE_DELAY = 300;
 const SYNC_RETRY_MAX_DELAY = 5_000;

--- a/packages/docsync/src/client/utils/syncRetry.ts
+++ b/packages/docsync/src/client/utils/syncRetry.ts
@@ -32,19 +32,36 @@ export function scheduleSyncRetry<
   O extends object,
 >(client: DocSyncClient<D, S, O>, docId: string, retry: () => void): boolean {
   const retryStates = client["_syncRetryState"];
-  const attempts = (retryStates.get(docId)?.attempts ?? 0) + 1;
+  const previousState = retryStates.get(docId);
+  const attempts = (previousState?.attempts ?? 0) + 1;
   if (attempts > SYNC_RETRY_MAX_ATTEMPTS) return false;
 
   const delay = Math.min(
     SYNC_RETRY_BASE_DELAY * 2 ** (attempts - 1),
     SYNC_RETRY_MAX_DELAY,
   );
-  const timeout = setTimeout(() => {
-    delete retryStates.get(docId)?.timeout;
+  const nextState: SyncRetryState = { attempts };
+  nextState.timeout = setTimeout(() => {
+    // A manual sync or a newer failure may have replaced this backoff. Only
+    // the timer still stored for the document is allowed to start a request.
+    if (retryStates.get(docId) !== nextState) return;
+    delete nextState.timeout;
     retry();
   }, delay);
-  retryStates.set(docId, { attempts, timeout });
+  retryStates.set(docId, nextState);
   return true;
+}
+
+/** Cancels a pending timer without resetting how far backoff has progressed. */
+export function cancelPendingSyncRetry<
+  D extends object,
+  S extends object,
+  O extends object,
+>(client: DocSyncClient<D, S, O>, docId: string): void {
+  const retryState = client["_syncRetryState"].get(docId);
+  if (!retryState?.timeout) return;
+  clearTimeout(retryState.timeout);
+  delete retryState.timeout;
 }
 
 /** Forgets the backoff for a document, so the next failure starts over. */

--- a/packages/docsync/src/exports/client.ts
+++ b/packages/docsync/src/exports/client.ts
@@ -1,6 +1,8 @@
 export { createDocBinding } from "../bindings/index.js";
 export { DocSyncClient } from "../client/index.js";
 export { indexedDBProvider } from "../client/providers/indexeddb.js";
+export { DocSyncError } from "../client/utils/DocSyncError.js";
+export type { DocSyncErrorType } from "../client/utils/DocSyncError.js";
 export { createReducer as _INTERNAL_createReducer } from "../client/utils/reducer.js";
 export { createQueryResultReducer as _INTERNAL_createQueryResultReducer } from "../client/utils/queryResultReducer.js";
 export type { DocBinding, Presence } from "../shared/types.js";

--- a/packages/docsync/src/exports/client.ts
+++ b/packages/docsync/src/exports/client.ts
@@ -22,6 +22,7 @@ export type {
   RequestClientAuthConfig,
   FetchStatus,
   GetDocArgs,
+  DocObserver,
   DocData,
   Identity,
   QueryResult,

--- a/tests/docsync-react/index.browser.test.tsx
+++ b/tests/docsync-react/index.browser.test.tsx
@@ -137,6 +137,60 @@ test("createDocSyncClient", async () => {
   >();
 }, 5000);
 
+test("useDoc never renders the previous document after its id changes", async () => {
+  localStorage.removeItem("docsync:localUserId");
+  const firstId = id.ending("101");
+  const secondId = id.ending("102");
+  const { useDoc, client } = createDocSyncClient({
+    server: {
+      url: testServerUrl(),
+      auth: { mode: "token", getToken: () => "test-token-id-change" },
+    },
+    local: { provider: indexedDBProvider },
+    docBinding: DocNodeBinding([docConfig]),
+  });
+  if (!client) throw new Error("Expected browser client");
+
+  const secondObserver = client.getDocObserver({
+    type: "test",
+    id: secondId,
+    createIfMissing: true,
+  });
+  const unsubscribeSecond = secondObserver.subscribe(() => undefined);
+  await expect
+    .poll(() => secondObserver.getSnapshot().fetchStatus)
+    .toBe("idle");
+
+  const renderedDocIds: string[] = [];
+  const hook = await renderHook(
+    (props?: { docId: string }) => {
+      const result = useDoc({
+        type: "test",
+        id: props?.docId ?? firstId,
+        createIfMissing: true,
+      });
+      if (result.status === "success") {
+        renderedDocIds.push(result.data.docId);
+      }
+      return result;
+    },
+    { initialProps: { docId: firstId } },
+  );
+  await expect.poll(() => hook.result.current.fetchStatus).toBe("idle");
+  expect(hook.result.current.data?.docId).toBe(firstId);
+
+  renderedDocIds.length = 0;
+  await hook.rerender({ docId: secondId });
+
+  expect(hook.result.current.data?.docId).toBe(secondId);
+  expect(renderedDocIds).not.toContain(firstId);
+
+  await hook.unmount();
+  unsubscribeSecond();
+  client.disconnect();
+  client["_bcHelper"]?.close();
+}, 5000);
+
 test("client keeps own presence for debounced outgoing sync", async () => {
   localStorage.setItem("docsync:localUserId", reactUserId);
   const { useDoc, usePresence, client } = createDocSyncClient({

--- a/tests/docsync/int/auth.browser.test.ts
+++ b/tests/docsync/int/auth.browser.test.ts
@@ -71,9 +71,10 @@ describe("Authentication", () => {
     const client = createClient("invalid");
     const results: QueryResult<DocData<Doc> | undefined>[] = [];
 
-    client.getDoc({ type: "t", id: "auth-rejection" }, (result) => {
-      results.push(result);
-    });
+    const observer = client.getDocObserver({ type: "t", id: "auth-rejection" });
+    const recordResult = () => results.push(observer.getSnapshot());
+    observer.subscribe(recordResult);
+    recordResult();
 
     await expect.poll(() => results.at(-1)?.status).toBe("error");
     const result = results.at(-1);

--- a/tests/docsync/int/auth.browser.test.ts
+++ b/tests/docsync/int/auth.browser.test.ts
@@ -1,9 +1,14 @@
 // TODO: move to unit tests
 
 import { describe, expect, inject, test } from "vitest";
-import { DocSyncClient, indexedDBProvider } from "@docukit/docsync/client";
+import {
+  DocSyncClient,
+  indexedDBProvider,
+  type DocData,
+  type QueryResult,
+} from "@docukit/docsync/client";
 import { DocNodeBinding } from "@docukit/docsync/docnode";
-import { defineNode, string } from "@docukit/docnode";
+import { defineNode, string, type Doc } from "@docukit/docnode";
 
 const LOCAL_IDENTITY_KEY = "docsync:localUserId";
 
@@ -60,5 +65,23 @@ describe("Authentication", () => {
     );
     expect(error.message).toContain("Authentication");
     socket.disconnect();
+  });
+
+  test("document query exposes an authentication rejection as error and paused", async () => {
+    const client = createClient("invalid");
+    const results: QueryResult<DocData<Doc> | undefined>[] = [];
+
+    client.getDoc({ type: "t", id: "auth-rejection" }, (result) => {
+      results.push(result);
+    });
+
+    await expect.poll(() => results.at(-1)?.status).toBe("error");
+    const result = results.at(-1);
+    expect(result?.fetchStatus).toBe("paused");
+    if (result?.status !== "error") {
+      throw new Error("Expected an error result");
+    }
+    expect(result.error.message).toContain("Authentication");
+    client.disconnect();
   });
 });

--- a/tests/docsync/int/utils.ts
+++ b/tests/docsync/int/utils.ts
@@ -339,18 +339,21 @@ const createClientUtils = async (
         throw new Error("Doc already loaded. Call unLoadDoc() first.");
       }
       await new Promise<void>((resolve, reject) => {
-        cleanup = client.getDoc(
-          { type: "test", id: docId, createIfMissing: true },
-          (result) => {
-            if (result.status === "success" && result.data) {
-              cachedDoc = result.data.doc;
-              resolve();
-            }
-            if (result.status === "error") {
-              reject(result.error);
-            }
-          },
-        );
+        const observer = client.getDocObserver({
+          type: "test",
+          id: docId,
+          createIfMissing: true,
+        });
+        const handleResult = () => {
+          const result = observer.getSnapshot();
+          if (result.status === "success") {
+            cachedDoc = result.data.doc;
+            resolve();
+          }
+          if (result.status === "error") reject(result.error);
+        };
+        cleanup = observer.subscribe(handleResult);
+        handleResult();
       });
     },
     unLoadDoc: () => {

--- a/tests/docsync/ui/editor/utils.ts
+++ b/tests/docsync/ui/editor/utils.ts
@@ -780,6 +780,10 @@ async function waitForEditorReady(page: Page) {
       .first()
       .waitFor({ state: "visible" });
   }
+  // The example keeps rendering the document when a query carries an error, so
+  // a broken demo no longer hides the editor. Assert the error is absent, or a
+  // regression like a rejected handshake would pass every editor test.
+  await expect(page.getByTestId("query-error")).toHaveCount(0);
 }
 
 export function collapsed(offset: number): SelectionExpectation {

--- a/tests/docsync/ui/subdocs/utils.ts
+++ b/tests/docsync/ui/subdocs/utils.ts
@@ -36,6 +36,10 @@ export class DocNodeHelper extends HelperBase {
     await page.goto(`examples/subdocs?docId=${helper.docId}`);
     await page.waitForLoadState("networkidle");
     await page.locator("#reference").first().waitFor({ state: "visible" });
+    // The example keeps rendering documents when a query carries an error, so
+    // a broken demo no longer hides the panels. Assert the error is absent, or
+    // a regression like a rejected handshake would pass every subdocs test.
+    await expect(page.getByTestId("query-error")).toHaveCount(0);
     return helper as T;
   }
 

--- a/tests/docsync/unit/client/events.browser.test.ts
+++ b/tests/docsync/unit/client/events.browser.test.ts
@@ -160,12 +160,14 @@ describe("Client Events", () => {
         loadSource = event.source;
       });
 
-      const cleanup = client.getDoc(
-        { type: "test", id: docId, createIfMissing: true },
-        () => {
-          /* doc updates callback */
-        },
-      );
+      const observer = client.getDocObserver({
+        type: "test",
+        id: docId,
+        createIfMissing: true,
+      });
+      const cleanup = observer.subscribe(() => {
+        /* doc updates callback */
+      });
       await expect.poll(() => loadSource).toBe("created");
 
       cleanup();
@@ -188,7 +190,8 @@ describe("Client Events", () => {
         unloadRefCount = event.refCount;
       });
 
-      const cleanup = client.getDoc({ type: "test", id: docId }, () => {
+      const observer = client.getDocObserver({ type: "test", id: docId });
+      const cleanup = observer.subscribe(() => {
         /* doc updates callback */
       });
       cleanup();

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -1410,6 +1410,45 @@ describe("DocSyncClient", () => {
         });
       });
 
+      test("should resume loaded queries when reconnecting, not just new ones", async () => {
+        const client = createClient();
+        const loadedCallback = createCallback();
+        const lateCallback = createCallback();
+        const docId = ulid().toLowerCase();
+
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          loadedCallback,
+        );
+        await expect
+          .poll(() => loadedCallback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        setSocketState(client, { active: false, connected: false });
+        emitMockedSocketEvent(
+          client,
+          "connect_error",
+          new Error("Authentication failed"),
+        );
+        expect(loadedCallback.mock.calls.at(-1)?.[0]).toMatchObject({
+          status: "error",
+          fetchStatus: "paused",
+        });
+
+        client.connect();
+        setSocketState(client, { active: true, connected: false });
+        client.getDoc(
+          { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
+          lateCallback,
+        );
+
+        // Both subscriptions have to agree about the connection they share.
+        expect(loadedCallback.mock.calls.at(-1)?.[0].fetchStatus).toBe(
+          "fetching",
+        );
+        expect(lateCallback.mock.calls[0]?.[0].fetchStatus).toBe("fetching");
+      });
+
       test("should keep the document instance when subscribing while an error is visible", async () => {
         const client = createClient();
         const callback = createCallback();
@@ -2168,6 +2207,9 @@ describe("DocSyncClient", () => {
         ([event]) => event === "sync",
       ).length;
       expect(syncCallsAfterFailure).toBe(1);
+      // A scheduled retry is still network work, so the query must not claim
+      // it has settled while the backoff is pending.
+      expect(callback.mock.calls.at(-1)?.[0].fetchStatus).toBe("fetching");
 
       // The retry is scheduled, not immediate, so a server outage cannot turn
       // into a hot loop.

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -2897,14 +2897,17 @@ describe("DocSyncClient", () => {
       }
       await client["_sync"](docId);
 
-      expect(client["_syncRetryState"].get(docId)).toStrictEqual({
-        attempts: 8,
-      });
+      // Exhausting the budget forgets it, so the next failure is free to open
+      // its own bounded chain instead of failing hard forever.
+      expect(client["_syncRetryState"].has(docId)).toBe(false);
       expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
         status: "error",
         fetchStatus: "idle",
         error: { type: "DatabaseError" },
       });
+
+      await client["_sync"](docId);
+      expect(client["_syncRetryState"].get(docId)?.attempts).toBe(1);
 
       socketMockState.syncResponses.delete(docId);
       await client["_sync"](docId);

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -2628,10 +2628,10 @@ describe("DocSyncClient", () => {
         .poll(() => socketMockState.deferredSyncAcks.get(docId)?.length)
         .toBe(2);
       expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
-        status: "error",
+        status: "success",
         fetchStatus: "fetching",
-        error: { type: "AuthorizationError" },
       });
+      expect(callback.mock.calls.at(-1)?.[0].error).toBeUndefined();
 
       const queuedAck = socketMockState.deferredSyncAcks.get(docId)?.[1];
       if (!queuedAck) throw new Error("Expected queued sync ack");
@@ -2697,11 +2697,8 @@ describe("DocSyncClient", () => {
 
       await expect
         .poll(() => callback.mock.calls.at(-1)?.[0])
-        .toMatchObject({
-          status: "error",
-          data: { docId },
-          error: { type: "DatabaseError", message: "database unavailable" },
-        });
+        .toMatchObject({ status: "success", data: { docId } });
+      expect(callback.mock.calls.at(-1)?.[0].error).toBeUndefined();
 
       const syncCallsAfterFailure = getSocketEmitMock(client).mock.calls.filter(
         ([event]) => event === "sync",
@@ -2761,10 +2758,10 @@ describe("DocSyncClient", () => {
       expect(socketMockState.deferredSyncAcks.get(docId)).toHaveLength(1);
       expect(client["_syncRetryState"].get(docId)?.timeout).toBeDefined();
       expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
-        status: "error",
+        status: "success",
         fetchStatus: "fetching",
-        error: { type: "DatabaseError" },
       });
+      expect(callback.mock.calls.at(-1)?.[0].error).toBeUndefined();
 
       setSocketState(client, { active: true, connected: false });
       emitMockedSocketEvent(client, "disconnect", "transport close");
@@ -2786,15 +2783,11 @@ describe("DocSyncClient", () => {
       await expect
         .poll(() => callback.mock.calls.at(-1)?.[0])
         .toMatchObject({
-          status: "error",
+          status: "success",
           fetchStatus: "fetching",
           data: { docId },
-          error: {
-            type: "NetworkError",
-            message: "network unavailable",
-            cause: networkFailure,
-          },
         });
+      expect(callback.mock.calls.at(-1)?.[0].error).toBeUndefined();
       expect(client["_syncRetryState"].get(docId)?.attempts).toBe(1);
 
       socketMockState.syncErrors.delete(docId);
@@ -2834,10 +2827,10 @@ describe("DocSyncClient", () => {
         expect(clearTimeoutSpy).toHaveBeenCalledWith(retryTimeout);
         expect(client["_syncRetryState"].has(docId)).toBe(false);
         expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
-          status: "error",
+          status: "success",
           fetchStatus: "paused",
-          error: { type: "DatabaseError" },
         });
+        expect(callback.mock.calls.at(-1)?.[0].error).toBeUndefined();
       } finally {
         clearTimeoutSpy.mockRestore();
       }

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -2338,6 +2338,42 @@ describe("DocSyncClient", () => {
       });
     });
 
+    describe("Background syncs", () => {
+      test("should not emit a query result for a sync that changes nothing", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+
+        subscribeToDoc(
+          client,
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        const settledResult = callback.mock.calls.at(-1)?.[0];
+        const callsAfterLoad = callback.mock.calls.length;
+
+        for (let attempt = 0; attempt < 5; attempt += 1) {
+          await client["_sync"](docId);
+        }
+
+        // A push does not stop the query from serving the document, and remote
+        // operations reach the live instance instead of replacing `data`, so a
+        // background sync has nothing to report. This is what keeps `useDoc`
+        // from re-rendering its whole subtree on every sync — at the 50ms
+        // collaborative debounce, roughly 40 times a second. Reintroducing a
+        // `fetchStarted` dispatch, or emitting an equal-but-new result, breaks
+        // exactly this and nothing else.
+        expect(callback.mock.calls.length).toBe(callsAfterLoad);
+        expect(client["_docsCache"].get(docId)?.queryResult).toBe(
+          settledResult,
+        );
+      });
+    });
+
     describe("Sync vs async behavior", () => {
       test("should emit pending before success when creating by id", async () => {
         const client = createClient();

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -353,6 +353,7 @@ describe("DocSyncClient", () => {
     const doc = { docId };
     client["_docsCache"].set(docId, {
       promisedDoc: Promise.resolve(doc),
+      activeSyncAttempt: undefined,
       refCount: 1,
       localVersion: 0,
       type: "test",
@@ -1436,6 +1437,48 @@ describe("DocSyncClient", () => {
         await expect
           .poll(() => callback.mock.calls.at(-1)?.[0])
           .toMatchObject({ status: "success", fetchStatus: "idle" });
+      });
+
+      test("getDocResult should report the state a new subscription would start from", () => {
+        const client = createClient();
+
+        expect(client.getDocResult({ id: "unknown" })).toStrictEqual({
+          status: "pending",
+          fetchStatus: "fetching",
+        });
+
+        setSocketState(client, { active: false, connected: false });
+        emitMockedSocketEvent(
+          client,
+          "connect_error",
+          new Error("Authentication failed"),
+        );
+
+        expect(client.getDocResult({ id: "unknown" })).toMatchObject({
+          status: "error",
+          fetchStatus: "paused",
+          error: { type: "ConnectionError" },
+        });
+      });
+
+      test("getDocResult should return the cached result of a loaded document", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        // Same object the subscription holds — a read, not a new query.
+        expect(client.getDocResult({ id: docId })).toBe(
+          callback.mock.calls.at(-1)?.[0],
+        );
+        expect(client["_docsCache"].get(docId)?.refCount).toBe(1);
       });
 
       test("should report the same fetch status for every subscription during a transient failure", async () => {

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -46,6 +46,7 @@ const socketMockState = vi.hoisted(() => ({
   autoIdentity: true,
   identityPayload: undefined as MockIdentityPayload | undefined,
   syncResponses: new Map<string, unknown>(),
+  syncErrors: new Map<string, Error>(),
   /**
    * Documents whose sync ack is withheld, so a test can settle the query
    * through a later sync and then release the superseded one.
@@ -97,6 +98,9 @@ const ioMock = vi.hoisted(() =>
                 return;
               }
 
+              const syncError = socketMockState.syncErrors.get(docId);
+              if (syncError) throw syncError;
+
               if (socketMockState.deferSyncDocIds.has(docId)) {
                 const acks = socketMockState.deferredSyncAcks.get(docId) ?? [];
                 acks.push(callback);
@@ -137,6 +141,7 @@ describe("DocSyncClient", () => {
     socketMockState.autoIdentity = true;
     socketMockState.identityPayload = undefined;
     socketMockState.syncResponses.clear();
+    socketMockState.syncErrors.clear();
     socketMockState.deferSyncDocIds.clear();
     socketMockState.deferredSyncAcks.clear();
     clearCachedLocalIdentity();
@@ -386,6 +391,100 @@ describe("DocSyncClient", () => {
     test("should initialize with local provider config", () => {
       const client = createClient();
       expect(client).toBeInstanceOf(DocSyncClient);
+    });
+
+    test.each([{ mode: "throw" }, { mode: "reject" }])(
+      "surfaces a token provider $mode as a connection error",
+      async ({ mode }) => {
+        const tokenError = new Error(`token ${mode}`);
+        const getToken = () => {
+          if (mode === "throw") throw tokenError;
+          return Promise.reject(tokenError);
+        };
+        socketMockState.autoIdentity = false;
+        const client = new DocSyncClient({
+          server: {
+            url: "ws://localhost:8081",
+            auth: { mode: "token", getToken },
+          },
+          docBinding: DocNodeBinding([
+            { type: "test", extensions: [{ nodes: [TestNode, ChildNode] }] },
+          ]),
+          local: { provider: indexedDBProvider },
+        });
+        setSocketState(client, { active: true, connected: false });
+        const callback = createCallback();
+        client.getDoc(
+          { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
+          callback,
+        );
+
+        const options = ioMock.mock.calls.at(-1)?.[1];
+        if (!options || typeof options.auth !== "function") {
+          throw new Error("Expected socket auth callback");
+        }
+        const authCallback = vi.fn();
+        options.auth(authCallback);
+
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0])
+          .toMatchObject({
+            status: "error",
+            fetchStatus: "paused",
+            error: {
+              type: "ConnectionError",
+              message: tokenError.message,
+              cause: tokenError,
+            },
+          });
+        expect(authCallback).not.toHaveBeenCalled();
+      },
+    );
+
+    test("ignores a token failure after a manual disconnect", async () => {
+      socketMockState.autoIdentity = false;
+      let rejectToken: ((reason?: unknown) => void) | undefined;
+      const client = new DocSyncClient({
+        server: {
+          url: "ws://localhost:8081",
+          auth: {
+            mode: "token",
+            getToken: () =>
+              new Promise<string>((_resolve, reject) => {
+                rejectToken = reject;
+              }),
+          },
+        },
+        docBinding: DocNodeBinding([
+          { type: "test", extensions: [{ nodes: [TestNode, ChildNode] }] },
+        ]),
+        local: { provider: indexedDBProvider },
+      });
+      setSocketState(client, { active: true, connected: false });
+      const callback = createCallback();
+      client.getDoc(
+        { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
+        callback,
+      );
+
+      const options = ioMock.mock.calls.at(-1)?.[1];
+      if (!options || typeof options.auth !== "function") {
+        throw new Error("Expected socket auth callback");
+      }
+      const authCallback = vi.fn();
+      options.auth(authCallback);
+      await flushMicrotasks();
+      if (!rejectToken) throw new Error("Expected pending token request");
+
+      client.disconnect();
+      rejectToken(new Error("too late"));
+      await flushMicrotasks();
+
+      expect(callback.mock.calls.at(-1)?.[0]).toStrictEqual({
+        status: "pending",
+        fetchStatus: "paused",
+      });
+      expect(authCallback).not.toHaveBeenCalled();
     });
 
     test("uses cached identity namespace and sends claimed user ID", async () => {
@@ -1389,24 +1488,22 @@ describe("DocSyncClient", () => {
         });
       });
 
-      test("should not inherit a permanent connection error after reconnecting", () => {
+      test("should keep a permanent connection error visible while reconnecting", () => {
         const client = createClient();
         const callback = createCallback();
+        const connectionError = new Error("Authentication failed");
 
         setSocketState(client, { active: false, connected: false });
-        emitMockedSocketEvent(
-          client,
-          "connect_error",
-          new Error("Authentication failed"),
-        );
+        emitMockedSocketEvent(client, "connect_error", connectionError);
 
         client.connect();
         setSocketState(client, { active: true, connected: false });
         client.getDoc({ type: "test", id: "test-id" }, callback);
 
-        expect(callback.mock.calls[0]?.[0]).toStrictEqual({
-          status: "pending",
+        expect(callback.mock.calls[0]?.[0]).toMatchObject({
+          status: "error",
           fetchStatus: "fetching",
+          error: { type: "ConnectionError", cause: connectionError },
         });
       });
 
@@ -1434,6 +1531,7 @@ describe("DocSyncClient", () => {
           status: "error",
           fetchStatus: "paused",
         });
+        const visibleError = loadedCallback.mock.calls.at(-1)?.[0].error;
 
         client.connect();
         setSocketState(client, { active: true, connected: false });
@@ -1442,11 +1540,42 @@ describe("DocSyncClient", () => {
           lateCallback,
         );
 
-        // Both subscriptions have to agree about the connection they share.
-        expect(loadedCallback.mock.calls.at(-1)?.[0].fetchStatus).toBe(
-          "fetching",
+        // Both subscriptions share the active retry and its last known error.
+        expect(loadedCallback.mock.calls.at(-1)?.[0]).toMatchObject({
+          status: "error",
+          fetchStatus: "fetching",
+          error: visibleError,
+        });
+        expect(lateCallback.mock.calls[0]?.[0]).toMatchObject({
+          status: "error",
+          fetchStatus: "fetching",
+          error: visibleError,
+        });
+      });
+
+      test("should resume loaded queries synchronously on automatic reconnect", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
         );
-        expect(lateCallback.mock.calls[0]?.[0].fetchStatus).toBe("fetching");
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        setSocketState(client, { active: true, connected: false });
+        emitMockedSocketEvent(client, "disconnect", "transport close");
+        expect(callback.mock.calls.at(-1)?.[0].fetchStatus).toBe("paused");
+
+        setSocketState(client, { active: true, connected: true });
+        emitMockedSocketEvent(client, "connect");
+
+        // The connect event must resume existing subscriptions before the
+        // asynchronous flush-and-sync work yields to another microtask.
+        expect(callback.mock.calls.at(-1)?.[0].fetchStatus).toBe("fetching");
       });
 
       test("should keep the document instance when subscribing while an error is visible", async () => {
@@ -1478,7 +1607,7 @@ describe("DocSyncClient", () => {
         expect(secondCallback.mock.calls[0]?.[0].data?.doc).toBe(loadedDoc);
       });
 
-      test("should ignore a sync failure that arrives after the query settled", async () => {
+      test("should discard an older sync after the newer sync succeeds", async () => {
         const client = createClient();
         const callback = createCallback();
         const docId = ulid().toLowerCase();
@@ -1492,6 +1621,7 @@ describe("DocSyncClient", () => {
           .poll(() => socketMockState.deferredSyncAcks.get(docId)?.length)
           .toBe(1);
         const supersededAck = socketMockState.deferredSyncAcks.get(docId)?.[0];
+        if (!supersededAck) throw new Error("Expected deferred sync ack");
 
         // Reconnecting starts a second sync, which settles the query first.
         socketMockState.deferSyncDocIds.delete(docId);
@@ -1502,40 +1632,131 @@ describe("DocSyncClient", () => {
           .toBe("idle");
         const settledResult = callback.mock.calls.at(-1)?.[0];
 
-        const unhandledReasons: unknown[] = [];
-        const handler = (event: PromiseRejectionEvent) => {
-          unhandledReasons.push(event.reason);
-          event.preventDefault();
-        };
         const syncEvents: unknown[] = [];
         client.on("sync", (event) => syncEvents.push(event));
-        window.addEventListener("unhandledrejection", handler);
-        try {
-          supersededAck?.({
-            error: { type: "ValidationError", message: "too late" },
+        supersededAck({
+          error: { type: "ValidationError", message: "too late" },
+        });
+        await flushMicrotasks();
+
+        // Stale attempts do not emit events, update query state, schedule a
+        // retry, or release flow control owned by a newer attempt.
+        expect(syncEvents).toStrictEqual([]);
+        expect(callback.mock.calls.at(-1)?.[0]).toBe(settledResult);
+        expect(settledResult).toMatchObject({
+          status: "success",
+          fetchStatus: "idle",
+        });
+        expect(client["_syncRetryState"].has(docId)).toBe(false);
+      });
+
+      test("should let a newer sync succeed after the older sync fails first", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+        const syncEvents: unknown[] = [];
+        client.on("sync", (event) => syncEvents.push(event));
+        socketMockState.deferSyncDocIds.add(docId);
+
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+        await expect
+          .poll(() => socketMockState.deferredSyncAcks.get(docId)?.length)
+          .toBe(1);
+
+        emitMockedSocketEvent(client, "disconnect", "transport close");
+        emitMockedSocketEvent(client, "connect");
+        await expect
+          .poll(() => socketMockState.deferredSyncAcks.get(docId)?.length)
+          .toBe(2);
+
+        const [supersededAck, currentAck] =
+          socketMockState.deferredSyncAcks.get(docId) ?? [];
+        if (!supersededAck || !currentAck) {
+          throw new Error("Expected both deferred sync acks");
+        }
+
+        supersededAck({
+          error: { type: "ValidationError", message: "too late" },
+        });
+        await flushMicrotasks();
+
+        expect(syncEvents).toStrictEqual([]);
+        expect(callback.mock.calls.at(-1)?.[0].fetchStatus).toBe("fetching");
+        expect(callback.mock.calls.at(-1)?.[0].status).not.toBe("error");
+
+        currentAck({
+          data: { docId, operations: [], serializedDoc: null, clock: 0 },
+        });
+
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0])
+          .toMatchObject({ status: "success", fetchStatus: "idle" });
+        expect(
+          syncEvents.some(
+            (event) =>
+              typeof event === "object" && event !== null && "error" in event,
+          ),
+        ).toBe(false);
+      });
+
+      test("should finish provider consolidation when a sync is invalidated after saving its snapshot", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        const doc = callback.mock.calls.at(-1)?.[0].data?.doc;
+        if (!doc) throw new Error("Expected loaded doc");
+        doc.root.append(doc.createNode(ChildNode));
+        doc.forceCommit();
+        await client["_flushLocalOperations"](docId, { sync: false });
+
+        const { provider } = await client["_localPromise"];
+        const transaction = provider.transaction.bind(provider);
+        let interruptAfterSnapshot = true;
+        const transactionSpy = vi
+          .spyOn(provider, "transaction")
+          .mockImplementation((mode, transactionCallback) => {
+            if (mode !== "readwrite" || !interruptAfterSnapshot) {
+              return transaction(mode, transactionCallback);
+            }
+            interruptAfterSnapshot = false;
+            return transaction(mode, (ctx) =>
+              transactionCallback({
+                ...ctx,
+                saveSerializedDoc: async (payload) => {
+                  await ctx.saveSerializedDoc(payload);
+                  setSocketState(client, { active: true, connected: false });
+                  emitMockedSocketEvent(
+                    client,
+                    "disconnect",
+                    "transport close",
+                  );
+                },
+              }),
+            );
           });
 
-          // The superseded response really is processed...
-          await expect
-            .poll(() =>
-              syncEvents.some(
-                (event) =>
-                  typeof event === "object" &&
-                  event !== null &&
-                  "error" in event,
-              ),
-            )
-            .toBe(true);
-          // ...and leaves the settled query untouched instead of resurrecting
-          // a stale error or breaking the reducer invariant.
-          expect(callback.mock.calls.at(-1)?.[0]).toBe(settledResult);
-          expect(settledResult).toMatchObject({
-            status: "success",
-            fetchStatus: "idle",
-          });
-          expect(unhandledReasons).toStrictEqual([]);
+        try {
+          await client["_sync"](docId);
+
+          const operations = await transaction("readonly", (ctx) =>
+            ctx.getOperations({ docId }),
+          );
+          expect(operations).toStrictEqual([]);
+          expect(callback.mock.calls.at(-1)?.[0].fetchStatus).toBe("paused");
         } finally {
-          window.removeEventListener("unhandledrejection", handler);
+          transactionSpy.mockRestore();
         }
       });
 
@@ -2148,6 +2369,52 @@ describe("DocSyncClient", () => {
       expect(syncCalls).toHaveLength(1);
     });
 
+    test("should run a queued sync after a permanent rejection", async () => {
+      const client = createClient();
+      const callback = createCallback();
+      const docId = ulid().toLowerCase();
+      socketMockState.deferSyncDocIds.add(docId);
+
+      client.getDoc(
+        { type: "test", id: docId, createIfMissing: true },
+        callback,
+      );
+      await expect
+        .poll(() => socketMockState.deferredSyncAcks.get(docId)?.length)
+        .toBe(1);
+
+      await client["_sync"](docId);
+      expect(client["_pushStatusByDocId"].get(docId)).toBe(
+        "pushing-with-pending",
+      );
+
+      const rejectedAck = socketMockState.deferredSyncAcks.get(docId)?.[0];
+      if (!rejectedAck) throw new Error("Expected deferred sync ack");
+      rejectedAck({
+        error: { type: "AuthorizationError", message: "Access denied" },
+      });
+
+      await expect
+        .poll(() => socketMockState.deferredSyncAcks.get(docId)?.length)
+        .toBe(2);
+      expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
+        status: "error",
+        fetchStatus: "fetching",
+        error: { type: "AuthorizationError" },
+      });
+
+      const queuedAck = socketMockState.deferredSyncAcks.get(docId)?.[1];
+      if (!queuedAck) throw new Error("Expected queued sync ack");
+      socketMockState.deferSyncDocIds.delete(docId);
+      queuedAck({
+        data: { docId, operations: [], serializedDoc: null, clock: 0 },
+      });
+
+      await expect
+        .poll(() => callback.mock.calls.at(-1)?.[0])
+        .toMatchObject({ status: "success", fetchStatus: "idle" });
+    });
+
     test("should not stop other documents from syncing after a rejection", async () => {
       const client = createClient();
       const rejectedCallback = createCallback();
@@ -2210,6 +2477,12 @@ describe("DocSyncClient", () => {
       // A scheduled retry is still network work, so the query must not claim
       // it has settled while the backoff is pending.
       expect(callback.mock.calls.at(-1)?.[0].fetchStatus).toBe("fetching");
+      expect(
+        callback.mock.calls.some(
+          ([result]) =>
+            result.status === "error" && result.fetchStatus === "idle",
+        ),
+      ).toBe(false);
 
       // The retry is scheduled, not immediate, so a server outage cannot turn
       // into a hot loop.
@@ -2227,6 +2500,184 @@ describe("DocSyncClient", () => {
       await expect
         .poll(() => callback.mock.calls.at(-1)?.[0])
         .toMatchObject({ status: "success", fetchStatus: "idle" });
+    });
+
+    test("should let a scheduled retry absorb a queued sync", async () => {
+      const client = createClient();
+      const callback = createCallback();
+      const docId = ulid().toLowerCase();
+      socketMockState.deferSyncDocIds.add(docId);
+
+      client.getDoc(
+        { type: "test", id: docId, createIfMissing: true },
+        callback,
+      );
+      await expect
+        .poll(() => socketMockState.deferredSyncAcks.get(docId)?.length)
+        .toBe(1);
+      await client["_sync"](docId);
+
+      const failedAck = socketMockState.deferredSyncAcks.get(docId)?.[0];
+      if (!failedAck) throw new Error("Expected deferred sync ack");
+      failedAck({
+        error: { type: "DatabaseError", message: "database unavailable" },
+      });
+      await flushMicrotasks();
+
+      expect(socketMockState.deferredSyncAcks.get(docId)).toHaveLength(1);
+      expect(client["_syncRetryState"].get(docId)?.timeout).toBeDefined();
+      expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
+        status: "error",
+        fetchStatus: "fetching",
+        error: { type: "DatabaseError" },
+      });
+
+      setSocketState(client, { active: true, connected: false });
+      emitMockedSocketEvent(client, "disconnect", "transport close");
+    });
+
+    test("should retry a rejected sync request as a network error", async () => {
+      const client = createClient();
+      const callback = createCallback();
+      const docId = ulid().toLowerCase();
+      const networkFailure = new Error("network unavailable");
+      socketMockState.syncErrors.set(docId, networkFailure);
+
+      client.getDoc(
+        { type: "test", id: docId, createIfMissing: true },
+        callback,
+      );
+
+      await expect
+        .poll(() => callback.mock.calls.at(-1)?.[0])
+        .toMatchObject({
+          status: "error",
+          fetchStatus: "fetching",
+          data: { docId },
+          error: {
+            type: "NetworkError",
+            message: "network unavailable",
+            cause: networkFailure,
+          },
+        });
+      expect(client["_syncRetryState"].get(docId)?.attempts).toBe(1);
+
+      socketMockState.syncErrors.delete(docId);
+      await client["_sync"](docId);
+
+      expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
+        status: "success",
+        fetchStatus: "idle",
+      });
+      expect(client["_syncRetryState"].has(docId)).toBe(false);
+    });
+
+    test("should cancel a pending document retry when the transport disconnects", async () => {
+      const client = createClient();
+      const callback = createCallback();
+      const docId = ulid().toLowerCase();
+      socketMockState.syncResponses.set(docId, {
+        error: { type: "DatabaseError", message: "database unavailable" },
+      });
+
+      client.getDoc(
+        { type: "test", id: docId, createIfMissing: true },
+        callback,
+      );
+      await expect
+        .poll(() => client["_syncRetryState"].get(docId)?.attempts)
+        .toBe(1);
+      const retryTimeout = client["_syncRetryState"].get(docId)?.timeout;
+      if (!retryTimeout) throw new Error("Expected retry timer");
+
+      const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+      try {
+        setSocketState(client, { active: true, connected: false });
+        emitMockedSocketEvent(client, "disconnect", "transport close");
+
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(retryTimeout);
+        expect(client["_syncRetryState"].has(docId)).toBe(false);
+        expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
+          status: "error",
+          fetchStatus: "paused",
+          error: { type: "DatabaseError" },
+        });
+      } finally {
+        clearTimeoutSpy.mockRestore();
+      }
+    });
+
+    test("should cancel a pending retry when a manual sync starts", async () => {
+      const client = createClient();
+      const callback = createCallback();
+      const docId = ulid().toLowerCase();
+      socketMockState.syncResponses.set(docId, {
+        error: { type: "DatabaseError", message: "database unavailable" },
+      });
+
+      client.getDoc(
+        { type: "test", id: docId, createIfMissing: true },
+        callback,
+      );
+      await expect
+        .poll(() => client["_syncRetryState"].get(docId)?.attempts)
+        .toBe(1);
+      const firstTimeout = client["_syncRetryState"].get(docId)?.timeout;
+      if (!firstTimeout) throw new Error("Expected first retry timer");
+
+      const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+      try {
+        // A user edit can start a real sync before the scheduled retry fires.
+        // Starting it must cancel that old timer while preserving the backoff.
+        await client["_sync"](docId);
+
+        const retryState = client["_syncRetryState"].get(docId);
+        expect(retryState?.attempts).toBe(2);
+        expect(retryState?.timeout).not.toBe(firstTimeout);
+        expect(clearTimeoutSpy).toHaveBeenCalledWith(firstTimeout);
+
+        socketMockState.syncResponses.delete(docId);
+        await client["_sync"](docId);
+        expect(client["_syncRetryState"].has(docId)).toBe(false);
+      } finally {
+        clearTimeoutSpy.mockRestore();
+      }
+    });
+
+    test("should settle on idle after exhausting the bounded retries", async () => {
+      const client = createClient();
+      const callback = createCallback();
+      const docId = ulid().toLowerCase();
+      socketMockState.syncResponses.set(docId, {
+        error: { type: "DatabaseError", message: "database unavailable" },
+      });
+
+      client.getDoc(
+        { type: "test", id: docId, createIfMissing: true },
+        callback,
+      );
+      await expect
+        .poll(() => client["_syncRetryState"].get(docId)?.attempts)
+        .toBe(1);
+
+      for (let attempts = 2; attempts <= 8; attempts += 1) {
+        await client["_sync"](docId);
+        expect(client["_syncRetryState"].get(docId)?.attempts).toBe(attempts);
+      }
+      await client["_sync"](docId);
+
+      expect(client["_syncRetryState"].get(docId)).toStrictEqual({
+        attempts: 8,
+      });
+      expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
+        status: "error",
+        fetchStatus: "idle",
+        error: { type: "DatabaseError" },
+      });
+
+      socketMockState.syncResponses.delete(docId);
+      await client["_sync"](docId);
+      expect(client["_syncRetryState"].has(docId)).toBe(false);
     });
 
     test("should emit error status when provider throws", async () => {
@@ -2249,6 +2700,7 @@ describe("DocSyncClient", () => {
         await expect.poll(() => getErrorResult(callback)).toBeDefined();
         const errorResult = getErrorResult(callback);
         expect(errorResult?.status).toBe("error");
+        expect(errorResult?.fetchStatus).toBe("idle");
         expect(errorResult?.error?.message).toBe(errorMessage);
         expect(errorResult?.data).toBeUndefined();
       } finally {

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -2695,17 +2695,30 @@ describe("DocSyncClient", () => {
         callback,
       );
 
+      // Wait for the first request to go out and be rejected. Polling the
+      // query instead would race: it reaches `success` as soon as the document
+      // loads from local storage, before any sync has been emitted.
       await expect
-        .poll(() => callback.mock.calls.at(-1)?.[0])
-        .toMatchObject({ status: "success", data: { docId } });
-      expect(callback.mock.calls.at(-1)?.[0].error).toBeUndefined();
+        .poll(
+          () =>
+            getSocketEmitMock(client).mock.calls.filter(
+              ([event]) => event === "sync",
+            ).length,
+        )
+        .toBe(1);
+      await expect
+        .poll(() => client["_syncRetryState"].get(docId)?.attempts)
+        .toBe(1);
 
-      const syncCallsAfterFailure = getSocketEmitMock(client).mock.calls.filter(
-        ([event]) => event === "sync",
-      ).length;
-      expect(syncCallsAfterFailure).toBe(1);
-      // A scheduled retry is still network work, so the query must not claim
-      // it has settled while the backoff is pending.
+      expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
+        status: "success",
+        data: { docId },
+      });
+      expect(callback.mock.calls.at(-1)?.[0].error).toBeUndefined();
+      // This document has never completed a sync, so it still cannot serve an
+      // authoritative result and stays `fetching` across the backoff. A failed
+      // attempt must neither settle it nor surface an error while a retry can
+      // still succeed.
       expect(callback.mock.calls.at(-1)?.[0].fetchStatus).toBe("fetching");
       expect(
         callback.mock.calls.some(

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, test, expect, vi, expectTypeOf } from "vitest";
 import {
   DocSyncClient,
+  DocSyncError,
   indexedDBProvider,
   type ClientConfig,
   type ClientProvider,
@@ -45,6 +46,12 @@ const socketMockState = vi.hoisted(() => ({
   autoIdentity: true,
   identityPayload: undefined as MockIdentityPayload | undefined,
   syncResponses: new Map<string, unknown>(),
+  /**
+   * Documents whose sync ack is withheld, so a test can settle the query
+   * through a later sync and then release the superseded one.
+   */
+  deferSyncDocIds: new Set<string>(),
+  deferredSyncAcks: new Map<string, ((response: unknown) => void)[]>(),
 }));
 
 // Mock socket.io-client to avoid real connections
@@ -90,6 +97,13 @@ const ioMock = vi.hoisted(() =>
                 return;
               }
 
+              if (socketMockState.deferSyncDocIds.has(docId)) {
+                const acks = socketMockState.deferredSyncAcks.get(docId) ?? [];
+                acks.push(callback);
+                socketMockState.deferredSyncAcks.set(docId, acks);
+                return;
+              }
+
               const mockedResponse = socketMockState.syncResponses.get(docId);
               if (mockedResponse !== undefined) {
                 callback(mockedResponse);
@@ -104,6 +118,7 @@ const ioMock = vi.hoisted(() =>
             callback({ data: undefined, success: true });
           },
         ),
+        connect: vi.fn(),
         disconnect: vi.fn(),
       };
     },
@@ -122,6 +137,8 @@ describe("DocSyncClient", () => {
     socketMockState.autoIdentity = true;
     socketMockState.identityPayload = undefined;
     socketMockState.syncResponses.clear();
+    socketMockState.deferSyncDocIds.clear();
+    socketMockState.deferredSyncAcks.clear();
     clearCachedLocalIdentity();
   });
 
@@ -268,6 +285,17 @@ describe("DocSyncClient", () => {
 
     const listener = eventCall[1];
     Reflect.apply(listener, undefined, []);
+  };
+
+  /** Drives the socket flags the query state machine reads. */
+  const setSocketState = <D extends object, S extends object, O extends object>(
+    client: DocSyncClient<D, S, O>,
+    state: { active: boolean; connected: boolean },
+  ) => {
+    Object.defineProperties(client["_socket"], {
+      active: { configurable: true, value: state.active },
+      connected: { configurable: true, value: state.connected },
+    });
   };
 
   const emitMockedSocketEvent = <
@@ -1170,10 +1198,7 @@ describe("DocSyncClient", () => {
         const client = createClient();
         const callback = createCallback();
 
-        Object.defineProperties(client["_socket"], {
-          active: { configurable: true, value: true },
-          connected: { configurable: true, value: false },
-        });
+        setSocketState(client, { active: true, connected: false });
         client.getDoc({ type: "test", id: "test-id" }, callback);
 
         expect(callback).toHaveBeenCalledWith({
@@ -1195,10 +1220,7 @@ describe("DocSyncClient", () => {
           .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
           .toBe("idle");
 
-        Object.defineProperties(client["_socket"], {
-          active: { configurable: true, value: false },
-          connected: { configurable: true, value: false },
-        });
+        setSocketState(client, { active: false, connected: false });
         emitMockedSocketEvent(client, "disconnect", "io client disconnect");
 
         expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
@@ -1220,10 +1242,7 @@ describe("DocSyncClient", () => {
           .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
           .toBe("idle");
 
-        Object.defineProperties(client["_socket"], {
-          active: { configurable: true, value: true },
-          connected: { configurable: true, value: false },
-        });
+        setSocketState(client, { active: true, connected: false });
         emitMockedSocketEvent(
           client,
           "connect_error",
@@ -1242,27 +1261,26 @@ describe("DocSyncClient", () => {
         const connectionError = new Error("Authentication failed");
         const docId = ulid().toLowerCase();
 
-        Object.defineProperties(client["_socket"], {
-          active: { configurable: true, value: false },
-          connected: { configurable: true, value: false },
-        });
+        setSocketState(client, { active: false, connected: false });
         emitMockedSocketEvent(client, "connect_error", connectionError);
         client.getDoc(
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
 
-        expect(callback.mock.calls[0]?.[0]).toStrictEqual({
+        expect(callback.mock.calls[0]?.[0]).toMatchObject({
           status: "error",
           fetchStatus: "paused",
-          error: connectionError,
+          error: { type: "ConnectionError", message: "Authentication failed" },
         });
+        expect(callback.mock.calls[0]?.[0].error).toBeInstanceOf(DocSyncError);
+        expect(callback.mock.calls[0]?.[0].error?.cause).toBe(connectionError);
         await expect
           .poll(() => callback.mock.calls.at(-1)?.[0])
           .toMatchObject({
             status: "error",
             fetchStatus: "paused",
-            error: connectionError,
+            error: { type: "ConnectionError" },
             data: { docId },
           });
       });
@@ -1280,17 +1298,18 @@ describe("DocSyncClient", () => {
           .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
           .toBe("idle");
 
-        Object.defineProperties(client["_socket"], {
-          active: { configurable: true, value: false },
-          connected: { configurable: true, value: false },
-        });
+        setSocketState(client, { active: false, connected: false });
         emitMockedSocketEvent(client, "disconnect", "io server disconnect");
 
         expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
           status: "error",
           fetchStatus: "paused",
           data: { docId },
+          error: { type: "ConnectionError" },
         });
+        expect(callback.mock.calls.at(-1)?.[0].error?.message).toContain(
+          "io server disconnect",
+        );
       });
 
       test("should recover a permanent connection error after reconnecting", async () => {
@@ -1298,10 +1317,7 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const docId = ulid().toLowerCase();
 
-        Object.defineProperties(client["_socket"], {
-          active: { configurable: true, value: false, writable: true },
-          connected: { configurable: true, value: false, writable: true },
-        });
+        setSocketState(client, { active: false, connected: false });
         emitMockedSocketEvent(
           client,
           "connect_error",
@@ -1315,15 +1331,173 @@ describe("DocSyncClient", () => {
           .poll(() => callback.mock.calls.at(-1)?.[0].status)
           .toBe("error");
 
-        Object.defineProperties(client["_socket"], {
-          active: { configurable: true, value: true },
-          connected: { configurable: true, value: true },
-        });
+        setSocketState(client, { active: true, connected: true });
         emitMockedSocketEvent(client, "connect");
 
         await expect
           .poll(() => callback.mock.calls.at(-1)?.[0])
           .toMatchObject({ status: "success", fetchStatus: "idle" });
+      });
+
+      test("should report the same fetch status for every subscription during a transient failure", async () => {
+        const client = createClient();
+        const loadedCallback = createCallback();
+        const lateCallback = createCallback();
+
+        client.getDoc(
+          { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
+          loadedCallback,
+        );
+        await expect
+          .poll(() => loadedCallback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        setSocketState(client, { active: true, connected: false });
+        emitMockedSocketEvent(
+          client,
+          "connect_error",
+          new Error("transport unavailable"),
+        );
+        expect(loadedCallback.mock.calls.at(-1)?.[0].fetchStatus).toBe(
+          "paused",
+        );
+
+        client.getDoc(
+          { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
+          lateCallback,
+        );
+
+        expect(lateCallback.mock.calls[0]?.[0]).toStrictEqual({
+          status: "pending",
+          fetchStatus: "paused",
+        });
+      });
+
+      test("should pause queries when disconnecting before the connection is established", () => {
+        const client = createClient();
+        const callback = createCallback();
+
+        setSocketState(client, { active: true, connected: false });
+        client.getDoc({ type: "test", id: "test-id" }, callback);
+        expect(callback.mock.calls.at(-1)?.[0].fetchStatus).toBe("fetching");
+
+        client.disconnect();
+
+        expect(callback.mock.calls.at(-1)?.[0]).toStrictEqual({
+          status: "pending",
+          fetchStatus: "paused",
+        });
+      });
+
+      test("should not inherit a permanent connection error after reconnecting", () => {
+        const client = createClient();
+        const callback = createCallback();
+
+        setSocketState(client, { active: false, connected: false });
+        emitMockedSocketEvent(
+          client,
+          "connect_error",
+          new Error("Authentication failed"),
+        );
+
+        client.connect();
+        setSocketState(client, { active: true, connected: false });
+        client.getDoc({ type: "test", id: "test-id" }, callback);
+
+        expect(callback.mock.calls[0]?.[0]).toStrictEqual({
+          status: "pending",
+          fetchStatus: "fetching",
+        });
+      });
+
+      test("should keep the document instance when subscribing while an error is visible", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+        const loadedDoc = callback.mock.calls.at(-1)?.[0].data?.doc;
+        const promisedDoc = client["_docsCache"].get(docId)?.promisedDoc;
+
+        setSocketState(client, { active: false, connected: false });
+        emitMockedSocketEvent(client, "disconnect", "io server disconnect");
+        expect(callback.mock.calls.at(-1)?.[0].status).toBe("error");
+
+        const secondCallback = createCallback();
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          secondCallback,
+        );
+
+        expect(client["_docsCache"].get(docId)?.promisedDoc).toBe(promisedDoc);
+        expect(secondCallback.mock.calls[0]?.[0].data?.doc).toBe(loadedDoc);
+      });
+
+      test("should ignore a sync failure that arrives after the query settled", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+        socketMockState.deferSyncDocIds.add(docId);
+
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+        await expect
+          .poll(() => socketMockState.deferredSyncAcks.get(docId)?.length)
+          .toBe(1);
+        const supersededAck = socketMockState.deferredSyncAcks.get(docId)?.[0];
+
+        // Reconnecting starts a second sync, which settles the query first.
+        socketMockState.deferSyncDocIds.delete(docId);
+        emitMockedSocketEvent(client, "disconnect", "transport close");
+        emitMockedSocketEvent(client, "connect");
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+        const settledResult = callback.mock.calls.at(-1)?.[0];
+
+        const unhandledReasons: unknown[] = [];
+        const handler = (event: PromiseRejectionEvent) => {
+          unhandledReasons.push(event.reason);
+          event.preventDefault();
+        };
+        const syncEvents: unknown[] = [];
+        client.on("sync", (event) => syncEvents.push(event));
+        window.addEventListener("unhandledrejection", handler);
+        try {
+          supersededAck?.({
+            error: { type: "ValidationError", message: "too late" },
+          });
+
+          // The superseded response really is processed...
+          await expect
+            .poll(() =>
+              syncEvents.some(
+                (event) =>
+                  typeof event === "object" &&
+                  event !== null &&
+                  "error" in event,
+              ),
+            )
+            .toBe(true);
+          // ...and leaves the settled query untouched instead of resurrecting
+          // a stale error or breaking the reducer invariant.
+          expect(callback.mock.calls.at(-1)?.[0]).toBe(settledResult);
+          expect(settledResult).toMatchObject({
+            status: "success",
+            fetchStatus: "idle",
+          });
+          expect(unhandledReasons).toStrictEqual([]);
+        } finally {
+          window.removeEventListener("unhandledrejection", handler);
+        }
       });
 
       test("should return undefined when document does not exist and createIfMissing is false", async () => {
@@ -1636,14 +1810,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const customId = ulid().toLowerCase();
 
-        Object.defineProperty(client["_socket"], "connected", {
-          configurable: true,
-          value: false,
-        });
-        Object.defineProperty(client["_socket"], "active", {
-          configurable: true,
-          value: false,
-        });
+        setSocketState(client, { active: true, connected: false });
+        emitMockedSocketEvent(client, "connect_error", new Error("offline"));
         client.getDoc(
           { type: "test", id: customId, createIfMissing: true },
           callback,
@@ -1939,6 +2107,84 @@ describe("DocSyncClient", () => {
         ([event]) => event === "sync",
       );
       expect(syncCalls).toHaveLength(1);
+    });
+
+    test("should not stop other documents from syncing after a rejection", async () => {
+      const client = createClient();
+      const rejectedCallback = createCallback();
+      const healthyCallback = createCallback();
+      const rejectedDocId = ulid().toLowerCase();
+      const healthyDocId = ulid().toLowerCase();
+      socketMockState.syncResponses.set(rejectedDocId, {
+        error: { type: "AuthorizationError", message: "Access denied" },
+      });
+
+      client.getDoc(
+        { type: "test", id: rejectedDocId, createIfMissing: true },
+        rejectedCallback,
+      );
+      await expect
+        .poll(() => rejectedCallback.mock.calls.at(-1)?.[0].status)
+        .toBe("error");
+
+      client.getDoc(
+        { type: "test", id: healthyDocId, createIfMissing: true },
+        healthyCallback,
+      );
+
+      await expect
+        .poll(() => healthyCallback.mock.calls.at(-1)?.[0])
+        .toMatchObject({ status: "success", fetchStatus: "idle" });
+      // The rejected document keeps its own error without leaking into the
+      // other document's query.
+      expect(rejectedCallback.mock.calls.at(-1)?.[0]).toMatchObject({
+        status: "error",
+        error: { type: "AuthorizationError" },
+      });
+    });
+
+    test("should retry a database error with backoff until it succeeds", async () => {
+      const client = createClient();
+      const callback = createCallback();
+      const docId = ulid().toLowerCase();
+      socketMockState.syncResponses.set(docId, {
+        error: { type: "DatabaseError", message: "database unavailable" },
+      });
+
+      client.getDoc(
+        { type: "test", id: docId, createIfMissing: true },
+        callback,
+      );
+
+      await expect
+        .poll(() => callback.mock.calls.at(-1)?.[0])
+        .toMatchObject({
+          status: "error",
+          data: { docId },
+          error: { type: "DatabaseError", message: "database unavailable" },
+        });
+
+      const syncCallsAfterFailure = getSocketEmitMock(client).mock.calls.filter(
+        ([event]) => event === "sync",
+      ).length;
+      expect(syncCallsAfterFailure).toBe(1);
+
+      // The retry is scheduled, not immediate, so a server outage cannot turn
+      // into a hot loop.
+      await expect
+        .poll(
+          () =>
+            getSocketEmitMock(client).mock.calls.filter(
+              ([event]) => event === "sync",
+            ).length,
+        )
+        .toBeGreaterThan(1);
+
+      socketMockState.syncResponses.delete(docId);
+
+      await expect
+        .poll(() => callback.mock.calls.at(-1)?.[0])
+        .toMatchObject({ status: "success", fetchStatus: "idle" });
     });
 
     test("should emit error status when provider throws", async () => {

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -2756,7 +2756,9 @@ describe("DocSyncClient", () => {
       await flushMicrotasks();
 
       expect(socketMockState.deferredSyncAcks.get(docId)).toHaveLength(1);
-      expect(client["_syncRetryState"].get(docId)?.timeout).toBeDefined();
+      await expect
+        .poll(() => client["_syncRetryState"].get(docId)?.timeout)
+        .toBeDefined();
       expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
         status: "success",
         fetchStatus: "fetching",
@@ -2780,15 +2782,19 @@ describe("DocSyncClient", () => {
         callback,
       );
 
+      // Wait on the retry, not on the query. The query reaches
+      // `success` / `fetching` as soon as the document loads from local
+      // storage, which is a different async path from the sync request that
+      // fails — polling the first and then asserting the second races them.
       await expect
-        .poll(() => callback.mock.calls.at(-1)?.[0])
-        .toMatchObject({
-          status: "success",
-          fetchStatus: "fetching",
-          data: { docId },
-        });
+        .poll(() => client["_syncRetryState"].get(docId)?.attempts)
+        .toBe(1);
+      expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
+        status: "success",
+        fetchStatus: "fetching",
+        data: { docId },
+      });
       expect(callback.mock.calls.at(-1)?.[0].error).toBeUndefined();
-      expect(client["_syncRetryState"].get(docId)?.attempts).toBe(1);
 
       socketMockState.syncErrors.delete(docId);
       await client["_sync"](docId);

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -59,6 +59,7 @@ const ioMock = vi.hoisted(() =>
     ) => {
       return {
         connected: true,
+        active: true,
         on: vi.fn((event: string, listener: (payload?: unknown) => void) => {
           if (event === "identity" && socketMockState.autoIdentity) {
             queueMicrotask(() =>
@@ -267,6 +268,27 @@ describe("DocSyncClient", () => {
 
     const listener = eventCall[1];
     Reflect.apply(listener, undefined, []);
+  };
+
+  const emitMockedSocketEvent = <
+    D extends object,
+    S extends object,
+    O extends object,
+  >(
+    client: DocSyncClient<D, S, O>,
+    event: "connect" | "connect_error" | "disconnect",
+    payload?: unknown,
+  ) => {
+    const onMock = getSocketOnMock(client);
+    const eventCall = onMock.mock.calls.find(
+      ([registeredEvent]) => registeredEvent === event,
+    );
+    if (!eventCall) {
+      throw new Error(`Expected socket listener for ${event}`);
+    }
+
+    const listener = eventCall[1];
+    Reflect.apply(listener, undefined, payload === undefined ? [] : [payload]);
   };
 
   const emitMockedCollaboration = (
@@ -1144,6 +1166,166 @@ describe("DocSyncClient", () => {
         });
       });
 
+      test("should remain fetching while the initial connection is active", () => {
+        const client = createClient();
+        const callback = createCallback();
+
+        Object.defineProperties(client["_socket"], {
+          active: { configurable: true, value: true },
+          connected: { configurable: true, value: false },
+        });
+        client.getDoc({ type: "test", id: "test-id" }, callback);
+
+        expect(callback).toHaveBeenCalledWith({
+          status: "pending",
+          fetchStatus: "fetching",
+        });
+      });
+
+      test("should pause an idle query after a manual disconnect", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        Object.defineProperties(client["_socket"], {
+          active: { configurable: true, value: false },
+          connected: { configurable: true, value: false },
+        });
+        emitMockedSocketEvent(client, "disconnect", "io client disconnect");
+
+        expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
+          status: "success",
+          fetchStatus: "paused",
+        });
+      });
+
+      test("should pause a transient connection failure without reporting an error", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        Object.defineProperties(client["_socket"], {
+          active: { configurable: true, value: true },
+          connected: { configurable: true, value: false },
+        });
+        emitMockedSocketEvent(
+          client,
+          "connect_error",
+          new Error("transport unavailable"),
+        );
+
+        expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
+          status: "success",
+          fetchStatus: "paused",
+        });
+      });
+
+      test("should preserve local data with a permanent connection error", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const connectionError = new Error("Authentication failed");
+        const docId = ulid().toLowerCase();
+
+        Object.defineProperties(client["_socket"], {
+          active: { configurable: true, value: false },
+          connected: { configurable: true, value: false },
+        });
+        emitMockedSocketEvent(client, "connect_error", connectionError);
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+
+        expect(callback.mock.calls[0]?.[0]).toStrictEqual({
+          status: "error",
+          fetchStatus: "paused",
+          error: connectionError,
+        });
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0])
+          .toMatchObject({
+            status: "error",
+            fetchStatus: "paused",
+            error: connectionError,
+            data: { docId },
+          });
+      });
+
+      test("should report a server-initiated disconnect as an error", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+
+        Object.defineProperties(client["_socket"], {
+          active: { configurable: true, value: false },
+          connected: { configurable: true, value: false },
+        });
+        emitMockedSocketEvent(client, "disconnect", "io server disconnect");
+
+        expect(callback.mock.calls.at(-1)?.[0]).toMatchObject({
+          status: "error",
+          fetchStatus: "paused",
+          data: { docId },
+        });
+      });
+
+      test("should recover a permanent connection error after reconnecting", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+
+        Object.defineProperties(client["_socket"], {
+          active: { configurable: true, value: false, writable: true },
+          connected: { configurable: true, value: false, writable: true },
+        });
+        emitMockedSocketEvent(
+          client,
+          "connect_error",
+          new Error("Authentication failed"),
+        );
+        client.getDoc(
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].status)
+          .toBe("error");
+
+        Object.defineProperties(client["_socket"], {
+          active: { configurable: true, value: true },
+          connected: { configurable: true, value: true },
+        });
+        emitMockedSocketEvent(client, "connect");
+
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0])
+          .toMatchObject({ status: "success", fetchStatus: "idle" });
+      });
+
       test("should return undefined when document does not exist and createIfMissing is false", async () => {
         const client = createClient();
         const callback = createCallback();
@@ -1458,6 +1640,10 @@ describe("DocSyncClient", () => {
           configurable: true,
           value: false,
         });
+        Object.defineProperty(client["_socket"], "active", {
+          configurable: true,
+          value: false,
+        });
         client.getDoc(
           { type: "test", id: customId, createIfMissing: true },
           callback,
@@ -1727,6 +1913,33 @@ describe("DocSyncClient", () => {
       if (reason instanceof Error) return reason.message.includes(substring);
       return false;
     };
+
+    test("should expose a permanent sync rejection without retrying", async () => {
+      const client = createClient();
+      const callback = createCallback();
+      const docId = ulid().toLowerCase();
+      socketMockState.syncResponses.set(docId, {
+        error: { type: "AuthorizationError", message: "Access denied" },
+      });
+
+      client.getDoc(
+        { type: "test", id: docId, createIfMissing: true },
+        callback,
+      );
+
+      await expect
+        .poll(() => callback.mock.calls.at(-1)?.[0])
+        .toMatchObject({
+          status: "error",
+          fetchStatus: "idle",
+          data: { docId },
+          error: { name: "AuthorizationError", message: "Access denied" },
+        });
+      const syncCalls = getSocketEmitMock(client).mock.calls.filter(
+        ([event]) => event === "sync",
+      );
+      expect(syncCalls).toHaveLength(1);
+    });
 
     test("should emit error status when provider throws", async () => {
       const errorMessage = "IndexedDB connection failed";

--- a/tests/docsync/unit/client/index.browser.test.ts
+++ b/tests/docsync/unit/client/index.browser.test.ts
@@ -31,6 +31,7 @@ import {
   cacheLocalIdentity,
   clearCachedLocalIdentity,
   LOCAL_IDENTITY_KEY,
+  subscribeToDoc,
 } from "./utils.js";
 
 type SocketAuthPayload = {
@@ -281,6 +282,18 @@ describe("DocSyncClient", () => {
     return emitMock;
   };
 
+  const getSocketConnectMock = <
+    D extends object,
+    S extends object,
+    O extends object,
+  >(
+    client: DocSyncClient<D, S, O>,
+  ) => {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- socket is a Vitest mock in this test file.
+    const connectMock = vi.mocked(client["_socket"].connect);
+    return connectMock;
+  };
+
   const emitMockedConnect = (client: DebounceTestClient) => {
     const onMock = getSocketOnMock(client);
     const eventCall = onMock.mock.calls.find(([event]) => event === "connect");
@@ -415,7 +428,8 @@ describe("DocSyncClient", () => {
         });
         setSocketState(client, { active: true, connected: false });
         const callback = createCallback();
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
           callback,
         );
@@ -463,7 +477,8 @@ describe("DocSyncClient", () => {
       });
       setSocketState(client, { active: true, connected: false });
       const callback = createCallback();
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
         callback,
       );
@@ -527,7 +542,8 @@ describe("DocSyncClient", () => {
       client["_socket"].connected = false;
 
       const callback = createCallback();
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
         callback,
       );
@@ -623,7 +639,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
 
         // Trigger _localPromise resolution by calling getDoc
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
           callback,
         );
@@ -664,7 +681,8 @@ describe("DocSyncClient", () => {
         const client = createClient();
         const callback = createCallback();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
           callback,
         );
@@ -888,7 +906,8 @@ describe("DocSyncClient", () => {
 
       const docId = ulid().toLowerCase();
       let latestResult: QueryResult<DocData<FakeDoc>> | undefined;
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: docId, createIfMissing: true },
         (result) => {
           latestResult = result;
@@ -1189,7 +1208,7 @@ describe("DocSyncClient", () => {
   // Type tests
   // ──────────────────────────────────────────────────────────────────────────
 
-  describe("getDoc types", () => {
+  describe("getDocObserver types", () => {
     type DocResult = QueryResult<DocData<Doc>>;
     type MaybeDocResult = QueryResult<DocData<Doc> | undefined>;
 
@@ -1199,41 +1218,47 @@ describe("DocSyncClient", () => {
       const id = ulid().toLowerCase();
 
       // with id, without createIfMissing → MaybeDocResult
-      client.getDoc({ type: "test", id }, (result) => {
+      subscribeToDoc(client, { type: "test", id }, (result) => {
         expectTypeOf(result).toEqualTypeOf<MaybeDocResult>();
       });
 
       // with id, createIfMissing: true → DocResult
-      client.getDoc({ type: "test", id, createIfMissing: true }, (result) => {
-        expectTypeOf(result).toEqualTypeOf<DocResult>();
-      });
+      subscribeToDoc(
+        client,
+        { type: "test", id, createIfMissing: true },
+        (result) => {
+          expectTypeOf(result).toEqualTypeOf<DocResult>();
+        },
+      );
 
       // with id, createIfMissing: false → MaybeDocResult
-      client.getDoc({ type: "test", id, createIfMissing: false }, (result) => {
-        expectTypeOf(result).toEqualTypeOf<MaybeDocResult>();
-      });
+      subscribeToDoc(
+        client,
+        { type: "test", id, createIfMissing: false },
+        (result) => {
+          expectTypeOf(result).toEqualTypeOf<MaybeDocResult>();
+        },
+      );
     });
 
     test("type errors for invalid arguments", () => {
       // These are compile-time checks only - we use a function that's never called
       // to avoid runtime execution while still getting TypeScript to check the types
       const typeCheck = (client: ReturnType<typeof createClient>) => {
-        const callback = createCallback();
-
         // @ts-expect-error - type is required (even with id)
-        client.getDoc({ id: "123" }, callback);
+        client.getDocObserver({ id: "123" });
 
         // @ts-expect-error - type is required (even with createIfMissing and id)
-        client.getDoc({ createIfMissing: true, id: "123" }, callback);
+        client.getDocObserver({ createIfMissing: true, id: "123" });
 
         // @ts-expect-error - id is required
-        client.getDoc({ type: "test" }, callback);
+        client.getDocObserver({ type: "test" });
 
         // @ts-expect-error - id is required
-        client.getDoc({ type: "test", createIfMissing: false }, callback);
+        client.getDocObserver({ type: "test", createIfMissing: false });
 
         // @ts-expect-error - id is required
-        client.getDoc({ type: "test", createIfMissing: true }, callback);
+        client.getDocObserver({ type: "test", createIfMissing: true });
       };
 
       // Verify the function exists (never called, just for type checking)
@@ -1265,10 +1290,10 @@ describe("DocSyncClient", () => {
   });
 
   // ──────────────────────────────────────────────────────────────────────────
-  // getDoc tests
+  // getDocObserver tests
   // ──────────────────────────────────────────────────────────────────────────
 
-  describe("getDoc", () => {
+  describe("getDocObserver", () => {
     const createDocWithChild = (client: ReturnType<typeof createClient>) => {
       const docId = ulid().toLowerCase();
       const { doc } = client["_docBinding"].create("test", docId);
@@ -1282,11 +1307,32 @@ describe("DocSyncClient", () => {
     };
 
     describe("Get existing document", () => {
+      test("should stay lazy until its first subscriber and share one document subscription", async () => {
+        const client = createClient();
+        const docId = ulid().toLowerCase();
+        const observer = client.getDocObserver({ type: "test", id: docId });
+
+        expect(observer.getSnapshot()).toStrictEqual({
+          status: "pending",
+          fetchStatus: "fetching",
+        });
+        expect(client["_docsCache"].has(docId)).toBe(false);
+
+        const unsubscribeFirst = observer.subscribe(() => undefined);
+        const unsubscribeSecond = observer.subscribe(() => undefined);
+        expect(client["_docsCache"].get(docId)?.refCount).toBe(1);
+
+        unsubscribeFirst();
+        expect(client["_docsCache"].get(docId)?.refCount).toBe(1);
+        unsubscribeSecond();
+        await expect.poll(() => client["_docsCache"].has(docId)).toBe(false);
+      });
+
       test("should emit pending status initially", () => {
         const client = createClient();
         const callback = createCallback();
 
-        client.getDoc({ type: "test", id: "test-id" }, callback);
+        subscribeToDoc(client, { type: "test", id: "test-id" }, callback);
 
         expect(callback).toHaveBeenCalledWith({
           status: "pending",
@@ -1299,7 +1345,7 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
 
         setSocketState(client, { active: true, connected: false });
-        client.getDoc({ type: "test", id: "test-id" }, callback);
+        subscribeToDoc(client, { type: "test", id: "test-id" }, callback);
 
         expect(callback).toHaveBeenCalledWith({
           status: "pending",
@@ -1312,7 +1358,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const docId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
@@ -1334,7 +1381,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const docId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
@@ -1363,7 +1411,8 @@ describe("DocSyncClient", () => {
 
         setSocketState(client, { active: false, connected: false });
         emitMockedSocketEvent(client, "connect_error", connectionError);
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
@@ -1390,7 +1439,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const docId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
@@ -1423,7 +1473,8 @@ describe("DocSyncClient", () => {
           "connect_error",
           new Error("Authentication failed"),
         );
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
@@ -1439,13 +1490,12 @@ describe("DocSyncClient", () => {
           .toMatchObject({ status: "success", fetchStatus: "idle" });
       });
 
-      test("getDocResult should report the state a new subscription would start from", () => {
+      test("observer should report the state a new subscription starts from", () => {
         const client = createClient();
 
-        expect(client.getDocResult({ id: "unknown" })).toStrictEqual({
-          status: "pending",
-          fetchStatus: "fetching",
-        });
+        expect(
+          client.getDocObserver({ type: "test", id: "unknown" }).getSnapshot(),
+        ).toStrictEqual({ status: "pending", fetchStatus: "fetching" });
 
         setSocketState(client, { active: false, connected: false });
         emitMockedSocketEvent(
@@ -1454,19 +1504,22 @@ describe("DocSyncClient", () => {
           new Error("Authentication failed"),
         );
 
-        expect(client.getDocResult({ id: "unknown" })).toMatchObject({
+        expect(
+          client.getDocObserver({ type: "test", id: "unknown" }).getSnapshot(),
+        ).toMatchObject({
           status: "error",
           fetchStatus: "paused",
           error: { type: "ConnectionError" },
         });
       });
 
-      test("getDocResult should return the cached result of a loaded document", async () => {
+      test("observer should return the cached result of a loaded document", async () => {
         const client = createClient();
         const callback = createCallback();
         const docId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
@@ -1475,9 +1528,9 @@ describe("DocSyncClient", () => {
           .toBe("idle");
 
         // Same object the subscription holds — a read, not a new query.
-        expect(client.getDocResult({ id: docId })).toBe(
-          callback.mock.calls.at(-1)?.[0],
-        );
+        expect(
+          client.getDocObserver({ type: "test", id: docId }).getSnapshot(),
+        ).toBe(callback.mock.calls.at(-1)?.[0]);
         expect(client["_docsCache"].get(docId)?.refCount).toBe(1);
       });
 
@@ -1486,7 +1539,8 @@ describe("DocSyncClient", () => {
         const loadedCallback = createCallback();
         const lateCallback = createCallback();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
           loadedCallback,
         );
@@ -1504,7 +1558,8 @@ describe("DocSyncClient", () => {
           "paused",
         );
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
           lateCallback,
         );
@@ -1520,7 +1575,7 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
 
         setSocketState(client, { active: true, connected: false });
-        client.getDoc({ type: "test", id: "test-id" }, callback);
+        subscribeToDoc(client, { type: "test", id: "test-id" }, callback);
         expect(callback.mock.calls.at(-1)?.[0].fetchStatus).toBe("fetching");
 
         client.disconnect();
@@ -1541,7 +1596,7 @@ describe("DocSyncClient", () => {
 
         client.connect();
         setSocketState(client, { active: true, connected: false });
-        client.getDoc({ type: "test", id: "test-id" }, callback);
+        subscribeToDoc(client, { type: "test", id: "test-id" }, callback);
 
         expect(callback.mock.calls[0]?.[0]).toMatchObject({
           status: "error",
@@ -1550,13 +1605,101 @@ describe("DocSyncClient", () => {
         });
       });
 
+      test("should leave an already connected client and its queries unchanged", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+
+        subscribeToDoc(
+          client,
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+        const settledResult = callback.mock.calls.at(-1)?.[0];
+        const connect = getSocketConnectMock(client);
+
+        client.connect();
+
+        expect(connect).not.toHaveBeenCalled();
+        expect(callback.mock.calls.at(-1)?.[0]).toBe(settledResult);
+      });
+
+      test("should preserve paused state when starting the socket throws", async () => {
+        const client = createClient();
+        const callback = createCallback();
+        const docId = ulid().toLowerCase();
+
+        subscribeToDoc(
+          client,
+          { type: "test", id: docId, createIfMissing: true },
+          callback,
+        );
+        await expect
+          .poll(() => callback.mock.calls.at(-1)?.[0].fetchStatus)
+          .toBe("idle");
+        setSocketState(client, { active: false, connected: false });
+        emitMockedSocketEvent(client, "disconnect", "io client disconnect");
+        getSocketConnectMock(client).mockImplementationOnce(() => {
+          throw new Error("socket start failed");
+        });
+
+        expect(() => client.connect()).toThrow("socket start failed");
+        expect(client["_connectionFetchStatus"]).toBe("paused");
+        expect(callback.mock.calls.at(-1)?.[0].fetchStatus).toBe("paused");
+      });
+
+      test("should update every query before notifying reconnect listeners", async () => {
+        const client = createClient();
+        const firstId = ulid().toLowerCase();
+        const secondId = ulid().toLowerCase();
+        const firstObserver = client.getDocObserver({
+          type: "test",
+          id: firstId,
+          createIfMissing: true,
+        });
+        const secondObserver = client.getDocObserver({
+          type: "test",
+          id: secondId,
+          createIfMissing: true,
+        });
+        firstObserver.subscribe(() => undefined);
+        secondObserver.subscribe(() => undefined);
+        await expect
+          .poll(() => secondObserver.getSnapshot().fetchStatus)
+          .toBe("idle");
+
+        setSocketState(client, { active: false, connected: false });
+        emitMockedSocketEvent(client, "disconnect", "io client disconnect");
+        firstObserver.subscribe(() => {
+          if (firstObserver.getSnapshot().fetchStatus === "fetching") {
+            expect(secondObserver.getSnapshot().fetchStatus).toBe("fetching");
+            throw new Error("listener failed");
+          }
+        });
+        let secondListenerSawFirstStatus: string | undefined;
+        secondObserver.subscribe(() => {
+          secondListenerSawFirstStatus =
+            firstObserver.getSnapshot().fetchStatus;
+        });
+
+        expect(() => client.connect()).toThrow("listener failed");
+        expect(getSocketConnectMock(client)).toHaveBeenCalledOnce();
+        expect(firstObserver.getSnapshot().fetchStatus).toBe("fetching");
+        expect(secondObserver.getSnapshot().fetchStatus).toBe("fetching");
+        expect(secondListenerSawFirstStatus).toBe("fetching");
+      });
+
       test("should resume loaded queries when reconnecting, not just new ones", async () => {
         const client = createClient();
         const loadedCallback = createCallback();
         const lateCallback = createCallback();
         const docId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           loadedCallback,
         );
@@ -1578,7 +1721,8 @@ describe("DocSyncClient", () => {
 
         client.connect();
         setSocketState(client, { active: true, connected: false });
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
           lateCallback,
         );
@@ -1601,7 +1745,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const docId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
@@ -1626,7 +1771,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const docId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
@@ -1641,7 +1787,8 @@ describe("DocSyncClient", () => {
         expect(callback.mock.calls.at(-1)?.[0].status).toBe("error");
 
         const secondCallback = createCallback();
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           secondCallback,
         );
@@ -1656,7 +1803,8 @@ describe("DocSyncClient", () => {
         const docId = ulid().toLowerCase();
         socketMockState.deferSyncDocIds.add(docId);
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
@@ -1701,7 +1849,8 @@ describe("DocSyncClient", () => {
         client.on("sync", (event) => syncEvents.push(event));
         socketMockState.deferSyncDocIds.add(docId);
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
@@ -1750,7 +1899,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const docId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
@@ -1807,7 +1957,11 @@ describe("DocSyncClient", () => {
         const client = createClient();
         const callback = createCallback();
 
-        client.getDoc({ type: "test", id: "non-existent-id" }, callback);
+        subscribeToDoc(
+          client,
+          { type: "test", id: "non-existent-id" },
+          callback,
+        );
         await expect
           .poll(() => callback.mock.calls.at(-1)?.[0])
           .toEqual({ status: "success", fetchStatus: "idle", data: undefined });
@@ -1827,7 +1981,8 @@ describe("DocSyncClient", () => {
           },
         });
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: serverDoc.docId, createIfMissing: false },
           callback,
         );
@@ -1858,7 +2013,8 @@ describe("DocSyncClient", () => {
         const docId = ulid().toLowerCase();
 
         // Create a doc first
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback1,
         );
@@ -1866,7 +2022,11 @@ describe("DocSyncClient", () => {
         const createdDoc = getSuccessData(callback1);
 
         // Request the same doc again
-        client.getDoc({ type: "test", id: createdDoc!.docId }, callback2);
+        subscribeToDoc(
+          client,
+          { type: "test", id: createdDoc!.docId },
+          callback2,
+        );
         await expect.poll(() => getSuccessData(callback2)).toBeDefined();
         const cachedDoc = getSuccessData(callback2);
         expect(cachedDoc?.doc).toBe(createdDoc!.doc);
@@ -1879,7 +2039,8 @@ describe("DocSyncClient", () => {
         const docId = ulid().toLowerCase();
 
         // Create a doc first
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback1,
         );
@@ -1887,7 +2048,11 @@ describe("DocSyncClient", () => {
         const createdDoc = getSuccessData(callback1);
 
         // Request the same doc - cache hit
-        client.getDoc({ type: "test", id: createdDoc!.docId }, callback2);
+        subscribeToDoc(
+          client,
+          { type: "test", id: createdDoc!.docId },
+          callback2,
+        );
 
         expect(callback2.mock.calls.length).toBe(1);
         expect(callback2.mock.calls[0]?.[0]?.status).toBe("success");
@@ -1901,7 +2066,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const docId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: docId, createIfMissing: true },
           callback,
         );
@@ -1913,7 +2079,8 @@ describe("DocSyncClient", () => {
         const client = createClient();
         const callback = createCallback();
 
-        const unsubscribe = client.getDoc(
+        const unsubscribe = subscribeToDoc(
+          client,
           { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
           callback,
         );
@@ -1928,7 +2095,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const customId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: customId, createIfMissing: true },
           callback,
         );
@@ -1941,8 +2109,9 @@ describe("DocSyncClient", () => {
         const callback2 = createCallback();
         const customId = ulid().toLowerCase();
 
-        client.getDoc({ type: "test", id: customId }, callback1);
-        client.getDoc(
+        subscribeToDoc(client, { type: "test", id: customId }, callback1);
+        subscribeToDoc(
+          client,
           { type: "test", id: customId, createIfMissing: true },
           callback2,
         );
@@ -1967,7 +2136,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const customId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: customId, createIfMissing: true },
           callback,
         );
@@ -2001,7 +2171,8 @@ describe("DocSyncClient", () => {
           },
         });
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: serverDoc.docId, createIfMissing: true },
           callback,
         );
@@ -2048,7 +2219,8 @@ describe("DocSyncClient", () => {
           },
         });
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: serverDoc.docId, createIfMissing: true },
           callback,
         );
@@ -2092,7 +2264,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const customId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: customId, createIfMissing: true },
           callback,
         );
@@ -2115,7 +2288,8 @@ describe("DocSyncClient", () => {
 
         setSocketState(client, { active: true, connected: false });
         emitMockedSocketEvent(client, "connect_error", new Error("offline"));
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: customId, createIfMissing: true },
           callback,
         );
@@ -2135,7 +2309,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const customId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: customId, createIfMissing: true },
           callback,
         );
@@ -2169,7 +2344,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const customId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: customId, createIfMissing: true },
           callback,
         );
@@ -2183,7 +2359,7 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const customId = ulid().toLowerCase();
 
-        client.getDoc({ type: "test", id: customId }, callback);
+        subscribeToDoc(client, { type: "test", id: customId }, callback);
 
         // First call should be pending
         expect(callback.mock.calls[0]?.[0]?.status).toBe("pending");
@@ -2200,7 +2376,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const createdId = ulid().toLowerCase();
 
-        const unsubscribe = client.getDoc(
+        const unsubscribe = subscribeToDoc(
+          client,
           { type: "test", id: createdId, createIfMissing: true },
           callback,
         );
@@ -2226,7 +2403,8 @@ describe("DocSyncClient", () => {
         const createdId = ulid().toLowerCase();
 
         // First subscription creates the doc
-        const unsubscribe1 = client.getDoc(
+        const unsubscribe1 = subscribeToDoc(
+          client,
           { type: "test", id: createdId, createIfMissing: true },
           callback1,
         );
@@ -2235,7 +2413,8 @@ describe("DocSyncClient", () => {
         const docId = getSuccessData(callback1)!.docId;
 
         // Second subscription to same doc
-        const unsubscribe2 = client.getDoc(
+        const unsubscribe2 = subscribeToDoc(
+          client,
           { type: "test", id: docId },
           callback2,
         );
@@ -2265,7 +2444,8 @@ describe("DocSyncClient", () => {
         const createdId = ulid().toLowerCase();
 
         // Create doc
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: createdId, createIfMissing: true },
           callback1,
         );
@@ -2276,11 +2456,11 @@ describe("DocSyncClient", () => {
         expect(cache.get(docId)?.refCount).toBe(1);
 
         // Second subscription
-        client.getDoc({ type: "test", id: docId }, callback2);
+        subscribeToDoc(client, { type: "test", id: docId }, callback2);
         await expect.poll(() => cache.get(docId)?.refCount).toBe(2);
 
         // Third subscription
-        client.getDoc({ type: "test", id: docId }, callback3);
+        subscribeToDoc(client, { type: "test", id: docId }, callback3);
         await expect.poll(() => cache.get(docId)?.refCount).toBe(3);
       });
 
@@ -2291,7 +2471,8 @@ describe("DocSyncClient", () => {
         const createdId = ulid().toLowerCase();
 
         // Create doc
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: createdId, createIfMissing: true },
           callback1,
         );
@@ -2299,7 +2480,8 @@ describe("DocSyncClient", () => {
         const doc1 = getSuccessData(callback1)!.doc;
 
         // Second subscription
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: getSuccessData(callback1)!.docId },
           callback2,
         );
@@ -2316,7 +2498,8 @@ describe("DocSyncClient", () => {
         const createdId = ulid().toLowerCase();
 
         // Create doc
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: createdId, createIfMissing: true },
           callback,
         );
@@ -2342,11 +2525,13 @@ describe("DocSyncClient", () => {
         const customId = ulid().toLowerCase();
 
         // Two simultaneous requests for the same non-existent doc
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: customId, createIfMissing: true },
           callback1,
         );
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: customId, createIfMissing: true },
           callback2,
         );
@@ -2393,7 +2578,8 @@ describe("DocSyncClient", () => {
         error: { type: "AuthorizationError", message: "Access denied" },
       });
 
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: docId, createIfMissing: true },
         callback,
       );
@@ -2418,7 +2604,8 @@ describe("DocSyncClient", () => {
       const docId = ulid().toLowerCase();
       socketMockState.deferSyncDocIds.add(docId);
 
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: docId, createIfMissing: true },
         callback,
       );
@@ -2468,7 +2655,8 @@ describe("DocSyncClient", () => {
         error: { type: "AuthorizationError", message: "Access denied" },
       });
 
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: rejectedDocId, createIfMissing: true },
         rejectedCallback,
       );
@@ -2476,7 +2664,8 @@ describe("DocSyncClient", () => {
         .poll(() => rejectedCallback.mock.calls.at(-1)?.[0].status)
         .toBe("error");
 
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: healthyDocId, createIfMissing: true },
         healthyCallback,
       );
@@ -2500,7 +2689,8 @@ describe("DocSyncClient", () => {
         error: { type: "DatabaseError", message: "database unavailable" },
       });
 
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: docId, createIfMissing: true },
         callback,
       );
@@ -2551,7 +2741,8 @@ describe("DocSyncClient", () => {
       const docId = ulid().toLowerCase();
       socketMockState.deferSyncDocIds.add(docId);
 
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: docId, createIfMissing: true },
         callback,
       );
@@ -2586,7 +2777,8 @@ describe("DocSyncClient", () => {
       const networkFailure = new Error("network unavailable");
       socketMockState.syncErrors.set(docId, networkFailure);
 
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: docId, createIfMissing: true },
         callback,
       );
@@ -2623,7 +2815,8 @@ describe("DocSyncClient", () => {
         error: { type: "DatabaseError", message: "database unavailable" },
       });
 
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: docId, createIfMissing: true },
         callback,
       );
@@ -2658,7 +2851,8 @@ describe("DocSyncClient", () => {
         error: { type: "DatabaseError", message: "database unavailable" },
       });
 
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: docId, createIfMissing: true },
         callback,
       );
@@ -2695,7 +2889,8 @@ describe("DocSyncClient", () => {
         error: { type: "DatabaseError", message: "database unavailable" },
       });
 
-      client.getDoc(
+      subscribeToDoc(
+        client,
         { type: "test", id: docId, createIfMissing: true },
         callback,
       );
@@ -2736,7 +2931,8 @@ describe("DocSyncClient", () => {
       window.addEventListener("unhandledrejection", handler);
 
       try {
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: "test-id", createIfMissing: true },
           callback,
         );
@@ -2763,7 +2959,8 @@ describe("DocSyncClient", () => {
 
       try {
         // "unknown-type" is not registered in the docBinding
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "unknown-type", id: "test-id", createIfMissing: true },
           callback,
         );
@@ -2789,7 +2986,8 @@ describe("DocSyncClient", () => {
       window.addEventListener("unhandledrejection", handler);
 
       try {
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: "test-id", createIfMissing: true },
           callback,
         );
@@ -2824,7 +3022,8 @@ describe("DocSyncClient", () => {
       window.addEventListener("unhandledrejection", handler);
 
       try {
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: "test-id", createIfMissing: true },
           callback,
         );
@@ -2863,7 +3062,8 @@ describe("DocSyncClient", () => {
         const callback = createCallback();
         const createdId = ulid().toLowerCase();
 
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: createdId, createIfMissing: true },
           callback,
         );
@@ -2918,7 +3118,8 @@ describe("DocSyncClient", () => {
         const createdId = ulid().toLowerCase();
 
         // Create a doc
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: createdId, createIfMissing: true },
           callback,
         );
@@ -2932,7 +3133,8 @@ describe("DocSyncClient", () => {
         // Simulate receiving operations from another tab
         // We need to create valid operations, so we'll create them from another doc
         const tempCallback = createCallback();
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: ulid().toLowerCase(), createIfMissing: true },
           tempCallback,
         );
@@ -2987,7 +3189,8 @@ describe("DocSyncClient", () => {
         const createdId = ulid().toLowerCase();
 
         // Create a doc - this will resolve _localPromise and initialize BroadcastChannel
-        client.getDoc(
+        subscribeToDoc(
+          client,
           { type: "test", id: createdId, createIfMissing: true },
           callback,
         );

--- a/tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts
+++ b/tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts
@@ -13,6 +13,16 @@ describe("createQueryResultReducer", () => {
   test.each(combinations)(
     "$stateCase.name + $actionCase.name",
     ({ stateCase, actionCase }) => {
+      // A settled query already holds the newest attempt's result, so a
+      // terminal network action from a superseded attempt leaves it untouched.
+      if (
+        actionCase.ignoredWhenSettled &&
+        stateCase.state.fetchStatus === "idle"
+      ) {
+        expect(actionCase.run(stateCase.state)).toBe(stateCase.state);
+        return;
+      }
+
       expect(actionCase.run(stateCase.state)).toStrictEqual(
         actionCase.expected(stateCase.state),
       );

--- a/tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts
+++ b/tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts
@@ -6,10 +6,6 @@ const combinations = stateCases.flatMap((stateCase) =>
 );
 
 describe("createQueryResultReducer", () => {
-  test("declares every state and action combination", () => {
-    expect(combinations).toHaveLength(stateCases.length * actionCases.length);
-  });
-
   test.each(combinations)(
     "$stateCase.name + $actionCase.name",
     ({ stateCase, actionCase }) => {

--- a/tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts
+++ b/tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts
@@ -13,16 +13,6 @@ describe("createQueryResultReducer", () => {
   test.each(combinations)(
     "$stateCase.name + $actionCase.name",
     ({ stateCase, actionCase }) => {
-      // A settled query already has the result of a newer sync, so a terminal
-      // network action from a superseded attempt must leave it untouched.
-      if (
-        actionCase.ignoredWhenSettled &&
-        stateCase.state.fetchStatus === "idle"
-      ) {
-        expect(actionCase.run(stateCase.state)).toBe(stateCase.state);
-        return;
-      }
-
       expect(actionCase.run(stateCase.state)).toStrictEqual(
         actionCase.expected(stateCase.state),
       );

--- a/tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts
+++ b/tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts
@@ -13,10 +13,13 @@ describe("createQueryResultReducer", () => {
   test.each(combinations)(
     "$stateCase.name + $actionCase.name",
     ({ stateCase, actionCase }) => {
-      const invalidReason = actionCase.invalid?.(stateCase.state);
-
-      if (invalidReason) {
-        expect(() => actionCase.run(stateCase.state)).toThrow(invalidReason);
+      // A settled query already has the result of a newer sync, so a terminal
+      // network action from a superseded attempt must leave it untouched.
+      if (
+        actionCase.ignoredWhenSettled &&
+        stateCase.state.fetchStatus === "idle"
+      ) {
+        expect(actionCase.run(stateCase.state)).toBe(stateCase.state);
         return;
       }
 

--- a/tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts
+++ b/tests/docsync/unit/client/queryResultReducer/queryResultReducer.test.ts
@@ -9,19 +9,20 @@ describe("createQueryResultReducer", () => {
   test.each(combinations)(
     "$stateCase.name + $actionCase.name",
     ({ stateCase, actionCase }) => {
-      // A settled query already holds the newest attempt's result, so a
-      // terminal network action from a superseded attempt leaves it untouched.
-      if (
-        actionCase.ignoredWhenSettled &&
-        stateCase.state.fetchStatus === "idle"
-      ) {
-        expect(actionCase.run(stateCase.state)).toBe(stateCase.state);
-        return;
-      }
+      const next = actionCase.run(stateCase.state);
+      expect(next).toStrictEqual(actionCase.expected(stateCase.state));
 
-      expect(actionCase.run(stateCase.state)).toStrictEqual(
-        actionCase.expected(stateCase.state),
-      );
+      // A sync that only confirms what the query already holds must return the
+      // very same object. Reporting an equal-but-new result would re-render
+      // every `useDoc` consumer on every background sync, which is the whole
+      // reason `fetchStatus` no longer tracks routine pushes.
+      if (
+        actionCase.unchangedWhenConfirming &&
+        stateCase.state.status === "success" &&
+        stateCase.state.fetchStatus !== "fetching"
+      ) {
+        expect(next).toBe(stateCase.state);
+      }
     },
   );
 });

--- a/tests/docsync/unit/client/queryResultReducer/utils.ts
+++ b/tests/docsync/unit/client/queryResultReducer/utils.ts
@@ -13,8 +13,6 @@ type ActionCase = {
   name: string;
   run: (state: State) => State;
   expected: (state: State) => State;
-  /** Terminal network actions leave a settled query untouched. */
-  ignoredWhenSettled?: boolean;
 };
 
 const fetchStatuses = ["fetching", "paused", "idle"] satisfies FetchStatus[];
@@ -22,7 +20,7 @@ const localError = new Error("local failed");
 const networkError = new Error("network failed");
 
 function reducerFor(state: State) {
-  return createQueryResultReducer<Data>({ initialState: state });
+  return createQueryResultReducer({ initialState: state });
 }
 
 function success(data: Data, fetchStatus: FetchStatus): State {
@@ -110,7 +108,8 @@ export const actionCases: ActionCase[] = [
     name: "localQueryError",
     run: (state) =>
       reducerFor(state).action.localQueryError({ error: localError }),
-    expected: (state) => errorState(state, state.fetchStatus, localError),
+    expected: (state) =>
+      errorState(state, terminalFetchStatus(state), localError),
   },
   {
     name: "fetchStarted",
@@ -141,21 +140,18 @@ export const actionCases: ActionCase[] = [
     run: (state) =>
       reducerFor(state).action.networkDocFound({ data: "network" }),
     expected: (state) => success("network", terminalFetchStatus(state)),
-    ignoredWhenSettled: true,
   },
   {
     name: "networkDocNotFound optional data",
     run: (state) =>
       reducerFor(state).action.networkDocNotFound({ createIfMissing: false }),
     expected: (state) => networkDocNotFoundExpected(state, false),
-    ignoredWhenSettled: true,
   },
   {
     name: "networkDocNotFound required data",
     run: (state) =>
       reducerFor(state).action.networkDocNotFound({ createIfMissing: true }),
     expected: (state) => networkDocNotFoundExpected(state, true),
-    ignoredWhenSettled: true,
   },
   {
     name: "networkQueryError",
@@ -163,6 +159,14 @@ export const actionCases: ActionCase[] = [
       reducerFor(state).action.networkQueryError({ error: networkError }),
     expected: (state) =>
       errorState(state, terminalFetchStatus(state), networkError),
-    ignoredWhenSettled: true,
+  },
+  {
+    name: "networkQueryError with pending retry",
+    run: (state) =>
+      reducerFor(state).action.networkQueryError({
+        error: networkError,
+        fetchStatus: "fetching",
+      }),
+    expected: (state) => errorState(state, "fetching", networkError),
   },
 ];

--- a/tests/docsync/unit/client/queryResultReducer/utils.ts
+++ b/tests/docsync/unit/client/queryResultReducer/utils.ts
@@ -13,7 +13,8 @@ type ActionCase = {
   name: string;
   run: (state: State) => State;
   expected: (state: State) => State;
-  invalid?: (state: State) => string | undefined;
+  /** Terminal network actions leave a settled query untouched. */
+  ignoredWhenSettled?: boolean;
 };
 
 const fetchStatuses = ["fetching", "paused", "idle"] satisfies FetchStatus[];
@@ -55,18 +56,22 @@ function withFetchStatus(state: State, fetchStatus: FetchStatus): State {
   return errorState(state, fetchStatus, state.error);
 }
 
-function invalidNetworkAction(state: State): string | undefined {
-  if (state.fetchStatus !== "idle") return undefined;
-  return "when fetchStatus is idle";
+/**
+ * Terminal network actions settle a query, but a query that went `paused` while
+ * the response was in flight must stay `paused`.
+ */
+function terminalFetchStatus(state: State): FetchStatus {
+  return state.fetchStatus === "paused" ? "paused" : "idle";
 }
 
 function networkDocNotFoundExpected(
   state: State,
   createIfMissing: boolean,
 ): State {
-  if ("data" in state) return success(state.data, "idle");
-  if (createIfMissing) return { status: "pending", fetchStatus: "idle" };
-  return success(undefined, "idle");
+  const fetchStatus = terminalFetchStatus(state);
+  if ("data" in state) return success(state.data, fetchStatus);
+  if (createIfMissing) return { status: "pending", fetchStatus };
+  return success(undefined, fetchStatus);
 }
 
 export const stateCases: StateCase[] = [
@@ -126,34 +131,38 @@ export const actionCases: ActionCase[] = [
     expected: (state) => withFetchStatus(state, "paused"),
   },
   {
+    name: "connectionError",
+    run: (state) =>
+      reducerFor(state).action.connectionError({ error: networkError }),
+    expected: (state) => errorState(state, "paused", networkError),
+  },
+  {
     name: "networkDocFound",
     run: (state) =>
       reducerFor(state).action.networkDocFound({ data: "network" }),
-    expected: () => success("network", "idle"),
-    invalid: invalidNetworkAction,
+    expected: (state) => success("network", terminalFetchStatus(state)),
+    ignoredWhenSettled: true,
   },
   {
     name: "networkDocNotFound optional data",
     run: (state) =>
       reducerFor(state).action.networkDocNotFound({ createIfMissing: false }),
     expected: (state) => networkDocNotFoundExpected(state, false),
-    invalid: invalidNetworkAction,
+    ignoredWhenSettled: true,
   },
   {
     name: "networkDocNotFound required data",
     run: (state) =>
       reducerFor(state).action.networkDocNotFound({ createIfMissing: true }),
     expected: (state) => networkDocNotFoundExpected(state, true),
-    invalid: invalidNetworkAction,
+    ignoredWhenSettled: true,
   },
   {
     name: "networkQueryError",
     run: (state) =>
-      reducerFor(state).action.networkQueryError({
-        error: networkError,
-        fetchStatus: "idle",
-      }),
-    expected: (state) => errorState(state, "idle", networkError),
-    invalid: invalidNetworkAction,
+      reducerFor(state).action.networkQueryError({ error: networkError }),
+    expected: (state) =>
+      errorState(state, terminalFetchStatus(state), networkError),
+    ignoredWhenSettled: true,
   },
 ];

--- a/tests/docsync/unit/client/queryResultReducer/utils.ts
+++ b/tests/docsync/unit/client/queryResultReducer/utils.ts
@@ -13,6 +13,8 @@ type ActionCase = {
   name: string;
   run: (state: State) => State;
   expected: (state: State) => State;
+  /** Terminal network actions leave a settled query untouched. */
+  ignoredWhenSettled?: boolean;
 };
 
 const fetchStatuses = ["fetching", "paused", "idle"] satisfies FetchStatus[];
@@ -137,24 +139,28 @@ export const actionCases: ActionCase[] = [
   },
   {
     name: "networkDocFound",
+    ignoredWhenSettled: true,
     run: (state) =>
       reducerFor(state).action.networkDocFound({ data: "network" }),
     expected: (state) => success("network", terminalFetchStatus(state)),
   },
   {
     name: "networkDocNotFound optional data",
+    ignoredWhenSettled: true,
     run: (state) =>
       reducerFor(state).action.networkDocNotFound({ createIfMissing: false }),
     expected: (state) => networkDocNotFoundExpected(state, false),
   },
   {
     name: "networkDocNotFound required data",
+    ignoredWhenSettled: true,
     run: (state) =>
       reducerFor(state).action.networkDocNotFound({ createIfMissing: true }),
     expected: (state) => networkDocNotFoundExpected(state, true),
   },
   {
     name: "networkQueryError",
+    ignoredWhenSettled: true,
     run: (state) =>
       reducerFor(state).action.networkQueryError({ error: networkError }),
     expected: (state) =>
@@ -162,6 +168,7 @@ export const actionCases: ActionCase[] = [
   },
   {
     name: "networkQueryError with pending retry",
+    ignoredWhenSettled: true,
     run: (state) =>
       reducerFor(state).action.networkQueryError({
         error: networkError,

--- a/tests/docsync/unit/client/queryResultReducer/utils.ts
+++ b/tests/docsync/unit/client/queryResultReducer/utils.ts
@@ -17,6 +17,13 @@ type ActionCase = {
   ignoredWhenSettled?: boolean;
 };
 
+type ActionCasesByReducerAction = {
+  [ActionName in keyof ReturnType<typeof reducerFor>["action"]]: readonly [
+    ActionCase,
+    ...ActionCase[],
+  ];
+};
+
 const fetchStatuses = ["fetching", "paused", "idle"] satisfies FetchStatus[];
 const localError = new Error("local failed");
 const networkError = new Error("network failed");
@@ -41,6 +48,10 @@ function errorWithData(fetchStatus: FetchStatus): State {
   return { status: "error", fetchStatus, data: "local", error: localError };
 }
 
+function errorWithUndefinedData(fetchStatus: FetchStatus): State {
+  return { status: "error", fetchStatus, data: undefined, error: localError };
+}
+
 function errorState(
   state: State,
   fetchStatus: FetchStatus,
@@ -51,9 +62,7 @@ function errorState(
 
 function withFetchStatus(state: State, fetchStatus: FetchStatus): State {
   if (state.fetchStatus === fetchStatus) return state;
-  if (state.status === "pending") return { status: "pending", fetchStatus };
-  if (state.status === "success") return success(state.data, fetchStatus);
-  return errorState(state, fetchStatus, state.error);
+  return { ...state, fetchStatus };
 }
 
 /**
@@ -69,7 +78,10 @@ function networkDocNotFoundExpected(
   createIfMissing: boolean,
 ): State {
   const fetchStatus = terminalFetchStatus(state);
-  if ("data" in state) return success(state.data, fetchStatus);
+  if (state.status === "success") return success(state.data, fetchStatus);
+  if (state.status === "error" && state.data !== undefined) {
+    return success(state.data, fetchStatus);
+  }
   if (createIfMissing) return { status: "pending", fetchStatus };
   return success(undefined, fetchStatus);
 }
@@ -95,85 +107,101 @@ export const stateCases: StateCase[] = [
     name: `error with data ${fetchStatus}`,
     state: errorWithData(fetchStatus),
   })),
+  ...fetchStatuses.map((fetchStatus) => ({
+    name: `error with explicit undefined data ${fetchStatus}`,
+    state: errorWithUndefinedData(fetchStatus),
+  })),
 ];
 
-export const actionCases: ActionCase[] = [
-  {
-    name: "localDocFound",
-    run: (state) => reducerFor(state).action.localDocFound({ data: "found" }),
-    expected: (state) =>
-      state.status === "error"
-        ? { ...state, data: "found" }
-        : success("found", state.fetchStatus),
-  },
-  {
-    name: "localQueryError",
-    run: (state) =>
-      reducerFor(state).action.localQueryError({ error: localError }),
-    expected: (state) =>
-      errorState(state, terminalFetchStatus(state), localError),
-  },
-  {
-    name: "fetchStarted",
-    run: (state) => reducerFor(state).action.fetchStarted(undefined),
-    expected: (state) => withFetchStatus(state, "fetching"),
-  },
-  {
-    name: "connected",
-    run: (state) => reducerFor(state).action.connected(undefined),
-    expected: (state) =>
-      state.fetchStatus === "paused"
-        ? withFetchStatus(state, "fetching")
-        : state,
-  },
-  {
-    name: "disconnected",
-    run: (state) => reducerFor(state).action.disconnected(undefined),
-    expected: (state) => withFetchStatus(state, "paused"),
-  },
-  {
-    name: "connectionError",
-    run: (state) =>
-      reducerFor(state).action.connectionError({ error: networkError }),
-    expected: (state) => errorState(state, "paused", networkError),
-  },
-  {
-    name: "networkDocFound",
-    ignoredWhenSettled: true,
-    run: (state) =>
-      reducerFor(state).action.networkDocFound({ data: "network" }),
-    expected: (state) => success("network", terminalFetchStatus(state)),
-  },
-  {
-    name: "networkDocNotFound optional data",
-    ignoredWhenSettled: true,
-    run: (state) =>
-      reducerFor(state).action.networkDocNotFound({ createIfMissing: false }),
-    expected: (state) => networkDocNotFoundExpected(state, false),
-  },
-  {
-    name: "networkDocNotFound required data",
-    ignoredWhenSettled: true,
-    run: (state) =>
-      reducerFor(state).action.networkDocNotFound({ createIfMissing: true }),
-    expected: (state) => networkDocNotFoundExpected(state, true),
-  },
-  {
-    name: "networkQueryError",
-    ignoredWhenSettled: true,
-    run: (state) =>
-      reducerFor(state).action.networkQueryError({ error: networkError }),
-    expected: (state) =>
-      errorState(state, terminalFetchStatus(state), networkError),
-  },
-  {
-    name: "networkQueryError with pending retry",
-    ignoredWhenSettled: true,
-    run: (state) =>
-      reducerFor(state).action.networkQueryError({
-        error: networkError,
-        fetchStatus: "fetching",
-      }),
-    expected: (state) => errorState(state, "fetching", networkError),
-  },
-];
+const actionCasesByReducerAction = {
+  localDocFound: [
+    {
+      name: "localDocFound",
+      run: (state) => reducerFor(state).action.localDocFound({ data: "found" }),
+      expected: (state) =>
+        state.status === "error"
+          ? { ...state, data: "found" }
+          : success("found", state.fetchStatus),
+    },
+  ],
+  localQueryError: [
+    {
+      name: "localQueryError",
+      run: (state) =>
+        reducerFor(state).action.localQueryError({ error: localError }),
+      expected: (state) =>
+        errorState(state, terminalFetchStatus(state), localError),
+    },
+  ],
+  fetchStarted: [
+    {
+      name: "fetchStarted",
+      run: (state) => reducerFor(state).action.fetchStarted(undefined),
+      expected: (state) => withFetchStatus(state, "fetching"),
+    },
+  ],
+  connected: [
+    {
+      name: "connected",
+      run: (state) => reducerFor(state).action.connected(undefined),
+      expected: (state) =>
+        state.fetchStatus === "paused"
+          ? withFetchStatus(state, "fetching")
+          : state,
+    },
+  ],
+  disconnected: [
+    {
+      name: "disconnected",
+      run: (state) => reducerFor(state).action.disconnected(undefined),
+      expected: (state) => withFetchStatus(state, "paused"),
+    },
+  ],
+  connectionError: [
+    {
+      name: "connectionError",
+      run: (state) =>
+        reducerFor(state).action.connectionError({ error: networkError }),
+      expected: (state) => errorState(state, "paused", networkError),
+    },
+  ],
+  networkDocFound: [
+    {
+      name: "networkDocFound",
+      ignoredWhenSettled: true,
+      run: (state) =>
+        reducerFor(state).action.networkDocFound({ data: "network" }),
+      expected: (state) => success("network", terminalFetchStatus(state)),
+    },
+  ],
+  networkDocNotFound: [
+    {
+      name: "networkDocNotFound optional data",
+      ignoredWhenSettled: true,
+      run: (state) =>
+        reducerFor(state).action.networkDocNotFound({ createIfMissing: false }),
+      expected: (state) => networkDocNotFoundExpected(state, false),
+    },
+    {
+      name: "networkDocNotFound required data",
+      ignoredWhenSettled: true,
+      run: (state) =>
+        reducerFor(state).action.networkDocNotFound({ createIfMissing: true }),
+      expected: (state) => networkDocNotFoundExpected(state, true),
+    },
+  ],
+  networkQueryError: [
+    {
+      name: "networkQueryError",
+      ignoredWhenSettled: true,
+      run: (state) =>
+        reducerFor(state).action.networkQueryError({ error: networkError }),
+      expected: (state) =>
+        errorState(state, terminalFetchStatus(state), networkError),
+    },
+  ],
+} satisfies ActionCasesByReducerAction;
+
+export const actionCases: ActionCase[] = Object.values(
+  actionCasesByReducerAction,
+).flat();

--- a/tests/docsync/unit/client/queryResultReducer/utils.ts
+++ b/tests/docsync/unit/client/queryResultReducer/utils.ts
@@ -13,8 +13,12 @@ type ActionCase = {
   name: string;
   run: (state: State) => State;
   expected: (state: State) => State;
-  /** Terminal network actions leave a settled query untouched. */
-  ignoredWhenSettled?: boolean;
+  /**
+   * The action confirms what the query already holds, so it must return the
+   * very same object. That identity is what keeps a settled document from
+   * re-rendering on every background sync.
+   */
+  unchangedWhenConfirming?: boolean;
 };
 
 type ActionCasesByReducerAction = {
@@ -133,13 +137,6 @@ const actionCasesByReducerAction = {
         errorState(state, terminalFetchStatus(state), localError),
     },
   ],
-  fetchStarted: [
-    {
-      name: "fetchStarted",
-      run: (state) => reducerFor(state).action.fetchStarted(undefined),
-      expected: (state) => withFetchStatus(state, "fetching"),
-    },
-  ],
   connected: [
     {
       name: "connected",
@@ -168,23 +165,28 @@ const actionCasesByReducerAction = {
   networkDocFound: [
     {
       name: "networkDocFound",
-      ignoredWhenSettled: true,
       run: (state) =>
         reducerFor(state).action.networkDocFound({ data: "network" }),
       expected: (state) => success("network", terminalFetchStatus(state)),
+    },
+    {
+      // The routine case: a background sync confirming the loaded document.
+      name: "networkDocFound confirming the current data",
+      unchangedWhenConfirming: true,
+      run: (state) =>
+        reducerFor(state).action.networkDocFound({ data: state.data }),
+      expected: (state) => success(state.data, terminalFetchStatus(state)),
     },
   ],
   networkDocNotFound: [
     {
       name: "networkDocNotFound optional data",
-      ignoredWhenSettled: true,
       run: (state) =>
         reducerFor(state).action.networkDocNotFound({ createIfMissing: false }),
       expected: (state) => networkDocNotFoundExpected(state, false),
     },
     {
       name: "networkDocNotFound required data",
-      ignoredWhenSettled: true,
       run: (state) =>
         reducerFor(state).action.networkDocNotFound({ createIfMissing: true }),
       expected: (state) => networkDocNotFoundExpected(state, true),
@@ -193,7 +195,6 @@ const actionCasesByReducerAction = {
   networkQueryError: [
     {
       name: "networkQueryError",
-      ignoredWhenSettled: true,
       run: (state) =>
         reducerFor(state).action.networkQueryError({ error: networkError }),
       expected: (state) =>

--- a/tests/docsync/unit/client/queryResultReducer/utils.ts
+++ b/tests/docsync/unit/client/queryResultReducer/utils.ts
@@ -96,13 +96,21 @@ export const actionCases: ActionCase[] = [
   {
     name: "localDocFound",
     run: (state) => reducerFor(state).action.localDocFound({ data: "found" }),
-    expected: (state) => success("found", state.fetchStatus),
+    expected: (state) =>
+      state.status === "error"
+        ? { ...state, data: "found" }
+        : success("found", state.fetchStatus),
   },
   {
     name: "localQueryError",
     run: (state) =>
       reducerFor(state).action.localQueryError({ error: localError }),
     expected: (state) => errorState(state, state.fetchStatus, localError),
+  },
+  {
+    name: "fetchStarted",
+    run: (state) => reducerFor(state).action.fetchStarted(undefined),
+    expected: (state) => withFetchStatus(state, "fetching"),
   },
   {
     name: "connected",
@@ -115,10 +123,7 @@ export const actionCases: ActionCase[] = [
   {
     name: "disconnected",
     run: (state) => reducerFor(state).action.disconnected(undefined),
-    expected: (state) =>
-      state.fetchStatus === "fetching"
-        ? withFetchStatus(state, "paused")
-        : state,
+    expected: (state) => withFetchStatus(state, "paused"),
   },
   {
     name: "networkDocFound",
@@ -144,7 +149,10 @@ export const actionCases: ActionCase[] = [
   {
     name: "networkQueryError",
     run: (state) =>
-      reducerFor(state).action.networkQueryError({ error: networkError }),
+      reducerFor(state).action.networkQueryError({
+        error: networkError,
+        fetchStatus: "idle",
+      }),
     expected: (state) => errorState(state, "idle", networkError),
     invalid: invalidNetworkAction,
   },

--- a/tests/docsync/unit/client/utils.ts
+++ b/tests/docsync/unit/client/utils.ts
@@ -7,6 +7,7 @@ import {
   type DocData,
   type ClientConfig,
   type Identity,
+  type GetDocArgs,
 } from "@docukit/docsync/client";
 import { DocNodeBinding } from "@docukit/docsync/docnode";
 import {
@@ -102,6 +103,27 @@ type DocCallback = Mock<
 >;
 
 export const createCallback = () => vi.fn() as DocCallback;
+
+export const subscribeToDoc = <
+  D extends object,
+  S extends object,
+  O extends object,
+  T extends GetDocArgs,
+>(
+  client: DocSyncClient<D, S, O>,
+  args: T,
+  onChange: (
+    result: QueryResult<
+      T extends { createIfMissing: true } ? DocData<D> : DocData<D> | undefined
+    >,
+  ) => void,
+): (() => void) => {
+  const observer = client.getDocObserver(args);
+  const notify = () => onChange(observer.getSnapshot());
+  const unsubscribe = observer.subscribe(notify);
+  notify();
+  return unsubscribe;
+};
 
 /**
  * Extracts the successful result from a callback mock.

--- a/tests/docsync/unit/client2/index.browser.test.ts
+++ b/tests/docsync/unit/client2/index.browser.test.ts
@@ -453,6 +453,9 @@ describe("Client 2", () => {
       if (!importHistory) throw new Error("Expected history support");
       const importError = new Error("history import failed");
       docBinding.importHistory = () => {
+        // Simulates a local edit landing while the replacement doc is being
+        // set up: the sync is queued as pushing-with-pending and must survive
+        // the throw below.
         void client["_sync"](docId);
         throw importError;
       };

--- a/tests/docsync/unit/client2/index.browser.test.ts
+++ b/tests/docsync/unit/client2/index.browser.test.ts
@@ -402,10 +402,19 @@ describe("Client 2", () => {
       expect(replacementDoc).toBeDefined();
       expect(replacementDoc).not.toBe(liveDoc);
       expect(replacementDoc?.root.first?.type).toBe("child");
+      expect(client["_docsCache"].get(docId)?.queryResult).toMatchObject({
+        status: "error",
+        fetchStatus: "idle",
+        error: importError,
+      });
 
       await client["_sync"](docId);
       expect(requestSpy).toHaveBeenCalledTimes(2);
       expect(client["_pushStatusByDocId"].get(docId)).toBe("idle");
+      expect(client["_docsCache"].get(docId)?.queryResult).toMatchObject({
+        status: "success",
+        fetchStatus: "idle",
+      });
     });
 
     test("should delete operations after successful push", async () => {

--- a/tests/docsync/unit/client2/index.browser.test.ts
+++ b/tests/docsync/unit/client2/index.browser.test.ts
@@ -468,10 +468,12 @@ describe("Client 2", () => {
 
       await expect.poll(() => requestSpy.mock.calls.length).toBe(2);
       expect(client["_docsCache"].get(docId)?.queryResult).toMatchObject({
-        status: "error",
+        status: "success",
         fetchStatus: "fetching",
-        error: importError,
       });
+      expect(
+        client["_docsCache"].get(docId)?.queryResult.error,
+      ).toBeUndefined();
 
       if (!finishQueuedRequest) throw new Error("Expected queued sync request");
       finishQueuedRequest({ data: s({ docId, clock: 2 }) });

--- a/tests/docsync/unit/client2/index.browser.test.ts
+++ b/tests/docsync/unit/client2/index.browser.test.ts
@@ -467,20 +467,26 @@ describe("Client 2", () => {
       }
 
       await expect.poll(() => requestSpy.mock.calls.length).toBe(2);
-      expect(client["_docsCache"].get(docId)?.queryResult).toMatchObject({
+      // The queued push is in flight, but the document is loaded and up to
+      // date, so the query stays settled: a background push is not a reason to
+      // tell the application it cannot serve the document.
+      const queryDuringQueuedSync =
+        client["_docsCache"].get(docId)?.queryResult;
+      expect(queryDuringQueuedSync).toMatchObject({
         status: "success",
-        fetchStatus: "fetching",
+        fetchStatus: "idle",
       });
-      expect(
-        client["_docsCache"].get(docId)?.queryResult.error,
-      ).toBeUndefined();
+      expect(queryDuringQueuedSync?.error).toBeUndefined();
 
       if (!finishQueuedRequest) throw new Error("Expected queued sync request");
       finishQueuedRequest({ data: s({ docId, clock: 2 }) });
 
-      await expect
-        .poll(() => client["_docsCache"].get(docId)?.queryResult)
-        .toMatchObject({ status: "success", fetchStatus: "idle" });
+      // Confirming the same document reports nothing new, so the identity of
+      // the result survives the whole queued sync.
+      await expect.poll(() => requestSpy.mock.calls.length).toBe(2);
+      expect(client["_docsCache"].get(docId)?.queryResult).toBe(
+        queryDuringQueuedSync,
+      );
     });
 
     test("should delete operations after successful push", async () => {

--- a/tests/docsync/unit/client2/index.browser.test.ts
+++ b/tests/docsync/unit/client2/index.browser.test.ts
@@ -417,6 +417,67 @@ describe("Client 2", () => {
       });
     });
 
+    test("runs a queued sync when history import throws", async () => {
+      const client = await createClient();
+      const docId = generateDocId();
+      const docBinding = client["_docBinding"];
+      const { doc: liveDoc } = await setupDocWithOperations(client, docId, {
+        operations: [],
+      });
+      cacheDoc(client, docId, liveDoc);
+
+      const { doc: serverDoc } = docBinding.create("test", docId);
+      serverDoc.root.append(serverDoc.createNode(ChildNode));
+      serverDoc.forceCommit();
+
+      let finishQueuedRequest:
+        | ((response: { data: ReturnType<typeof s> }) => void)
+        | undefined;
+      const requestSpy = spyOnRequest(client);
+      requestSpy
+        .mockResolvedValueOnce({
+          data: s({
+            docId,
+            clock: 1,
+            serializedDoc: docBinding.serialize(serverDoc),
+          }),
+        })
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              finishQueuedRequest = resolve;
+            }),
+        );
+
+      const importHistory = docBinding.importHistory;
+      if (!importHistory) throw new Error("Expected history support");
+      const importError = new Error("history import failed");
+      docBinding.importHistory = () => {
+        void client["_sync"](docId);
+        throw importError;
+      };
+
+      try {
+        await expect(client["_sync"](docId)).rejects.toBe(importError);
+      } finally {
+        docBinding.importHistory = importHistory;
+      }
+
+      await expect.poll(() => requestSpy.mock.calls.length).toBe(2);
+      expect(client["_docsCache"].get(docId)?.queryResult).toMatchObject({
+        status: "error",
+        fetchStatus: "fetching",
+        error: importError,
+      });
+
+      if (!finishQueuedRequest) throw new Error("Expected queued sync request");
+      finishQueuedRequest({ data: s({ docId, clock: 2 }) });
+
+      await expect
+        .poll(() => client["_docsCache"].get(docId)?.queryResult)
+        .toMatchObject({ status: "success", fetchStatus: "idle" });
+    });
+
     test("should delete operations after successful push", async () => {
       const client = await createClient();
       const docId = generateDocId();

--- a/tests/docsync/unit/client2/utils.ts
+++ b/tests/docsync/unit/client2/utils.ts
@@ -191,6 +191,7 @@ export const cacheDoc = (
 ) => {
   client["_docsCache"].set(docId, {
     promisedDoc: Promise.resolve(doc),
+    activeSyncAttempt: undefined,
     refCount: 1,
     localVersion: 0,
     type: "test",


### PR DESCRIPTION
## Summary

- **Breaking:** replace `DocSyncClient.getDoc(args, onChange)` with `DocSyncClient.getDocObserver(args)`
- align DocSync query state with independent `status` and `fetchStatus` semantics
- preserve local or stale `data` alongside later errors
- classify permanent connection and sync failures with the public `DocSyncError`
- use bounded exponential backoff for transient sync failures without hot loops
- prevent stale sync attempts from changing current cache, query, or provider state
- preserve sync work queued during a failed attempt
- document the state contract and retry/reconnection policy

## Breaking changes

### `getDoc` was replaced by `getDocObserver`

The callback-based subscription is gone. `getDocObserver(args)` returns a lazy
`{ getSnapshot, subscribe }` observer instead: `getSnapshot()` does not load the
document, the first subscriber starts the query, and dropping the last
subscriber releases it. There is no deprecated alias.

**Migration:**

```ts
// Before
const unsubscribe = client.getDoc({ type: "notes", id: "abc" }, (result) => {
  render(result);
});

// After
const observer = client.getDocObserver({ type: "notes", id: "abc" });
const unsubscribe = observer.subscribe(() => render(observer.getSnapshot()));
render(observer.getSnapshot()); // the first snapshot is not pushed
```

`subscribe` notifies on later changes only, so read the initial state with
`getSnapshot()` yourself. `getSnapshot()` returns the same object until the
query state actually changes, which is what `useSyncExternalStore` requires.

`useDoc` keeps the same signature and return type. It now reads through
`useSyncExternalStore` internally, which fixes a render of the previous
document right after the `id` changes.

### `QueryResult.data` can be present while `status === "error"`

Code shaped like `status === "success" && data.docId === id` should become
`data?.docId === id`, so stale-but-usable content keeps rendering next to a
later failure instead of being replaced by an error screen. Both docs examples
were updated this way.


## Query state contract

`fetchStatus` answers exactly one question: can this query serve the authoritative document right now?

| Situation | `status` | `fetchStatus` | Result |
| --- | --- | --- | --- |
| Loading for the first time, or resyncing after a reconnect | `pending`, `success`, or `error` | `fetching` | Existing local data and errors are preserved |
| Temporarily offline or manually disconnected | `pending`, `success`, or `error` | `paused` | Existing local data and errors are preserved |
| Document available and up to date | `success` | `idle` | Server result is available, including `undefined` when an optional document is absent |
| A routine background sync is in flight | unchanged | unchanged | Nothing is emitted: the document on screen is already correct |
| Local storage failed | `error` | `idle` or `paused` | The local failure is visible; a disconnected query remains paused |
| Authentication or permanent connection rejection | `error` | `paused` | The connection failure is visible |
| Server permanently rejected a sync | `error` | `idle` | Existing data is preserved; the authorization or validation failure is visible |
| Sync request or database attempt failed and is retrying | unchanged | unchanged | Existing data and any existing error are preserved until a retry succeeds |
| Sync retry budget was exhausted | `error` | `idle` | Existing data and the final error remain visible |

`data` and `error` can coexist. Applications can keep stale data visible, show definitive errors immediately, and delay generic paused notices so brief disconnects do not flash an alert.

### Background syncs do not report `fetching`

DocSync is realtime over a persistent socket and applies local edits optimistically, so while a push is in flight the document being rendered is already correct; remote operations are applied to the same live document instance. Neither produces a new query result.

The alternative — flipping `idle → fetching → idle` around every sync, the way TanStack Query reports a background refetch — was considered and rejected. It overloads `fetchStatus` with a second meaning applications cannot act on, and it emits two new query results per sync: at the 50ms collaborative debounce, roughly 40 re-renders per second of everything under `useDoc`, for a document that never changed. Measured on the test client: 5 background syncs now emit 0 query results, against 10 under the rejected design.

**For a "Saving…" indicator**, use the client's `sync` event, which fires once per sync with the request and its outcome. That keeps the signal out of the query result for applications that do not want one.

## Error and retry policy

- Socket.IO `connect_error` with `socket.active === true`: transient; queries pause without a new error.
- Socket.IO `connect_error` with `socket.active === false`: permanent; queries become `error + paused`.
- Manual disconnect: paused without a new error.
- Server-initiated permanent disconnect: `error + paused`.
- `AuthorizationError` and `ValidationError` sync responses: visible error without automatic retry.
- `DatabaseError` and request rejection: bounded exponential backoff for about 24 seconds; the query stays fetching during each delay and becomes idle after exhaustion.
- Transport disconnect cancels per-document retries. Socket.IO reconnects the transport, and DocSync resumes with a fresh retry budget.
- If work is queued during a failed sync, an existing retry absorbs it; otherwise exactly one follow-up sync starts.

## Concurrency safety

- Per-document attempt tokens make stale responses inert after reconnect or a newer sync.
- Provider reconciliation keeps snapshot writes and operation cleanup atomic once the write starts.
- History import failures keep replacement and cache state consistent while remaining visible to the caller.

## Verification

- `pnpm fix`
- `pnpm test:coverage:once`
- `pnpm test:ci`
- `pnpm build`
- `pnpm exec playwright test`
- DocNode coverage remains 100% for statements, functions, and lines


