### PR TITLE
chore: release v0.4.1-alpha.2

### DIFF
--- a/changelog/v0.4.1-alpha.2.md
+++ b/changelog/v0.4.1-alpha.2.md
@@ -1,0 +1,27 @@
+# v0.4.1-alpha.2 — 2026-09-04
+
+## Highlights
+
+- **DocSync now stays useful through connection and server failures.** Loaded documents remain available while typed errors, bounded retries, and clearer connection states tell applications when user action is actually needed. (#61) See the [DocSync client docs](https://docukit.dev/docsync/client).
+- **Document subscriptions are now stable external stores.** The new observer API gives imperative consumers consistent snapshots, while React avoids showing the previous document after its ID changes and skips unnecessary renders during background sync. (#61) See [`getDocObserver`](https://docukit.dev/docsync/client#getdocobserver).
+
+## Breaking changes
+
+- **`DocSyncClient.getDoc(args, onChange)` was replaced by `getDocObserver(args)`.** The observer is lazy: its first subscriber starts the query, and listeners are notified only after the initial snapshot. **Migration:** create an observer, call `observer.subscribe(listener)`, and read both the initial and later values with `observer.getSnapshot()`; call the returned unsubscribe function when finished. (#61)
+- **`fetchStatus` now reports document availability, not background push activity.** Routine syncs leave it unchanged, temporary disconnections use `"paused"`, and retryable sync failures do not change the query until retries are exhausted. **Migration:** use the client's `sync` event for saving indicators or per-attempt failures; use `fetchStatus` only to decide whether the authoritative document is available. (#61)
+- **A terminal query error can keep previously loaded `data`.** Applications no longer need to discard a usable document when a later sync fails. **Migration:** render usable content from `result.data` independently of `result.status` (for example, check `result.data?.docId`) and display `result.error` alongside it when `status === "error"`. (#61)
+
+## Features
+
+- Added public `DocSyncError`, `DocSyncErrorType`, and machine-readable authorization, connection, database, network, and validation error types. (#61)
+- Added bounded exponential backoff for transient network and database sync failures, with permanent failures surfaced immediately. (#61)
+
+## Fixes
+
+- Prevented stale sync responses from overwriting newer cache or local-provider state, and preserved sync work queued while an earlier attempt failed. (#61)
+- Updated React `useDoc` to use `useSyncExternalStore`, preventing a changed document ID from briefly rendering the previous document and avoiding redundant background-sync renders. (#61)
+- Paused all loaded queries consistently when connections fail or disconnect, including token-loading failures and disconnects during the initial handshake. (#61)
+
+## Docs
+
+- Documented the query-state contract, error and retry policy, `getDocObserver`, token-authentication failures, and how to build a saving indicator from sync events. (#61)

--- a/packages/docsync-react/package.json
+++ b/packages/docsync-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docukit/docsync-react",
-  "version": "0.4.1-alpha.1",
+  "version": "0.4.1-alpha.2",
   "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "homepage": "https://docukit.dev/docsync",

--- a/packages/docsync/package.json
+++ b/packages/docsync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docukit/docsync",
-  "version": "0.4.1-alpha.1",
+  "version": "0.4.1-alpha.2",
   "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "homepage": "https://docukit.dev/docsync",


### PR DESCRIPTION
Release PR. See `changelog/v0.4.1-alpha.2.md` for notes.