### PR TITLE
fix: make release publishing resilient

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -162,4 +162,4 @@ Report the PR URL back. Remind the user:
 - Merging into main (squash merge) triggers the `publish` job, which pushes to npm and creates the GitHub release.
 - The Discord copy is ready at `changelog/<tag>_DISCORD.md` for after publish.
 
-If publishing fails after npm accepted the packages, inspect the registry before retrying. Once the fix is on `main`, rerun the workflow manually with the exact `release_tag`; the workflow skips versions already on npm and finishes the missing release steps.
+If publishing fails after npm accepted the packages, inspect the registry before retrying. Once the fix is on `main`, rerun the workflow manually. It finds the most recent `chore: release v...` commit, skips versions already on npm, and finishes the missing release steps.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -162,4 +162,4 @@ Report the PR URL back. Remind the user:
 - Merging into main (squash merge) triggers the `publish` job, which pushes to npm and creates the GitHub release.
 - The Discord copy is ready at `changelog/<tag>_DISCORD.md` for after publish.
 
-If publishing fails after npm accepted the packages, inspect the registry before retrying. Once the fix is on `main`, rerun the workflow manually. It finds the most recent `chore: release v...` commit, skips versions already on npm, and finishes the missing release steps.
+If npm accepts a package but registry metadata is still propagating after the verification window, treat that delay as a warning and continue the release. Only an actual `npm publish` failure blocks the workflow. If an older workflow already failed after npm accepted the packages, inspect the registry before retrying. Once the fix is on `main`, rerun the workflow manually. It finds the most recent `chore: release v...` commit, skips versions already on npm, and finishes the missing release steps.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -28,9 +28,9 @@ When the user reports the bump is done, continue.
 Silently verify the bump makes sense. If anything is off, flag it to the user before drafting notes.
 
 1. Run `git diff --name-only` — should show only `packages/*/package.json` files. Flag anything else.
-2. Read each bumped `package.json` and confirm all publishable packages agree on `major.minor.patch`. Alpha packages may carry `-alpha.N`.
-3. Derive the target release tag:
-   - If at least one publishable package is stable (no `-alpha.`), tag = `v<major>.<minor>.<patch>`.
+2. Read each bumped `package.json` and confirm all bumped publishable packages agree on `major.minor.patch`. Alpha packages may carry `-alpha.N`.
+3. Derive the target release tag from the bumped packages only. Unchanged package versions never determine the tag:
+   - If at least one bumped package is stable (no `-alpha.`), tag = `v<major>.<minor>.<patch>`.
    - Otherwise (alpha-only release), tag = `v<major>.<minor>.<patch>-alpha.<N>`.
 4. Determine the baseline: the most recent `changelog/v*.md` file, or the first commit if none exists.
 5. Count commits between baseline and HEAD (`git log BASELINE..HEAD --no-merges --oneline | wc -l`). If zero, stop — there is nothing to release.
@@ -161,3 +161,5 @@ Report the PR URL back. Remind the user:
 - The `validate` workflow job runs on PR open — it should turn green.
 - Merging into main (squash merge) triggers the `publish` job, which pushes to npm and creates the GitHub release.
 - The Discord copy is ready at `changelog/<tag>_DISCORD.md` for after publish.
+
+If publishing fails after npm accepted the packages, inspect the registry before retrying. Once the fix is on `main`, rerun the workflow manually with the exact `release_tag`; the workflow skips versions already on npm and finishes the missing release steps.

--- a/.claude/skills/release
+++ b/.claude/skills/release
@@ -1,0 +1,1 @@
+../../.agents/skills/release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      release_tag:
-        description: "Release tag to publish or recover (for example, v0.4.1-alpha.2)"
-        required: true
-        type: string
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches: [main]
@@ -78,8 +73,6 @@ jobs:
 
       - name: Publish to npm
         id: publish
-        env:
-          RELEASE_TAG: ${{ inputs.release_tag || '' }}
         run: node scripts/publish.ts
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to publish or recover (for example, v0.4.1-alpha.2)"
+        required: true
+        type: string
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches: [main]
@@ -37,7 +42,7 @@ jobs:
   publish:
     if: "github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore: release v'))"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: write
       id-token: write
@@ -73,6 +78,8 @@ jobs:
 
       - name: Publish to npm
         id: publish
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag || '' }}
         run: node scripts/publish.ts
 
       - name: Create GitHub Release

--- a/scripts/publish-utils.ts
+++ b/scripts/publish-utils.ts
@@ -1,27 +1,17 @@
-const releaseTagPattern = /^v\d+\.\d+\.\d+(?:-alpha\.\d+)?$/;
 const releaseCommitPattern =
   /^chore: release (v\d+\.\d+\.\d+(?:-alpha\.\d+)?)(?: \(#\d+\))?$/;
 
 export const resolveReleaseTag = (
-  explicitTag: string | undefined,
   commitSubject: string,
   packageVersions: string[],
 ) => {
-  const requestedTag = explicitTag?.trim();
   const commitMatch = releaseCommitPattern.exec(commitSubject.trim());
-  const releaseTag =
-    requestedTag === undefined || requestedTag === ""
-      ? commitMatch?.[1]
-      : requestedTag;
+  const releaseTag = commitMatch?.[1];
 
   if (!releaseTag) {
     throw new Error(
-      "cannot derive release tag: use RELEASE_TAG or a 'chore: release v...' commit",
+      "cannot derive release tag from a 'chore: release v...' commit",
     );
-  }
-
-  if (!releaseTagPattern.test(releaseTag)) {
-    throw new Error(`invalid release tag: ${releaseTag}`);
   }
 
   const releaseVersion = releaseTag.slice(1);

--- a/scripts/publish-utils.ts
+++ b/scripts/publish-utils.ts
@@ -1,0 +1,79 @@
+const releaseTagPattern = /^v\d+\.\d+\.\d+(?:-alpha\.\d+)?$/;
+const releaseCommitPattern =
+  /^chore: release (v\d+\.\d+\.\d+(?:-alpha\.\d+)?)(?: \(#\d+\))?$/;
+
+export const resolveReleaseTag = (
+  explicitTag: string | undefined,
+  commitSubject: string,
+  packageVersions: string[],
+) => {
+  const requestedTag = explicitTag?.trim();
+  const commitMatch = releaseCommitPattern.exec(commitSubject.trim());
+  const releaseTag =
+    requestedTag === undefined || requestedTag === ""
+      ? commitMatch?.[1]
+      : requestedTag;
+
+  if (!releaseTag) {
+    throw new Error(
+      "cannot derive release tag: use RELEASE_TAG or a 'chore: release v...' commit",
+    );
+  }
+
+  if (!releaseTagPattern.test(releaseTag)) {
+    throw new Error(`invalid release tag: ${releaseTag}`);
+  }
+
+  const releaseVersion = releaseTag.slice(1);
+  if (!packageVersions.includes(releaseVersion)) {
+    throw new Error(
+      `release tag ${releaseTag} does not match a publishable package version`,
+    );
+  }
+
+  return releaseTag;
+};
+
+const expectedVersion = (spec: string) => spec.slice(spec.lastIndexOf("@") + 1);
+
+const defaultWait = (delayMs: number): Promise<void> =>
+  new Promise((resolveWait) => {
+    setTimeout(resolveWait, delayMs);
+  });
+
+export const verifyPublishedSpecs = async (
+  specs: string[],
+  options: {
+    readVersion: (spec: string) => string | undefined;
+    attempts?: number;
+    delayMs?: number;
+    wait?: (delayMs: number) => Promise<void>;
+    onRetry?: (spec: string, attempt: number, attempts: number) => void;
+  },
+) => {
+  const attempts = options.attempts ?? 61;
+  const delayMs = options.delayMs ?? 5_000;
+  const wait = options.wait ?? defaultWait;
+
+  const failures = await Promise.all(
+    specs.map(async (spec) => {
+      const expected = expectedVersion(spec);
+
+      for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        const actual = options.readVersion(spec);
+        if (actual === expected) return undefined;
+
+        if (attempt < attempts) {
+          options.onRetry?.(spec, attempt, attempts);
+          await wait(delayMs);
+        } else {
+          return `${spec} (registry: ${actual ?? "not found"})`;
+        }
+      }
+
+      return `${spec} (registry: not found)`;
+    }),
+  );
+
+  return failures.filter((failure) => failure !== undefined);
+};

--- a/scripts/publish.test.ts
+++ b/scripts/publish.test.ts
@@ -2,18 +2,9 @@ import { describe, expect, test } from "vitest";
 import { resolveReleaseTag, verifyPublishedSpecs } from "./publish-utils.ts";
 
 describe("resolveReleaseTag", () => {
-  test("uses the explicit tag for a manual recovery run", () => {
-    expect(
-      resolveReleaseTag("v0.4.1-alpha.2", "fix: make publishing resilient", [
-        "0.4.1",
-        "0.4.1-alpha.2",
-      ]),
-    ).toBe("v0.4.1-alpha.2");
-  });
-
   test("reads the tag from a squash-merged release commit", () => {
     expect(
-      resolveReleaseTag(undefined, "chore: release v0.4.1-alpha.2 (#62)", [
+      resolveReleaseTag("chore: release v0.4.1-alpha.2 (#62)", [
         "0.4.1",
         "0.4.1-alpha.2",
       ]),
@@ -22,10 +13,22 @@ describe("resolveReleaseTag", () => {
 
   test("rejects a tag that does not match a publishable package", () => {
     expect(() =>
-      resolveReleaseTag("v0.4.2", "", ["0.4.1", "0.4.1-alpha.2"]),
+      resolveReleaseTag("chore: release v0.4.2 (#63)", [
+        "0.4.1",
+        "0.4.1-alpha.2",
+      ]),
     ).toThrow(
       "release tag v0.4.2 does not match a publishable package version",
     );
+  });
+
+  test("rejects a commit that is not a release", () => {
+    expect(() =>
+      resolveReleaseTag("fix: make publishing resilient", [
+        "0.4.1",
+        "0.4.1-alpha.2",
+      ]),
+    ).toThrow("cannot derive release tag from a 'chore: release v...' commit");
   });
 });
 

--- a/scripts/publish.test.ts
+++ b/scripts/publish.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+import { resolveReleaseTag, verifyPublishedSpecs } from "./publish-utils.ts";
+
+describe("resolveReleaseTag", () => {
+  test("uses the explicit tag for a manual recovery run", () => {
+    expect(
+      resolveReleaseTag("v0.4.1-alpha.2", "fix: make publishing resilient", [
+        "0.4.1",
+        "0.4.1-alpha.2",
+      ]),
+    ).toBe("v0.4.1-alpha.2");
+  });
+
+  test("reads the tag from a squash-merged release commit", () => {
+    expect(
+      resolveReleaseTag(undefined, "chore: release v0.4.1-alpha.2 (#62)", [
+        "0.4.1",
+        "0.4.1-alpha.2",
+      ]),
+    ).toBe("v0.4.1-alpha.2");
+  });
+
+  test("rejects a tag that does not match a publishable package", () => {
+    expect(() =>
+      resolveReleaseTag("v0.4.2", "", ["0.4.1", "0.4.1-alpha.2"]),
+    ).toThrow(
+      "release tag v0.4.2 does not match a publishable package version",
+    );
+  });
+});
+
+describe("verifyPublishedSpecs", () => {
+  test("checks packages in parallel while npm metadata becomes visible", async () => {
+    const first = "@docukit/docsync@0.4.1-alpha.2";
+    const second = "@docukit/docsync-react@0.4.1-alpha.2";
+    const reads = new Map<string, number>();
+    const trace: string[] = [];
+
+    const failures = await verifyPublishedSpecs([first, second], {
+      attempts: 3,
+      delayMs: 0,
+      readVersion: (spec) => {
+        trace.push(spec);
+        const count = (reads.get(spec) ?? 0) + 1;
+        reads.set(spec, count);
+        return count === 2 ? "0.4.1-alpha.2" : undefined;
+      },
+      wait: async () => Promise.resolve(),
+    });
+
+    expect(failures).toStrictEqual([]);
+    expect(trace.slice(0, 2)).toStrictEqual([first, second]);
+  });
+
+  test("reports packages still missing after the retry window", async () => {
+    const spec = "@docukit/docsync@0.4.1-alpha.2";
+
+    const failures = await verifyPublishedSpecs([spec], {
+      attempts: 2,
+      delayMs: 0,
+      readVersion: () => undefined,
+      wait: async () => Promise.resolve(),
+    });
+
+    expect(failures).toStrictEqual([`${spec} (registry: not found)`]);
+  });
+});

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -11,6 +11,7 @@ import { execSync } from "node:child_process";
 import { join, resolve, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { resolveReleaseTag, verifyPublishedSpecs } from "./publish-utils.ts";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -32,11 +33,6 @@ const capture = (cmd: string): string | undefined => {
     return undefined;
   }
 };
-const sleep = (ms: number): Promise<void> =>
-  new Promise((resolveSleep) => {
-    setTimeout(resolveSleep, ms);
-  });
-
 function readWorkspaceGlobs(): string[] {
   const yaml = readFileSync(join(ROOT, "pnpm-workspace.yaml"), "utf8");
   const globs: string[] = [];
@@ -88,6 +84,18 @@ if (loaded.length === 0) {
   process.exit(1);
 }
 
+let releaseTag: string;
+try {
+  releaseTag = resolveReleaseTag(
+    process.env.RELEASE_TAG,
+    captureRequired("git log -1 --pretty=%s"),
+    loaded.flatMap(({ pkg }) => (pkg.version ? [pkg.version] : [])),
+  );
+} catch (error) {
+  console.error(`✖ ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}
+
 const packDir = mkdtempSync(join(tmpdir(), "docukit-publish-"));
 
 const results: { published: string[]; skipped: string[]; failed: string[] } = {
@@ -120,40 +128,25 @@ for (const { dir, pkg } of loaded) {
       `npm publish ${JSON.stringify(tarball)} --access public --provenance${tagFlag}`,
     );
     results.published.push(spec);
-  } catch (err) {
+  } catch (error) {
     results.failed.push(spec);
-    console.error(`✖ publish failed for ${spec}: ${(err as Error).message}`);
+    console.error(
+      `✖ publish failed for ${spec}: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }
 
-const verifySpec = async (spec: string): Promise<string | undefined> => {
-  const parts = spec.split("@");
-  const expected = parts[parts.length - 1];
-  const attempts = 8;
-  const delayMs = 5_000;
-
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const actual = capture(`npm view ${spec} version 2>/dev/null`);
-    if (actual === expected) return undefined;
-
-    if (attempt < attempts) {
+const verifyFailed = await verifyPublishedSpecs(
+  [...results.published, ...results.skipped],
+  {
+    readVersion: (spec) => capture(`npm view ${spec} version 2>/dev/null`),
+    onRetry: (spec, attempt, attempts) => {
       console.log(
         `Waiting for ${spec} to appear on npm (${attempt}/${attempts})...`,
       );
-      await sleep(delayMs);
-    } else {
-      return `${spec} (registry: ${actual ?? "not found"})`;
-    }
-  }
-
-  return `${spec} (registry: not found)`;
-};
-
-const verifyFailed: string[] = [];
-for (const spec of [...results.published, ...results.skipped]) {
-  const failure = await verifySpec(spec);
-  if (failure) verifyFailed.push(failure);
-}
+    },
+  },
+);
 
 console.log("\n=== Publish summary ===");
 console.log(`published (${results.published.length}):`);
@@ -170,17 +163,7 @@ if (verifyFailed.length) {
 
 if (results.failed.length || verifyFailed.length) process.exit(1);
 
-// Release tag: prefer a stable (non-alpha) version. If only alpha packages exist,
-// use the full alpha version. Sort by package name for determinism.
-const sorted = [...loaded].sort((a, b) => a.pkg.name.localeCompare(b.pkg.name));
-const stable = sorted.find((l) => !l.pkg.version?.includes("-alpha."));
-const releaseVersion = (stable ?? sorted[0])?.pkg.version;
-if (!releaseVersion) {
-  console.error("✖ cannot derive release tag");
-  process.exit(1);
-}
-
 if (process.env.GITHUB_OUTPUT) {
-  appendFileSync(process.env.GITHUB_OUTPUT, `release_tag=v${releaseVersion}\n`);
+  appendFileSync(process.env.GITHUB_OUTPUT, `release_tag=${releaseTag}\n`);
 }
-console.log(`\n✓ release tag: v${releaseVersion}`);
+console.log(`\n✓ release tag: ${releaseTag}`);

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -161,11 +161,14 @@ console.log(`failed (${results.failed.length}):`);
 for (const s of results.failed) console.log(`  ✖ ${s}`);
 
 if (verifyFailed.length) {
-  console.error("\n✖ post-publish verification failed:");
-  for (const s of verifyFailed) console.error(`  - ${s}`);
+  console.warn("\n⚠ npm registry propagation is still pending:");
+  for (const s of verifyFailed) console.warn(`  - ${s}`);
+  console.warn(
+    "npm accepted the publish; continuing while registry metadata propagates.",
+  );
 }
 
-if (results.failed.length || verifyFailed.length) process.exit(1);
+if (results.failed.length) process.exit(1);
 
 if (process.env.GITHUB_OUTPUT) {
   appendFileSync(process.env.GITHUB_OUTPUT, `release_tag=${releaseTag}\n`);

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -86,9 +86,13 @@ if (loaded.length === 0) {
 
 let releaseTag: string;
 try {
+  const releaseCommitSubject = captureRequired(
+    process.env.GITHUB_EVENT_NAME === "workflow_dispatch"
+      ? "git log -1 --format=%s --grep='^chore: release v'"
+      : "git log -1 --pretty=%s",
+  );
   releaseTag = resolveReleaseTag(
-    process.env.RELEASE_TAG,
-    captureRequired("git log -1 --pretty=%s"),
+    releaseCommitSubject,
     loaded.flatMap(({ pkg }) => (pkg.version ? [pkg.version] : [])),
   );
 } catch (error) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "ultimate-tooling/bundler/dom",
   "exclude": ["packages", "docs", "playwright", "tests", "examples"],
-  "compilerOptions": { "exactOptionalPropertyTypes": true }
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "exactOptionalPropertyTypes": true
+  }
 }


### PR DESCRIPTION
## Summary

- verify npm packages concurrently for up to five minutes
- treat delayed npm registry metadata as a warning after npm has accepted the publish; only a real npm publish failure blocks the release
- derive automatic release tags from the release commit and make manual recovery find the most recent release commit automatically
- make .agents/skills/release the canonical release skill while keeping Claude support through a symlink
- correct the skill so alpha tags are derived only from packages changed by the bump

## Verification

- SKIP_ENV_VALIDATION=true pnpm build
- pnpm fix
- pnpm test:coverage:once (768 passed; docnode 100% statements/functions/lines)
- actionlint .github/workflows/release.yml
- Codex skill quick_validate.py

## Recovery after merge

Run the Release workflow manually without inputs. It finds chore: release v0.4.1-alpha.2 (#62), skips the npm versions that already exist, and continues with the missing GitHub release and deployment steps.