### PR TITLE
feat(docnode)!: add scoped skipUndo without forcing transactions

### DIFF
--- a/docs/content/docs/docnode/operations-and-diff.mdx
+++ b/docs/content/docs/docnode/operations-and-diff.mdx
@@ -73,7 +73,7 @@ You can replay operations into the same or another document:
 
 ```ts
 doc.applyOperations(operations);
-doc.skipUndo(() => doc.applyOperations(operations));
+doc.undoManager.skipUndo(() => doc.applyOperations(operations));
 ```
 
 In OT mode, the set of operations must be ordered. For all clients to converge on the same document, they must apply the same operations in the same order. Therefore, a central server is required as the source of truth.

--- a/docs/content/docs/docnode/operations-and-diff.mdx
+++ b/docs/content/docs/docnode/operations-and-diff.mdx
@@ -73,7 +73,7 @@ You can replay operations into the same or another document:
 
 ```ts
 doc.applyOperations(operations);
-doc.applyOperations(operations, { skipUndo: true });
+doc.skipUndo(() => doc.applyOperations(operations));
 ```
 
 In OT mode, the set of operations must be ordered. For all clients to converge on the same document, they must apply the same operations in the same order. Therefore, a central server is required as the source of truth.

--- a/docs/content/docs/docnode/overview.mdx
+++ b/docs/content/docs/docnode/overview.mdx
@@ -122,6 +122,5 @@ doc.undoManager.isEnabled; // Check if maxUndoSteps is greater than 0
 doc.undoManager.onPush(callback); // Listen when a step is pushed to undo or redo
 doc.undoManager.onPop(callback); // Listen after undo or redo pops a step
 
-doc.skipUndo(callback); // Exclude synchronous mutations without forcing a commit
-doc.skipUndo(() => doc.applyOperations(operations)); // Apply operations without adding to undo history
+doc.undoManager.skipUndo(callback); // Exclude synchronous mutations from undo history
 ```

--- a/docs/content/docs/docnode/overview.mdx
+++ b/docs/content/docs/docnode/overview.mdx
@@ -122,6 +122,6 @@ doc.undoManager.isEnabled; // Check if maxUndoSteps is greater than 0
 doc.undoManager.onPush(callback); // Listen when a step is pushed to undo or redo
 doc.undoManager.onPop(callback); // Listen after undo or redo pops a step
 
-doc.forceCommit(callback, { skipUndo: true }); // Commit without adding to undo history
-doc.applyOperations(operations, { skipUndo: true }); // Apply operations without adding to undo history
+doc.skipUndo(callback); // Exclude synchronous mutations without forcing a commit
+doc.skipUndo(() => doc.applyOperations(operations)); // Apply operations without adding to undo history
 ```

--- a/docs/content/docs/docnode/undo-manager.mdx
+++ b/docs/content/docs/docnode/undo-manager.mdx
@@ -52,9 +52,50 @@ If `undoManager` is omitted, `maxUndoSteps` defaults to `0`.
 Use `skipUndo` for changes that should not become undoable, such as initial content, imports, or remote operations.
 
 ```ts
-doc.forceCommit(() => seedInitialContent(doc), { skipUndo: true });
-doc.applyOperations(remoteOperations, { skipUndo: true });
+doc.skipUndo(() => seedInitialContent(doc));
+doc.skipUndo(() => doc.applyOperations(remoteOperations));
 ```
+
+`doc.skipUndo(callback)` is synchronous, returns the callback's result, and can
+be nested. It affects only this document. It does not start or commit a
+transaction; subsequent mutations can still belong to the same transaction.
+Promises and async callbacks are unsupported. Do not start asynchronous work
+inside this scope: the wrapper cannot cancel a scheduled continuation.
+
+```ts
+const page = doc.skipUndo(() => {
+  const page = doc.createNode(PageNode);
+  trash.append(page);
+  return page;
+});
+page.move(projects, "append");
+// One transaction. Undo moves the same page back to trash; redo moves it out.
+```
+
+Change events and synchronization still include **all** mutations. Their
+`inverseOperations` revert the complete transaction, including excluded changes.
+The undo manager records only the undoable portions. Aborting a transaction also
+rolls back excluded changes. An excluded-only change does not clear redo.
+The event's `flags.skipUndo` describes a change with no undoable inverse; it
+cannot describe the individual portions of a mixed change.
+
+`onNormalize` mutations remain undoable, even when the triggering mutation was
+excluded. Use `doc.skipUndo` **inside the normalizer** to exclude its corrections.
+Initialization retains its existing exclusion from user history.
+
+Skipping is not protection from later undo: undoing a parent's creation can
+remove children added in an excluded scope. For repeated writes to the same
+field, the first undoable write in each portion captures the value immediately
+before it; earlier undoable writes can still overwrite later excluded values.
+
+### Migration
+
+The flags arguments of `forceCommit` and `applyOperations` have been removed.
+Replace `doc.applyOperations(ops, { skipUndo: true })` with
+`doc.skipUndo(() => doc.applyOperations(ops))`. Replace
+`doc.forceCommit(callback, { skipUndo: true })` with `doc.skipUndo(callback)`,
+or `doc.skipUndo(() => doc.forceCommit(callback))` if a synchronous commit is
+needed. `applyOperations` keeps its own transaction boundaries.
 
 <Callout type="info">
   The first transaction created in the same microtask as a new `Doc` is skipped

--- a/docs/content/docs/docnode/undo-manager.mdx
+++ b/docs/content/docs/docnode/undo-manager.mdx
@@ -52,18 +52,21 @@ If `undoManager` is omitted, `maxUndoSteps` defaults to `0`.
 Use `skipUndo` for changes that should not become undoable, such as initial content, imports, or remote operations.
 
 ```ts
-doc.skipUndo(() => seedInitialContent(doc));
-doc.skipUndo(() => doc.applyOperations(remoteOperations));
+doc.undoManager.skipUndo(() => seedInitialContent(doc));
+doc.undoManager.skipUndo(() => doc.applyOperations(remoteOperations));
 ```
 
-`doc.skipUndo(callback)` is synchronous, returns the callback's result, and can
+`doc.undoManager.skipUndo(callback)` is synchronous, returns the callback's result, and can
 be nested. It affects only this document. It does not start or commit a
 transaction; subsequent mutations can still belong to the same transaction.
+If the callback throws, the active transaction is rolled back, including changes
+made before entering the scope. The callback error is rethrown.
+
 Promises and async callbacks are unsupported. Do not start asynchronous work
 inside this scope: the wrapper cannot cancel a scheduled continuation.
 
 ```ts
-const page = doc.skipUndo(() => {
+const page = doc.undoManager.skipUndo(() => {
   const page = doc.createNode(PageNode);
   trash.append(page);
   return page;
@@ -72,30 +75,49 @@ page.move(projects, "append");
 // One transaction. Undo moves the same page back to trash; redo moves it out.
 ```
 
-Change events and synchronization still include **all** mutations. Their
-`inverseOperations` revert the complete transaction, including excluded changes.
-The undo manager records only the undoable portions. Aborting a transaction also
+Mutations excluded from undo still appear in content change events and
+synchronization. Their `inverseOperations` revert the complete transaction,
+including excluded changes.
+The undo manager records only undoable mutations. Aborting a transaction also
 rolls back excluded changes. An excluded-only change does not clear redo.
 The event's `flags.skipUndo` describes a change with no undoable inverse; it
 cannot describe the individual portions of a mixed change.
 
+`onChange` also fires when a transaction changes undo history without changing
+the document's final content. For example, creating a node inside `skipUndo`
+and deleting it outside the scope leaves the document unchanged, but undo can
+restore that node. This event has empty `operations` and `inverseOperations`
+(`[[], {}]`) and an empty `diff`. The listener sees the updated undo and redo
+state. DocSync's DocNode bindings ignore these history-only events.
+
+A transaction with no effect on either content or history emits no event.
+In particular, an empty `skipUndo` callback, or one whose changes cancel out,
+does not prevent surrounding undoable writes from cancelling each other.
+
 `onNormalize` mutations remain undoable, even when the triggering mutation was
-excluded. Use `doc.skipUndo` **inside the normalizer** to exclude its corrections.
+excluded. Use `doc.undoManager.skipUndo` **inside the normalizer** to exclude its corrections.
 Initialization retains its existing exclusion from user history.
 
 Skipping is not protection from later undo: undoing a parent's creation can
 remove children added in an excluded scope. For repeated writes to the same
-field, the first undoable write in each portion captures the value immediately
-before it; earlier undoable writes can still overwrite later excluded values.
+field, undo captures the value immediately before its first undoable write.
+Earlier undoable writes can still overwrite later excluded values. Writes that
+return to that undo value do not leave an empty state-change step in history.
 
 ### Migration
 
 The flags arguments of `forceCommit` and `applyOperations` have been removed.
 Replace `doc.applyOperations(ops, { skipUndo: true })` with
-`doc.skipUndo(() => doc.applyOperations(ops))`. Replace
-`doc.forceCommit(callback, { skipUndo: true })` with `doc.skipUndo(callback)`,
-or `doc.skipUndo(() => doc.forceCommit(callback))` if a synchronous commit is
+`doc.undoManager.skipUndo(() => doc.applyOperations(ops))`. Replace
+`doc.forceCommit(callback, { skipUndo: true })` with `doc.undoManager.skipUndo(callback)`,
+or `doc.undoManager.skipUndo(() => doc.forceCommit(callback))` if a synchronous commit is
 needed. `applyOperations` keeps its own transaction boundaries.
+
+The old transaction-wide flag also excluded normalization. The wrapper excludes
+only mutations in its scope: use an explicit `doc.undoManager.skipUndo` inside
+the normalizer if its corrections should also be excluded. Combining work into
+one transaction also means normalization runs on the combined result and an
+error can roll back changes that previously belonged to separate transactions.
 
 <Callout type="info">
   The first transaction created in the same microtask as a new `Doc` is skipped

--- a/packages/docnode-lexical/src/syncLexicalToDocNode.ts
+++ b/packages/docnode-lexical/src/syncLexicalToDocNode.ts
@@ -72,7 +72,7 @@ export function syncLexicalToDocNode(
         };
 
         if (tags.has(SKIP_UNDO_TAG)) {
-          doc.forceCommit(syncToDocNode, { skipUndo: true });
+          doc.skipUndo(() => doc.forceCommit(syncToDocNode));
         } else {
           syncToDocNode();
           // Force commit to trigger onChange handlers

--- a/packages/docnode-lexical/src/syncLexicalToDocNode.ts
+++ b/packages/docnode-lexical/src/syncLexicalToDocNode.ts
@@ -72,7 +72,7 @@ export function syncLexicalToDocNode(
         };
 
         if (tags.has(SKIP_UNDO_TAG)) {
-          doc.skipUndo(() => doc.forceCommit(syncToDocNode));
+          doc.undoManager.skipUndo(() => doc.forceCommit(syncToDocNode));
         } else {
           syncToDocNode();
           // Force commit to trigger onChange handlers

--- a/packages/docnode/src/main.ts
+++ b/packages/docnode/src/main.ts
@@ -556,64 +556,8 @@ export class Doc {
   protected _inverseOperations: ops.Operations = [[], {}];
   protected _transactionFlags: TransactionFlags;
   private _isForceCommitCallback = false;
-  protected _skipUndoDepth = 0;
-  private _undoCapture: ReturnType<typeof ops.createCapture> | undefined;
-  private _undoPortions: ops.Operations[] = [];
-  protected _undoInverseOperations: ops.Operations = [[], {}];
-
-  protected _getUndoCapture() {
-    if (
-      this._skipUndoDepth ||
-      this._transactionFlags?.skipUndo ||
-      !this.undoManager
-    )
-      return;
-    return (this._undoCapture ??= ops.createCapture());
-  }
-
-  protected _finishUndoPortion() {
-    const capture = this._undoCapture;
-    if (!capture) return;
-    const { diff, operations, inverseOperations } = capture;
-    if (
-      diff.inserted.size ||
-      diff.deleted.size ||
-      diff.moved.size ||
-      !isObjectEmpty(operations[1])
-    ) {
-      inverseOperations[0].reverse();
-      this._undoPortions.push(inverseOperations);
-    }
-    this._undoCapture = undefined;
-    this._undoInverseOperations = ops.mergeOperations(
-      ...this._undoPortions.slice().reverse(),
-    );
-  }
-
-  /** Excludes only synchronous mutations in the callback from user undo.
-   * Does not commit. Rollback and change events still include every mutation.
-   */
-  skipUndo<T>(callback: () => T extends PromiseLike<unknown> ? never : T): T {
-    this._finishUndoPortion();
-    this._skipUndoDepth++;
-    try {
-      const result = callback();
-      if (
-        result !== null &&
-        (typeof result === "object" || typeof result === "function") &&
-        "then" in result &&
-        typeof result.then === "function"
-      ) {
-        throw new Error("skipUndo requires a synchronous callback");
-      }
-      return result;
-    } catch (error) {
-      if (this._lifeCycleStage === "update") this.abort();
-      throw error;
-    } finally {
-      this._skipUndoDepth--;
-    }
-  }
+  // Absent when the full transaction inverse is also the user-undo inverse.
+  protected _undoChanges: ReturnType<typeof ops.createUndoChanges> | undefined;
 
   protected _diff: Diff = {
     deleted: new Map(),
@@ -801,13 +745,14 @@ export class Doc {
       ? nodeIdFactory(this, idGen.extractTime)
       : idGen.generate;
 
+    this.undoManager = new UndoManager(this, config.undoManager);
+    this._transactionFlags = { skipUndo: true };
     this._lifeCycleStage = "init";
     config.extensions.forEach((extension) => {
       extension.register?.(this);
     });
     this._lifeCycleStage = "idle";
     this._forceCommit(true);
-    this.undoManager = new UndoManager(this, config.undoManager);
     this._transactionFlags = { skipUndo: true };
     // If the first tx happens in the same microtask the doc is created,
     // we can skip the undo manager for that tx.
@@ -1078,9 +1023,7 @@ export class Doc {
     ops.maybeTriggerListeners(this, ignoreEmptyDiff);
     this._operations = [[], {}];
     this._inverseOperations = [[], {}];
-    this._undoCapture = undefined;
-    this._undoPortions = [];
-    this._undoInverseOperations = [[], {}];
+    this._undoChanges = undefined;
     this._transactionFlags = {};
     this._diff = {
       deleted: new Map(),
@@ -1108,9 +1051,7 @@ export class Doc {
     );
     this["_operations"] = [[], {}];
     this["_inverseOperations"] = [[], {}];
-    this._undoCapture = undefined;
-    this._undoPortions = [];
-    this._undoInverseOperations = [[], {}];
+    this._undoChanges = undefined;
     this["_transactionFlags"] = {};
     this["_diff"] = {
       deleted: new Map(),

--- a/packages/docnode/src/main.ts
+++ b/packages/docnode/src/main.ts
@@ -552,25 +552,26 @@ export class Doc {
     | "normalize2"
     | "change"
     | "disposed" = "idle";
-  protected _operations: ops.Operations = [[], {}];
-  protected _inverseOperations: ops.Operations = [[], {}];
+  protected _operations!: ops.Operations;
+  protected _inverseOperations!: ops.Operations;
   protected _transactionFlags: TransactionFlags;
   private _isForceCommitCallback = false;
-  // Absent when the full transaction inverse is also the user-undo inverse.
-  protected _undoChanges: ReturnType<typeof ops.createUndoChanges> | undefined;
-
-  protected _diff: Diff = {
-    deleted: new Map(),
-    inserted: new Set(),
-    moved: new Set(),
-    updated: new Set(),
-  };
+  protected _diff!: Diff;
+  // Rollback and change events use the full transaction bookkeeping. `_undo`
+  // exists only after a mutation inside `skipUndo` and sees the undoable
+  // mutations from then on; it becomes the undo step. See `ops.Tracker`.
+  protected _full!: ops.Tracker;
+  protected _undo: ops.Tracker | undefined;
+  // Cached so that mutations never allocate: [full] and [full, undo].
+  private _fullOnly!: [ops.Tracker];
+  private _trackers!: ops.Tracker[];
   protected _nodeIdGenerator: (doc: Doc) => string;
   protected _idGen: NodeIdGenerator;
   readonly root: DocNode;
   readonly undoManager: UndoManager;
 
   constructor(config: DocConfig) {
+    this._resetTransaction();
     this._nodeDefs = new Set();
     this._resolvedNodeDefs = new Map();
     const RootNode = defineNode({ type: config.type });
@@ -1021,9 +1022,13 @@ export class Doc {
     // End update stage before normalization
     this._lifeCycleStage = "idle";
     ops.maybeTriggerListeners(this, ignoreEmptyDiff);
+    this._resetTransaction();
+    this._lifeCycleStage = "idle";
+  }
+
+  private _resetTransaction() {
     this._operations = [[], {}];
     this._inverseOperations = [[], {}];
-    this._undoChanges = undefined;
     this._transactionFlags = {};
     this._diff = {
       deleted: new Map(),
@@ -1031,7 +1036,15 @@ export class Doc {
       moved: new Set(),
       updated: new Set(),
     };
-    this._lifeCycleStage = "idle";
+    this._full = {
+      inverse: this._inverseOperations,
+      inserted: this._diff.inserted,
+      deleted: this._diff.deleted,
+      moved: this._diff.moved,
+    };
+    this._undo = undefined;
+    this._fullOnly = [this._full];
+    this._trackers = this._fullOnly;
   }
 
   /**
@@ -1049,16 +1062,7 @@ export class Doc {
       },
       true,
     );
-    this["_operations"] = [[], {}];
-    this["_inverseOperations"] = [[], {}];
-    this._undoChanges = undefined;
-    this["_transactionFlags"] = {};
-    this["_diff"] = {
-      deleted: new Map(),
-      inserted: new Set(),
-      moved: new Set(),
-      updated: new Set(),
-    };
+    this._resetTransaction();
     this["_lifeCycleStage"] = "idle";
   }
 

--- a/packages/docnode/src/main.ts
+++ b/packages/docnode/src/main.ts
@@ -556,6 +556,65 @@ export class Doc {
   protected _inverseOperations: ops.Operations = [[], {}];
   protected _transactionFlags: TransactionFlags;
   private _isForceCommitCallback = false;
+  protected _skipUndoDepth = 0;
+  private _undoCapture: ReturnType<typeof ops.createCapture> | undefined;
+  private _undoPortions: ops.Operations[] = [];
+  protected _undoInverseOperations: ops.Operations = [[], {}];
+
+  protected _getUndoCapture() {
+    if (
+      this._skipUndoDepth ||
+      this._transactionFlags?.skipUndo ||
+      !this.undoManager
+    )
+      return;
+    return (this._undoCapture ??= ops.createCapture());
+  }
+
+  protected _finishUndoPortion() {
+    const capture = this._undoCapture;
+    if (!capture) return;
+    const { diff, operations, inverseOperations } = capture;
+    if (
+      diff.inserted.size ||
+      diff.deleted.size ||
+      diff.moved.size ||
+      !isObjectEmpty(operations[1])
+    ) {
+      inverseOperations[0].reverse();
+      this._undoPortions.push(inverseOperations);
+    }
+    this._undoCapture = undefined;
+    this._undoInverseOperations = ops.mergeOperations(
+      ...this._undoPortions.slice().reverse(),
+    );
+  }
+
+  /** Excludes only synchronous mutations in the callback from user undo.
+   * Does not commit. Rollback and change events still include every mutation.
+   */
+  skipUndo<T>(callback: () => T extends PromiseLike<unknown> ? never : T): T {
+    this._finishUndoPortion();
+    this._skipUndoDepth++;
+    try {
+      const result = callback();
+      if (
+        result !== null &&
+        (typeof result === "object" || typeof result === "function") &&
+        "then" in result &&
+        typeof result.then === "function"
+      ) {
+        throw new Error("skipUndo requires a synchronous callback");
+      }
+      return result;
+    } catch (error) {
+      if (this._lifeCycleStage === "update") this.abort();
+      throw error;
+    } finally {
+      this._skipUndoDepth--;
+    }
+  }
+
   protected _diff: Diff = {
     deleted: new Map(),
     inserted: new Set(),
@@ -953,7 +1012,7 @@ export class Doc {
     this._normalizeListeners.add(callback);
   }
 
-  applyOperations(operations: ops.Operations, flags?: TransactionFlags) {
+  applyOperations(operations: ops.Operations) {
     const hasOperations =
       operations[0].length > 0 || !isObjectEmpty(operations[1]);
     if (!hasOperations) {
@@ -973,7 +1032,6 @@ export class Doc {
     }
     if (this._lifeCycleStage === "update") this.forceCommit();
     let didApplyOperations = false;
-    if (flags) this._transactionFlags = flags;
     withTransaction(
       this,
       () => {
@@ -992,8 +1050,8 @@ export class Doc {
    * Using forceCommit is uncommon and can hurt your app's performance.
    */
   forceCommit(): void;
-  forceCommit(callback: () => void, flags: TransactionFlags): void;
-  forceCommit(callback?: () => void, flags?: TransactionFlags): void {
+  forceCommit(callback: () => void): void;
+  forceCommit(callback?: () => void): void {
     if (this._isForceCommitCallback) {
       throw new Error(
         "You can't call forceCommit inside a forceCommit callback",
@@ -1001,7 +1059,7 @@ export class Doc {
     }
     this._forceCommit();
     if (!callback) return;
-    this._transactionFlags = flags ?? {};
+    this._transactionFlags = {};
     this._isForceCommitCallback = true;
     try {
       withTransaction(this, callback);
@@ -1015,13 +1073,14 @@ export class Doc {
   private _forceCommit(ignoreEmptyDiff = false) {
     if (this._lifeCycleStage === "change")
       throw new Error("You can't trigger an update inside a change event");
-    // push + reverse is more performant than unshift at insertion time
-    this._inverseOperations[0].reverse();
     // End update stage before normalization
     this._lifeCycleStage = "idle";
     ops.maybeTriggerListeners(this, ignoreEmptyDiff);
     this._operations = [[], {}];
     this._inverseOperations = [[], {}];
+    this._undoCapture = undefined;
+    this._undoPortions = [];
+    this._undoInverseOperations = [[], {}];
     this._transactionFlags = {};
     this._diff = {
       deleted: new Map(),
@@ -1036,7 +1095,10 @@ export class Doc {
    * Aborts the current transaction and rolls back all changes.
    */
   abort() {
-    const inverseOps: ops.Operations = [...this["_inverseOperations"]];
+    const inverseOps: ops.Operations = [
+      this._inverseOperations[0].slice().reverse(),
+      this._inverseOperations[1],
+    ];
     withTransaction(
       this,
       () => {
@@ -1046,6 +1108,9 @@ export class Doc {
     );
     this["_operations"] = [[], {}];
     this["_inverseOperations"] = [[], {}];
+    this._undoCapture = undefined;
+    this._undoPortions = [];
+    this._undoInverseOperations = [[], {}];
     this["_transactionFlags"] = {};
     this["_diff"] = {
       deleted: new Map(),

--- a/packages/docnode/src/operations.ts
+++ b/packages/docnode/src/operations.ts
@@ -31,63 +31,189 @@ export function parseStateKey(
   return stateValue;
 }
 
-// Each transaction has its complete capture and, when history is enabled,
-// a capture of the current contiguous undoable portion. Sharing the recorder
-// keeps insertion/deletion optimizations identical without filtering a diff
-// that has already lost intermediate values.
-export function createCapture() {
-  const operations: Operations = [[], {}];
-  const inverseOperations: Operations = [[], {}];
-  const diff: Diff = {
-    inserted: new Set(),
-    deleted: new Map(),
-    moved: new Set(),
-    updated: new Set(),
-  };
-  return { operations, inverseOperations, diff };
+// The existing transaction inverse is the base. Only disagreements with user
+// undo are stored here: alternate state, structural membership, and omitted or
+// undo-only inverse operations. Ordinary transactions allocate none of this.
+export function createUndoChanges() {
+  const changes: {
+    nodes?: Map<
+      string,
+      {
+        inserted?: boolean;
+        deleted?: boolean;
+        moved?: boolean;
+        state?: Map<string, string | undefined>;
+      }
+    >;
+    ordered?: Map<number, { omit?: true; before?: OrderedOperation[] }>;
+  } = {};
+  return changes;
 }
 
-type Capture = ReturnType<typeof createCapture>;
+function nodeUndoChanges(doc: Doc, id: string) {
+  const changes = (doc["_undoChanges"] ??= createUndoChanges());
+  const nodes = (changes.nodes ??= new Map());
+  let node = nodes.get(id);
+  if (!node) {
+    node = {};
+    nodes.set(id, node);
+  }
+  return node;
+}
 
-function captureChange(doc: Doc, callback: (capture: Capture) => void) {
-  callback({
-    operations: doc["_operations"],
-    inverseOperations: doc["_inverseOperations"],
-    diff: doc["_diff"],
-  });
-  const history = doc["_getUndoCapture"]();
-  if (history) callback(history);
+function trimUndoChanges(doc: Doc, id: string) {
+  const changes = doc["_undoChanges"];
+  const node = changes?.nodes?.get(id);
+  if (node) {
+    if (node.state?.size === 0) delete node.state;
+    if (isObjectEmpty(node)) changes!.nodes!.delete(id);
+  }
+  if (changes?.nodes?.size === 0) delete changes.nodes;
+  if (changes && isObjectEmpty(changes)) doc["_undoChanges"] = undefined;
+}
+
+function isExcluded(doc: Doc) {
+  // Initialization is excluded as a whole at commit and needs no differences.
+  return (
+    !doc["_transactionFlags"]?.skipUndo &&
+    Boolean(doc.undoManager?.["_skipUndoDepth"])
+  );
+}
+
+function undoHas(doc: Doc, kind: "inserted" | "deleted" | "moved", id: string) {
+  return (
+    doc["_undoChanges"]?.nodes?.get(id)?.[kind] ?? doc["_diff"][kind].has(id)
+  );
+}
+
+function setMembership(
+  doc: Doc,
+  node: DocNode,
+  kind: "inserted" | "deleted" | "moved",
+  full: boolean,
+  undo: boolean,
+) {
+  const diff = doc["_diff"];
+  if (!full) diff[kind].delete(node.id);
+  else if (kind === "deleted") diff.deleted.set(node.id, node);
+  else diff[kind].add(node.id);
+  if (full !== undo) nodeUndoChanges(doc, node.id)[kind] = undo;
+  else {
+    const change = doc["_undoChanges"]?.nodes?.get(node.id);
+    if (change) delete change[kind];
+    trimUndoChanges(doc, node.id);
+  }
+}
+
+// Missing key means inherit the full inverse; a stored undefined means omit it.
+function undoValue(doc: Doc, id: string, key: string) {
+  const state = doc["_undoChanges"]?.nodes?.get(id)?.state;
+  return state?.has(key)
+    ? state.get(key)
+    : doc["_inverseOperations"][1][id]?.[key];
+}
+
+function setInverseValue(
+  doc: Doc,
+  id: string,
+  key: string,
+  full: string | undefined,
+  undo: string | undefined,
+) {
+  const state = doc["_inverseOperations"][1];
+  if (full === undefined) {
+    const patch = state[id];
+    if (patch) {
+      delete patch[key];
+      if (isObjectEmpty(patch)) delete state[id];
+    }
+  } else (state[id] ??= {})[key] = full;
+  if (full !== undo)
+    (nodeUndoChanges(doc, id).state ??= new Map()).set(key, undo);
+  else {
+    doc["_undoChanges"]?.nodes?.get(id)?.state?.delete(key);
+    trimUndoChanges(doc, id);
+  }
+}
+
+function appendInverse(
+  doc: Doc,
+  operation: OrderedOperation,
+  full: boolean,
+  undo: boolean,
+) {
+  const ordered = doc["_inverseOperations"][0];
+  // Full ordered inverses are append-only until commit. This index also names
+  // the gap before the next full inverse, for operations needed only by undo.
+  const at = ordered.length;
+  if (full) ordered.push(operation);
+  if (full === undo) return;
+  const changes = (doc["_undoChanges"] ??= createUndoChanges());
+  const exceptions = (changes.ordered ??= new Map());
+  let change = exceptions.get(at);
+  if (!change) {
+    change = {};
+    exceptions.set(at, change);
+  }
+  if (full) change.omit = true;
+  else (change.before ??= []).push(operation);
+}
+
+function hasChanges(diff: Omit<Diff, "updated">, statePatch: StatePatch) {
+  return Boolean(
+    diff.inserted.size ||
+    diff.deleted.size ||
+    diff.moved.size ||
+    !isObjectEmpty(statePatch),
+  );
 }
 
 export const onSetState = {
   operations: (node: DocNode, key: string) => {
-    const valueString = stringifyStateKey(node, key);
-    captureChange(node.doc, ({ operations, inverseOperations, diff }) => {
-      const statePatchs = operations[1];
-      const prevValueString = inverseOperations[1][node.id]?.[key];
-      const nodePatch = statePatchs[node.id];
-      if (prevValueString === valueString && nodePatch) {
-        delete nodePatch[key];
-        if (isObjectEmpty(nodePatch)) {
-          delete statePatchs[node.id];
-          diff.updated.delete(node.id);
+    const doc = node.doc;
+    const value = stringifyStateKey(node, key);
+    const full = doc["_inverseOperations"][1][node.id]?.[key];
+    const undo = undoValue(doc, node.id, key);
+    setInverseValue(
+      doc,
+      node.id,
+      key,
+      full === value ? undefined : full,
+      !isExcluded(doc) && undo === value ? undefined : undo,
+    );
+    if (full === value) {
+      const patch = doc["_operations"][1][node.id];
+      if (patch) {
+        delete patch[key];
+        if (isObjectEmpty(patch)) {
+          delete doc["_operations"][1][node.id];
+          doc["_diff"].updated.delete(node.id);
         }
-        delete inverseOperations[1][node.id]?.[key];
-      } else {
-        (statePatchs[node.id] ??= {})[key] = valueString;
-        if (!diff.inserted.has(node.id)) diff.updated.add(node.id);
       }
-    });
+    } else {
+      (doc["_operations"][1][node.id] ??= {})[key] = value;
+      if (!doc["_diff"].inserted.has(node.id))
+        doc["_diff"].updated.add(node.id);
+    }
   },
   inverseOps: (node: DocNode, key: string) => {
-    captureChange(node.doc, ({ inverseOperations, diff }) => {
-      if (diff.inserted.has(node.id)) return;
-      if (inverseOperations[1][node.id]?.[key] !== undefined) return;
-      (inverseOperations[1][node.id] ??= {})[key] = stringifyStateKey(
-        node,
-        key,
-      );
-    });
+    const doc = node.doc;
+    const full = doc["_inverseOperations"][1][node.id]?.[key];
+    const undo = undoValue(doc, node.id, key);
+    const needsFull = !doc["_diff"].inserted.has(node.id) && full === undefined;
+    const needsUndo =
+      !isExcluded(doc) &&
+      !undoHas(doc, "inserted", node.id) &&
+      undo === undefined;
+    if (!needsFull && !needsUndo) return;
+    const value = stringifyStateKey(node, key);
+    setInverseValue(
+      doc,
+      node.id,
+      key,
+      needsFull ? value : full,
+      needsUndo ? value : undo,
+    );
   },
 };
 
@@ -112,63 +238,76 @@ export const onInsertRange = (
       newParent = target.parent!;
       break;
   }
-  captureChange(doc, (capture) => {
-    const { operations, inverseOperations, diff } = capture;
-
-    operations[0].push([
-      0,
-      nodes.map((node) => [node.id, node.type]),
-      newParent === doc.root ? 0 : newParent.id,
-      newPrev?.id ?? 0,
-      newNext?.id ?? 0,
-    ]);
-    if (newParent && !diff.inserted.has(newParent.id)) {
-      inverseOperations[0].push([
-        1,
-        nodes[0]!.id,
-        nodes.length > 1 ? nodes.at(-1)!.id : 0,
-      ]);
-    }
-    nodes.forEach((topLevelNode) => {
-      copyInsertedToDiff(topLevelNode, capture);
-      topLevelNode.descendants().forEach((node) => {
-        copyInsertedToDiff(node, capture);
-        const parent = node.parent!;
-        const children = getChildren(parent);
-        if (!node.prev) {
-          operations[0].push([
-            0,
-            children.map((child) => [child.id, child.type]),
-            parent.id,
-            0,
-            0,
-          ]);
-          if (!diff.inserted.has(parent.id)) {
-            inverseOperations[0].push([
-              1,
-              node.id,
-              parent.last !== node ? parent.last!.id : 0,
-            ]);
-          }
-        }
-      });
+  doc["_operations"][0].push([
+    0,
+    nodes.map((node) => [node.id, node.type]),
+    newParent === doc.root ? 0 : newParent.id,
+    newPrev?.id ?? 0,
+    newNext?.id ?? 0,
+  ]);
+  const full = !doc["_diff"].inserted.has(newParent.id);
+  const undo = !isExcluded(doc) && !undoHas(doc, "inserted", newParent.id);
+  if (full || undo)
+    appendInverse(
+      doc,
+      [1, nodes[0]!.id, nodes.length > 1 ? nodes.at(-1)!.id : 0],
+      full,
+      undo,
+    );
+  nodes.forEach((topLevelNode) => {
+    copyInsertedToDiff(topLevelNode);
+    topLevelNode.descendants().forEach((node) => {
+      copyInsertedToDiff(node);
+      const parent = node.parent!;
+      if (!node.prev) {
+        doc["_operations"][0].push([
+          0,
+          getChildren(parent).map((child) => [child.id, child.type]),
+          parent.id,
+          0,
+          0,
+        ]);
+        const full = !doc["_diff"].inserted.has(parent.id);
+        const undo = !isExcluded(doc) && !undoHas(doc, "inserted", parent.id);
+        if (full || undo)
+          appendInverse(
+            doc,
+            [1, node.id, parent.last !== node ? parent.last!.id : 0],
+            full,
+            undo,
+          );
+      }
     });
   });
 };
 
-function copyInsertedToDiff(node: DocNode, capture: Capture) {
-  const { diff, operations } = capture;
-  const deletedInSameTransaction = diff.deleted.delete(node.id);
-  if (deletedInSameTransaction) {
-    diff.moved.add(node.id);
-    diff.updated.add(node.id);
-  } else {
-    diff.inserted.add(node.id);
-  }
+function copyInsertedToDiff(node: DocNode) {
+  const doc = node.doc;
+  const diff = doc["_diff"];
+  const deleted = diff.deleted.has(node.id);
+  const undoDeleted = undoHas(doc, "deleted", node.id);
+  const undoInserted = undoHas(doc, "inserted", node.id);
+  const undoMoved = undoHas(doc, "moved", node.id);
+  const excluded = isExcluded(doc);
+  setMembership(doc, node, "deleted", false, excluded ? undoDeleted : false);
+  setMembership(
+    doc,
+    node,
+    "inserted",
+    diff.inserted.has(node.id) || !deleted,
+    excluded ? undoInserted : undoInserted || !undoDeleted,
+  );
+  setMembership(
+    doc,
+    node,
+    "moved",
+    diff.moved.has(node.id) || deleted,
+    excluded ? undoMoved : undoMoved || undoDeleted,
+  );
+  if (deleted) diff.updated.add(node.id);
   // [#4GOSK]
   const jsonState = node["_stateToJson"]();
-  if (isObjectEmpty(jsonState)) return;
-  operations[1][node.id] = jsonState;
+  if (!isObjectEmpty(jsonState)) doc["_operations"][1][node.id] = jsonState;
 }
 
 export const onDeleteRange = (
@@ -176,57 +315,49 @@ export const onDeleteRange = (
   startNode: DocNode,
   endNode: DocNode,
 ) => {
-  captureChange(doc, (capture) => {
-    const operations = capture.operations[0];
-    const inverseOperations = capture.inverseOperations[0];
-    const tempInverseOperations: OrderedOperation[] = [];
-    const parent = startNode.parent!;
-
-    operations.push([1, startNode.id, startNode !== endNode ? endNode.id : 0]);
-    const jsonNodes: [string, string][] = [];
-    startNode.to(endNode).forEach((node) => {
-      jsonNodes.push([node.id, node.type]);
-      copyDeletedToDiff(node, capture);
-    });
-    // If the parent was inserted in the same transaction, it means that
-    // is deleted in inverseOps, so it is not possible to insert descendants.
-    const shouldAddToInverseOps = !capture.diff.inserted.has(parent.id);
-    if (shouldAddToInverseOps) {
-      tempInverseOperations.push([
-        0,
-        jsonNodes,
-        parent === doc.root ? 0 : parent.id,
-        startNode.prev?.id ?? 0,
-        endNode.next?.id ?? 0,
-      ]);
-    }
-
-    startNode.to(endNode).forEach((node) => {
-      node.descendants({ includeSelf: true }).forEach((node) => {
-        delete capture.operations[1][node.id];
-        capture.diff.updated.delete(node.id);
-        if (node.first) {
-          const jsonNodes: [string, string][] = [];
-          node.children().forEach((childNode) => {
-            copyDeletedToDiff(childNode, capture);
-            jsonNodes.push([childNode.id, childNode.type]);
-          });
-          if (shouldAddToInverseOps) {
-            tempInverseOperations.push([0, jsonNodes, node.id, 0, 0]);
-          }
-        }
-      });
-    });
-    /**
-     * All operations are reversed in main.ts. But we reverse the delete operations
-     * again here because they're the only ones that don't need to be reversed
-     * (reversed + reversed = not reversed). This is because descendants are removed
-     * after the ancestors.
-     * TODO: To avoid a reverse and make this more performant, we can use an iterator
-     * other than.descendants().forEach above.
-     */
-    inverseOperations.push(...tempInverseOperations.reverse());
+  const parent = startNode.parent!;
+  doc["_operations"][0].push([
+    1,
+    startNode.id,
+    startNode !== endNode ? endNode.id : 0,
+  ]);
+  const jsonNodes: [string, string][] = [];
+  startNode.to(endNode).forEach((node) => {
+    jsonNodes.push([node.id, node.type]);
+    copyDeletedToDiff(node);
   });
+  // Rollback can omit descendants of a newly inserted parent; undo may still
+  // need them when that parent's insertion was excluded from history.
+  const full = !doc["_diff"].inserted.has(parent.id);
+  const undo = !isExcluded(doc) && !undoHas(doc, "inserted", parent.id);
+  const inverse: OrderedOperation[] = [];
+  if (full || undo)
+    inverse.push([
+      0,
+      jsonNodes,
+      parent === doc.root ? 0 : parent.id,
+      startNode.prev?.id ?? 0,
+      endNode.next?.id ?? 0,
+    ]);
+  startNode.to(endNode).forEach((node) => {
+    node.descendants({ includeSelf: true }).forEach((node) => {
+      delete doc["_operations"][1][node.id];
+      doc["_diff"].updated.delete(node.id);
+      if (node.first) {
+        const children: [string, string][] = [];
+        node.children().forEach((child) => {
+          copyDeletedToDiff(child);
+          children.push([child.id, child.type]);
+        });
+        if (full || undo) inverse.push([0, children, node.id, 0, 0]);
+      }
+    });
+  });
+  // The commit reverses the complete sequence. Reverse this subtree first so
+  // replay still restores each parent before its children.
+  inverse
+    .reverse()
+    .forEach((operation) => appendInverse(doc, operation, full, undo));
   detachRange(startNode, endNode);
 };
 
@@ -238,32 +369,38 @@ export const onMoveRange = (
   newPrev: DocNode | undefined,
   newNext: DocNode | undefined,
 ) => {
-  captureChange(doc, ({ operations, inverseOperations, diff }) => {
-    const endId = endNode.id === startNode.id ? 0 : endNode.id;
-    operations[0].push([
-      2,
-      startNode.id,
-      endId,
-      newParent === doc.root ? 0 : newParent.id,
-      newPrev?.id ?? 0,
-      newNext?.id ?? 0,
-    ]);
-    // TODO: non-null assertion because it doesn't make sense to move root
-    // but should be tested!
-    const currentParent = startNode.parent!;
-    const currentPrev = startNode.prev;
-    const currentNext = endNode.next;
-    inverseOperations[0].push([
+  const endId = endNode.id === startNode.id ? 0 : endNode.id;
+  doc["_operations"][0].push([
+    2,
+    startNode.id,
+    endId,
+    newParent === doc.root ? 0 : newParent.id,
+    newPrev?.id ?? 0,
+    newNext?.id ?? 0,
+  ]);
+  const currentParent = startNode.parent!;
+  appendInverse(
+    doc,
+    [
       2,
       startNode.id,
       endId,
       currentParent === doc.root ? 0 : currentParent.id,
-      currentPrev?.id ?? 0,
-      currentNext?.id ?? 0,
-    ]);
-    startNode.to(endNode).forEach((node) => {
-      if (!diff.inserted.has(node.id)) diff.moved.add(node.id);
-    });
+      startNode.prev?.id ?? 0,
+      endNode.next?.id ?? 0,
+    ],
+    true,
+    !isExcluded(doc),
+  );
+  startNode.to(endNode).forEach((node) => {
+    const moved = undoHas(doc, "moved", node.id);
+    setMembership(
+      doc,
+      node,
+      "moved",
+      doc["_diff"].moved.has(node.id) || !doc["_diff"].inserted.has(node.id),
+      moved || (!isExcluded(doc) && !undoHas(doc, "inserted", node.id)),
+    );
   });
 };
 
@@ -336,18 +473,9 @@ export const onApplyOperations = (doc: Doc, operations: Operations) => {
       patch[key] = value;
     }
     if (isObjectEmpty(patch)) continue;
-    captureChange(doc, ({ operations: current, inverseOperations, diff }) => {
-      current[1][id] = { ...current[1][id], ...patch };
-      if (!diff.inserted.has(id)) diff.updated.add(id);
-      if (!diff.inserted.has(id)) {
-        for (const key in patch) {
-          (inverseOperations[1][id] ??= {})[key] ??= stringifyStateKey(
-            node,
-            key,
-          );
-        }
-      }
-    });
+    doc["_operations"][1][id] = { ...doc["_operations"][1][id], ...patch };
+    if (!inserted) doc["_diff"].updated.add(id);
+    for (const key in patch) onSetState.inverseOps(node, key);
     for (const key in patch) {
       const state = (node as DocNode<UnsafeDefinition>)["_state"];
       state[key] = parseStateKey(node, key, patch[key]!);
@@ -355,78 +483,151 @@ export const onApplyOperations = (doc: Doc, operations: Operations) => {
   }
 };
 
-/** We trigger listeners at the end of each update if there were operations (i.e. something changed) */
+// A transaction can change history without changing content. Such events carry
+// canonical empty operations so content adapters can ignore them without replay.
 export const maybeTriggerListeners = (doc: Doc, ignoreEmptyDiff = false) => {
-  const hasChanges = () => {
-    const { inserted, deleted, moved } = doc["_diff"];
-    return (
-      inserted.size ||
-      deleted.size ||
-      moved.size ||
-      !isObjectEmpty(doc["_operations"][1])
-    );
-  };
-  if (!hasChanges() && !ignoreEmptyDiff) {
-    doc["_finishUndoPortion"]();
-    doc["_lifeCycleStage"] = "change";
-    doc.undoManager?.["_record"]();
-    return;
-  }
-  doc["_finishUndoPortion"]();
-  const skipDepth = doc["_skipUndoDepth"];
-  doc["_skipUndoDepth"] = 0;
-  doc["_lifeCycleStage"] = "normalize";
-  try {
-    doc["_normalizeListeners"].forEach((listener) =>
-      listener({ diff: doc["_diff"] }),
-    );
-    if (doc["_strictMode"]) {
-      doc["_lifeCycleStage"] = "normalize2";
+  const hasDocumentChanges = () =>
+    hasChanges(doc["_diff"], doc["_operations"][1]);
+  if (hasDocumentChanges() || ignoreEmptyDiff) {
+    const skipDepth = doc.undoManager["_skipUndoDepth"];
+    doc.undoManager["_skipUndoDepth"] = 0;
+    doc["_lifeCycleStage"] = "normalize";
+    try {
       doc["_normalizeListeners"].forEach((listener) =>
         listener({ diff: doc["_diff"] }),
       );
+      if (doc["_strictMode"]) {
+        doc["_lifeCycleStage"] = "normalize2";
+        doc["_normalizeListeners"].forEach((listener) =>
+          listener({ diff: doc["_diff"] }),
+        );
+      }
+    } finally {
+      doc.undoManager["_skipUndoDepth"] = skipDepth;
     }
-  } finally {
-    doc["_finishUndoPortion"]();
-    doc["_skipUndoDepth"] = skipDepth;
   }
+  const undo = getUndoOperations(doc);
+  // An ordinary transaction shares the entire inverse with history. Reverse
+  // shared arrays only once; mixed histories may have their own array of refs.
+  if (undo && undo[0] !== doc["_inverseOperations"][0]) undo[0].reverse();
   doc["_inverseOperations"][0].reverse();
   doc["_lifeCycleStage"] = "change";
-  doc.undoManager?.["_record"]();
-  if (!hasChanges()) return;
+  const historyChanged = doc.undoManager?.["_record"](undo);
+  const documentChanged = hasDocumentChanges();
+  if (!documentChanged && !historyChanged) return;
   doc["_changeListeners"].forEach((listener) =>
     listener({
-      operations: doc["_operations"],
-      inverseOperations: doc["_inverseOperations"],
-      diff: doc["_diff"],
-      flags:
-        doc["_undoInverseOperations"][0].length ||
-        Object.values(doc["_undoInverseOperations"][1]).some(
-          (patch) => Object.keys(patch).length,
-        )
-          ? {}
-          : { skipUndo: true },
+      operations: documentChanged ? doc["_operations"] : [[], {}],
+      inverseOperations: documentChanged ? doc["_inverseOperations"] : [[], {}],
+      diff: documentChanged
+        ? doc["_diff"]
+        : {
+            inserted: new Set(),
+            deleted: new Map(),
+            moved: new Set(),
+            updated: new Set(),
+          },
+      flags: undo ? {} : { skipUndo: true },
     }),
   );
 };
 
-const copyDeletedToDiff = (node: DocNode, capture: Capture) => {
-  const { diff, inverseOperations } = capture;
-  // remove from operations.statePatch if its state changed in the same transaction
-  // remove from diff if it was inserted in the same transaction
-  const insertedInSameTransaction = diff.inserted.delete(node.id);
-  if (insertedInSameTransaction) {
-    diff.moved.delete(node.id);
-  } else {
-    // backup the previous state in inverseOperations.statePatch
-    const inversePatchState = inverseOperations[1][node.id];
-    const currentState = node["_stateToJson"]();
-    const previousState = { ...currentState, ...inversePatchState };
-    inverseOperations[1][node.id] = previousState;
-    // add to diff.deleted
-    diff.deleted.set(node.id, node);
+function copyDeletedToDiff(node: DocNode) {
+  const doc = node.doc;
+  const diff = doc["_diff"];
+  const inserted = diff.inserted.has(node.id);
+  const undoInserted = undoHas(doc, "inserted", node.id);
+  const undoMoved = undoHas(doc, "moved", node.id);
+  const undoDeleted = undoHas(doc, "deleted", node.id);
+  const excluded = isExcluded(doc);
+  if (!inserted || (!excluded && !undoInserted)) {
+    const current: Record<string, string> = node["_stateToJson"]();
+    for (const key in current) {
+      const full = doc["_inverseOperations"][1][node.id]?.[key];
+      const undo = undoValue(doc, node.id, key);
+      setInverseValue(
+        doc,
+        node.id,
+        key,
+        inserted ? full : (full ?? current[key]),
+        excluded || undoInserted ? undo : (undo ?? current[key]),
+      );
+    }
   }
-};
+  setMembership(doc, node, "inserted", false, excluded ? undoInserted : false);
+  setMembership(
+    doc,
+    node,
+    "moved",
+    inserted ? false : diff.moved.has(node.id),
+    excluded ? undoMoved : undoInserted ? false : undoMoved,
+  );
+  setMembership(
+    doc,
+    node,
+    "deleted",
+    diff.deleted.has(node.id) || !inserted,
+    excluded ? undoDeleted : undoDeleted || !undoInserted,
+  );
+}
+
+function getUndoOperations(doc: Doc) {
+  if (doc["_transactionFlags"]?.skipUndo) return;
+  const base = doc["_inverseOperations"];
+  const changes = doc["_undoChanges"];
+  if (!changes)
+    return hasChanges(doc["_diff"], doc["_operations"][1]) ? base : undefined;
+  let state = base[1];
+  changes?.nodes?.forEach((node, id) => {
+    if (!node.state) return;
+    if (state === base[1]) state = { ...state };
+    const patch = { ...state[id] };
+    node.state.forEach((value, key) => {
+      if (value === undefined) delete patch[key];
+      else patch[key] = value;
+    });
+    if (isObjectEmpty(patch)) delete state[id];
+    else state[id] = patch;
+  });
+  // Excluded writes can cancel the final undo effect too. Preserve state for
+  // nodes whose inverse recreates them, even when their current value matches.
+  for (const id in state) {
+    const node = doc.getNodeById(id);
+    if (!node || undoHas(doc, "moved", id)) continue;
+    for (const key in state[id]) {
+      if (stringifyStateKey(node, key) !== state[id][key]) continue;
+      if (state === base[1]) state = { ...state };
+      if (state[id] === base[1][id]) state[id] = { ...state[id] };
+      delete state[id]![key];
+    }
+    if (isObjectEmpty(state[id]!)) delete state[id];
+  }
+  let structuralCount =
+    doc["_diff"].inserted.size +
+    doc["_diff"].deleted.size +
+    doc["_diff"].moved.size;
+  changes?.nodes?.forEach((node, id) => {
+    for (const kind of ["inserted", "deleted", "moved"] as const) {
+      if (node[kind] !== undefined)
+        structuralCount +=
+          Number(node[kind]) - Number(doc["_diff"][kind].has(id));
+    }
+  });
+  if (!structuralCount && isObjectEmpty(state)) return;
+  let ordered = base[0];
+  if (changes?.ordered) {
+    ordered = [];
+    for (let at = 0; at <= base[0].length; at++) {
+      const change = changes.ordered.get(at);
+      if (change?.before) ordered.push(...change.before);
+      const operation = base[0][at];
+      if (operation && !change?.omit) ordered.push(operation);
+    }
+  }
+  if (ordered === base[0] && state === base[1]) return base;
+  const inverse: Operations = [ordered, state];
+  return inverse;
+}
 
 type InsertOperation = [
   operation: 0,

--- a/packages/docnode/src/operations.ts
+++ b/packages/docnode/src/operations.ts
@@ -1,5 +1,5 @@
 import { type Doc, type DocNode } from "./main.js";
-import { type Json, type UnsafeDefinition } from "./types.js";
+import { type Json, type UnsafeDefinition, type Diff } from "./types.js";
 import { detachRange, isObjectEmpty } from "./utils.js";
 
 export function stringifyStateKey(node: DocNode, key: string): string {
@@ -31,35 +31,63 @@ export function parseStateKey(
   return stateValue;
 }
 
+// Each transaction has its complete capture and, when history is enabled,
+// a capture of the current contiguous undoable portion. Sharing the recorder
+// keeps insertion/deletion optimizations identical without filtering a diff
+// that has already lost intermediate values.
+export function createCapture() {
+  const operations: Operations = [[], {}];
+  const inverseOperations: Operations = [[], {}];
+  const diff: Diff = {
+    inserted: new Set(),
+    deleted: new Map(),
+    moved: new Set(),
+    updated: new Set(),
+  };
+  return { operations, inverseOperations, diff };
+}
+
+type Capture = ReturnType<typeof createCapture>;
+
+function captureChange(doc: Doc, callback: (capture: Capture) => void) {
+  callback({
+    operations: doc["_operations"],
+    inverseOperations: doc["_inverseOperations"],
+    diff: doc["_diff"],
+  });
+  const history = doc["_getUndoCapture"]();
+  if (history) callback(history);
+}
+
 export const onSetState = {
   operations: (node: DocNode, key: string) => {
-    const { doc } = node;
-    const statePatchs = doc["_operations"][1];
     const valueString = stringifyStateKey(node, key);
-
-    const prevValueString = doc["_inverseOperations"][1][node.id]?.[key];
-    const nodePatch = statePatchs[node.id];
-    if (prevValueString === valueString && nodePatch) {
-      delete nodePatch[key];
-      if (isObjectEmpty(nodePatch)) {
-        delete statePatchs[node.id];
-        doc["_diff"].updated.delete(node.id);
+    captureChange(node.doc, ({ operations, inverseOperations, diff }) => {
+      const statePatchs = operations[1];
+      const prevValueString = inverseOperations[1][node.id]?.[key];
+      const nodePatch = statePatchs[node.id];
+      if (prevValueString === valueString && nodePatch) {
+        delete nodePatch[key];
+        if (isObjectEmpty(nodePatch)) {
+          delete statePatchs[node.id];
+          diff.updated.delete(node.id);
+        }
+        delete inverseOperations[1][node.id]?.[key];
+      } else {
+        (statePatchs[node.id] ??= {})[key] = valueString;
+        if (!diff.inserted.has(node.id)) diff.updated.add(node.id);
       }
-      delete doc["_inverseOperations"][1][node.id]?.[key];
-    } else {
-      (statePatchs[node.id] ??= {})[key] = valueString;
-      if (!doc["_diff"].inserted.has(node.id))
-        doc["_diff"].updated.add(node.id);
-    }
+    });
   },
   inverseOps: (node: DocNode, key: string) => {
-    const { doc } = node;
-    const insertedInSameTransaction = doc["_diff"].inserted.has(node.id);
-    if (insertedInSameTransaction) return;
-    const inverseStatePatchs = doc["_inverseOperations"][1];
-    if (inverseStatePatchs[node.id]?.[key] !== undefined) return;
-    const originalStringifiedState = stringifyStateKey(node, key);
-    (inverseStatePatchs[node.id] ??= {})[key] = originalStringifiedState;
+    captureChange(node.doc, ({ inverseOperations, diff }) => {
+      if (diff.inserted.has(node.id)) return;
+      if (inverseOperations[1][node.id]?.[key] !== undefined) return;
+      (inverseOperations[1][node.id] ??= {})[key] = stringifyStateKey(
+        node,
+        key,
+      );
+    });
   },
 };
 
@@ -84,61 +112,63 @@ export const onInsertRange = (
       newParent = target.parent!;
       break;
   }
-  const diff = doc["_diff"];
-  doc["_operations"][0].push([
-    0,
-    nodes.map((node) => [node.id, node.type]),
-    newParent === doc.root ? 0 : newParent.id,
-    newPrev?.id ?? 0,
-    newNext?.id ?? 0,
-  ]);
-  if (newParent && !diff.inserted.has(newParent.id)) {
-    doc["_inverseOperations"][0].push([
-      1,
-      nodes[0]!.id,
-      nodes.length > 1 ? nodes.at(-1)!.id : 0,
+  captureChange(doc, (capture) => {
+    const { operations, inverseOperations, diff } = capture;
+
+    operations[0].push([
+      0,
+      nodes.map((node) => [node.id, node.type]),
+      newParent === doc.root ? 0 : newParent.id,
+      newPrev?.id ?? 0,
+      newNext?.id ?? 0,
     ]);
-  }
-  nodes.forEach((topLevelNode) => {
-    copyInsertedToDiff(topLevelNode);
-    topLevelNode.descendants().forEach((node) => {
-      copyInsertedToDiff(node);
-      const parent = node.parent!;
-      const children = getChildren(parent);
-      if (!node.prev) {
-        doc["_operations"][0].push([
-          0,
-          children.map((child) => [child.id, child.type]),
-          parent.id,
-          0,
-          0,
-        ]);
-        if (!diff.inserted.has(parent.id)) {
-          doc["_inverseOperations"][0].push([
-            1,
-            node.id,
-            parent.last !== node ? parent.last!.id : 0,
+    if (newParent && !diff.inserted.has(newParent.id)) {
+      inverseOperations[0].push([
+        1,
+        nodes[0]!.id,
+        nodes.length > 1 ? nodes.at(-1)!.id : 0,
+      ]);
+    }
+    nodes.forEach((topLevelNode) => {
+      copyInsertedToDiff(topLevelNode, capture);
+      topLevelNode.descendants().forEach((node) => {
+        copyInsertedToDiff(node, capture);
+        const parent = node.parent!;
+        const children = getChildren(parent);
+        if (!node.prev) {
+          operations[0].push([
+            0,
+            children.map((child) => [child.id, child.type]),
+            parent.id,
+            0,
+            0,
           ]);
+          if (!diff.inserted.has(parent.id)) {
+            inverseOperations[0].push([
+              1,
+              node.id,
+              parent.last !== node ? parent.last!.id : 0,
+            ]);
+          }
         }
-      }
+      });
     });
   });
 };
 
-function copyInsertedToDiff(node: DocNode) {
-  const doc = node.doc;
-  const diff = doc["_diff"];
+function copyInsertedToDiff(node: DocNode, capture: Capture) {
+  const { diff, operations } = capture;
   const deletedInSameTransaction = diff.deleted.delete(node.id);
   if (deletedInSameTransaction) {
     diff.moved.add(node.id);
-    doc["_diff"].updated.add(node.id);
+    diff.updated.add(node.id);
   } else {
     diff.inserted.add(node.id);
   }
   // [#4GOSK]
   const jsonState = node["_stateToJson"]();
   if (isObjectEmpty(jsonState)) return;
-  doc["_operations"][1][node.id] = jsonState;
+  operations[1][node.id] = jsonState;
 }
 
 export const onDeleteRange = (
@@ -146,56 +176,58 @@ export const onDeleteRange = (
   startNode: DocNode,
   endNode: DocNode,
 ) => {
-  const operations = doc["_operations"][0];
-  const inverseOperations = doc["_inverseOperations"][0];
-  const tempInverseOperations: OrderedOperation[] = [];
-  const parent = startNode.parent!;
+  captureChange(doc, (capture) => {
+    const operations = capture.operations[0];
+    const inverseOperations = capture.inverseOperations[0];
+    const tempInverseOperations: OrderedOperation[] = [];
+    const parent = startNode.parent!;
 
-  operations.push([1, startNode.id, startNode !== endNode ? endNode.id : 0]);
-  const jsonNodes: [string, string][] = [];
-  startNode.to(endNode).forEach((node) => {
-    jsonNodes.push([node.id, node.type]);
-    copyDeletedToDiff(node);
-  });
-  // If the parent was inserted in the same transaction, it means that
-  // is deleted in inverseOps, so it is not possible to insert descendants.
-  const shouldAddToInverseOps = !doc["_diff"].inserted.has(parent.id);
-  if (shouldAddToInverseOps) {
-    tempInverseOperations.push([
-      0,
-      jsonNodes,
-      parent === doc.root ? 0 : parent.id,
-      startNode.prev?.id ?? 0,
-      endNode.next?.id ?? 0,
-    ]);
-  }
-
-  detachRange(startNode, endNode);
-  startNode.to(endNode).forEach((node) => {
-    node.descendants({ includeSelf: true }).forEach((node) => {
-      delete doc["_operations"][1][node.id];
-      doc["_diff"].updated.delete(node.id);
-      if (node.first) {
-        const jsonNodes: [string, string][] = [];
-        node.children().forEach((childNode) => {
-          copyDeletedToDiff(childNode);
-          jsonNodes.push([childNode.id, childNode.type]);
-        });
-        if (shouldAddToInverseOps) {
-          tempInverseOperations.push([0, jsonNodes, node.id, 0, 0]);
-        }
-      }
+    operations.push([1, startNode.id, startNode !== endNode ? endNode.id : 0]);
+    const jsonNodes: [string, string][] = [];
+    startNode.to(endNode).forEach((node) => {
+      jsonNodes.push([node.id, node.type]);
+      copyDeletedToDiff(node, capture);
     });
+    // If the parent was inserted in the same transaction, it means that
+    // is deleted in inverseOps, so it is not possible to insert descendants.
+    const shouldAddToInverseOps = !capture.diff.inserted.has(parent.id);
+    if (shouldAddToInverseOps) {
+      tempInverseOperations.push([
+        0,
+        jsonNodes,
+        parent === doc.root ? 0 : parent.id,
+        startNode.prev?.id ?? 0,
+        endNode.next?.id ?? 0,
+      ]);
+    }
+
+    startNode.to(endNode).forEach((node) => {
+      node.descendants({ includeSelf: true }).forEach((node) => {
+        delete capture.operations[1][node.id];
+        capture.diff.updated.delete(node.id);
+        if (node.first) {
+          const jsonNodes: [string, string][] = [];
+          node.children().forEach((childNode) => {
+            copyDeletedToDiff(childNode, capture);
+            jsonNodes.push([childNode.id, childNode.type]);
+          });
+          if (shouldAddToInverseOps) {
+            tempInverseOperations.push([0, jsonNodes, node.id, 0, 0]);
+          }
+        }
+      });
+    });
+    /**
+     * All operations are reversed in main.ts. But we reverse the delete operations
+     * again here because they're the only ones that don't need to be reversed
+     * (reversed + reversed = not reversed). This is because descendants are removed
+     * after the ancestors.
+     * TODO: To avoid a reverse and make this more performant, we can use an iterator
+     * other than.descendants().forEach above.
+     */
+    inverseOperations.push(...tempInverseOperations.reverse());
   });
-  /**
-   * All operations are reversed in main.ts. But we reverse the delete operations
-   * again here because they're the only ones that don't need to be reversed
-   * (reversed + reversed = not reversed). This is because descendants are removed
-   * after the ancestors.
-   * TODO: To avoid a reverse and make this more performant, we can use an iterator
-   * other than.descendants().forEach above.
-   */
-  inverseOperations.push(...tempInverseOperations.reverse());
+  detachRange(startNode, endNode);
 };
 
 export const onMoveRange = (
@@ -206,30 +238,32 @@ export const onMoveRange = (
   newPrev: DocNode | undefined,
   newNext: DocNode | undefined,
 ) => {
-  const endId = endNode.id === startNode.id ? 0 : endNode.id;
-  doc["_operations"][0].push([
-    2,
-    startNode.id,
-    endId,
-    newParent === doc.root ? 0 : newParent.id,
-    newPrev?.id ?? 0,
-    newNext?.id ?? 0,
-  ]);
-  // TODO: non-null assertion because it doesn't make sense to move root
-  // but should be tested!
-  const currentParent = startNode.parent!;
-  const currentPrev = startNode.prev;
-  const currentNext = endNode.next;
-  doc["_inverseOperations"][0].push([
-    2,
-    startNode.id,
-    endId,
-    currentParent === doc.root ? 0 : currentParent.id,
-    currentPrev?.id ?? 0,
-    currentNext?.id ?? 0,
-  ]);
-  startNode.to(endNode).forEach((node) => {
-    if (!doc["_diff"].inserted.has(node.id)) doc["_diff"].moved.add(node.id);
+  captureChange(doc, ({ operations, inverseOperations, diff }) => {
+    const endId = endNode.id === startNode.id ? 0 : endNode.id;
+    operations[0].push([
+      2,
+      startNode.id,
+      endId,
+      newParent === doc.root ? 0 : newParent.id,
+      newPrev?.id ?? 0,
+      newNext?.id ?? 0,
+    ]);
+    // TODO: non-null assertion because it doesn't make sense to move root
+    // but should be tested!
+    const currentParent = startNode.parent!;
+    const currentPrev = startNode.prev;
+    const currentNext = endNode.next;
+    inverseOperations[0].push([
+      2,
+      startNode.id,
+      endId,
+      currentParent === doc.root ? 0 : currentParent.id,
+      currentPrev?.id ?? 0,
+      currentNext?.id ?? 0,
+    ]);
+    startNode.to(endNode).forEach((node) => {
+      if (!diff.inserted.has(node.id)) diff.moved.add(node.id);
+    });
   });
 };
 
@@ -287,27 +321,36 @@ export const onApplyOperations = (doc: Doc, operations: Operations) => {
   });
   // Apply state patch
   const toApplyStatePatch = operations[1];
-  const currentStatePatch = doc["_operations"][1];
-  const currentInverseStatePatch = doc["_inverseOperations"][1];
   for (const id in toApplyStatePatch) {
     const node = doc.getNodeById(id);
     if (!node) continue;
-    const insertedInSameTransaction = doc["_diff"].inserted.has(id);
+    // A value already in place on a pre-existing node is treated as applied,
+    // like an insert of an existing node: it changes nothing and needs no
+    // inverse. The state of a node inserted in this transaction is part of
+    // its creation and is taken verbatim.
+    const inserted = doc["_diff"].inserted.has(id);
+    const patch: Record<string, string> = {};
     for (const key in toApplyStatePatch[id]) {
       const value = toApplyStatePatch[id][key]!;
-      // The state of a node inserted in this transaction is part of its
-      // creation and needs no inverse: the inverse operation is a delete.
-      if (!insertedInSameTransaction) {
-        const current = stringifyStateKey(node, key);
-        // A value already in place is treated as applied, like an insert of
-        // an existing node. It changes nothing and needs no inverse.
-        if (current === value) continue;
-        doc["_diff"].updated.add(id);
-        (currentInverseStatePatch[id] ??= {})[key] ??= current;
+      if (!inserted && stringifyStateKey(node, key) === value) continue;
+      patch[key] = value;
+    }
+    if (isObjectEmpty(patch)) continue;
+    captureChange(doc, ({ operations: current, inverseOperations, diff }) => {
+      current[1][id] = { ...current[1][id], ...patch };
+      if (!diff.inserted.has(id)) diff.updated.add(id);
+      if (!diff.inserted.has(id)) {
+        for (const key in patch) {
+          (inverseOperations[1][id] ??= {})[key] ??= stringifyStateKey(
+            node,
+            key,
+          );
+        }
       }
-      (currentStatePatch[id] ??= {})[key] = value;
+    });
+    for (const key in patch) {
       const state = (node as DocNode<UnsafeDefinition>)["_state"];
-      state[key] = parseStateKey(node, key, value);
+      state[key] = parseStateKey(node, key, patch[key]!);
     }
   }
 };
@@ -323,32 +366,52 @@ export const maybeTriggerListeners = (doc: Doc, ignoreEmptyDiff = false) => {
       !isObjectEmpty(doc["_operations"][1])
     );
   };
-  if (!hasChanges() && !ignoreEmptyDiff) return;
+  if (!hasChanges() && !ignoreEmptyDiff) {
+    doc["_finishUndoPortion"]();
+    doc["_lifeCycleStage"] = "change";
+    doc.undoManager?.["_record"]();
+    return;
+  }
+  doc["_finishUndoPortion"]();
+  const skipDepth = doc["_skipUndoDepth"];
+  doc["_skipUndoDepth"] = 0;
   doc["_lifeCycleStage"] = "normalize";
-  doc["_normalizeListeners"].forEach((listener) =>
-    listener({ diff: doc["_diff"] }),
-  );
-  if (doc["_strictMode"]) {
-    doc["_lifeCycleStage"] = "normalize2";
+  try {
     doc["_normalizeListeners"].forEach((listener) =>
       listener({ diff: doc["_diff"] }),
     );
+    if (doc["_strictMode"]) {
+      doc["_lifeCycleStage"] = "normalize2";
+      doc["_normalizeListeners"].forEach((listener) =>
+        listener({ diff: doc["_diff"] }),
+      );
+    }
+  } finally {
+    doc["_finishUndoPortion"]();
+    doc["_skipUndoDepth"] = skipDepth;
   }
-  if (!hasChanges()) return;
+  doc["_inverseOperations"][0].reverse();
   doc["_lifeCycleStage"] = "change";
+  doc.undoManager?.["_record"]();
+  if (!hasChanges()) return;
   doc["_changeListeners"].forEach((listener) =>
     listener({
       operations: doc["_operations"],
       inverseOperations: doc["_inverseOperations"],
       diff: doc["_diff"],
-      flags: doc["_transactionFlags"],
+      flags:
+        doc["_undoInverseOperations"][0].length ||
+        Object.values(doc["_undoInverseOperations"][1]).some(
+          (patch) => Object.keys(patch).length,
+        )
+          ? {}
+          : { skipUndo: true },
     }),
   );
 };
 
-const copyDeletedToDiff = (node: DocNode) => {
-  const doc = node.doc;
-  const diff = doc["_diff"];
+const copyDeletedToDiff = (node: DocNode, capture: Capture) => {
+  const { diff, inverseOperations } = capture;
   // remove from operations.statePatch if its state changed in the same transaction
   // remove from diff if it was inserted in the same transaction
   const insertedInSameTransaction = diff.inserted.delete(node.id);
@@ -356,10 +419,10 @@ const copyDeletedToDiff = (node: DocNode) => {
     diff.moved.delete(node.id);
   } else {
     // backup the previous state in inverseOperations.statePatch
-    const inversePatchState = doc["_inverseOperations"][1][node.id];
+    const inversePatchState = inverseOperations[1][node.id];
     const currentState = node["_stateToJson"]();
     const previousState = { ...currentState, ...inversePatchState };
-    doc["_inverseOperations"][1][node.id] = previousState;
+    inverseOperations[1][node.id] = previousState;
     // add to diff.deleted
     diff.deleted.set(node.id, node);
   }

--- a/packages/docnode/src/operations.ts
+++ b/packages/docnode/src/operations.ts
@@ -31,132 +31,44 @@ export function parseStateKey(
   return stateValue;
 }
 
-// The existing transaction inverse is the base. Only disagreements with user
-// undo are stored here: alternate state, structural membership, and omitted or
-// undo-only inverse operations. Ordinary transactions allocate none of this.
-export function createUndoChanges() {
-  const changes: {
-    nodes?: Map<
-      string,
-      {
-        inserted?: boolean;
-        deleted?: boolean;
-        moved?: boolean;
-        state?: Map<string, string | undefined>;
-      }
-    >;
-    ordered?: Map<number, { omit?: true; before?: OrderedOperation[] }>;
-  } = {};
-  return changes;
-}
+/**
+ * Bookkeeping of one transaction: the inverse operations and the structural
+ * membership they depend on. The full tracker sees every mutation and serves
+ * rollback and change events. When a mutation happens inside `skipUndo`, the
+ * full tracker is forked into an undo tracker that only sees the undoable
+ * mutations from then on, and that fork becomes the undo step. Transactions
+ * without `skipUndo` never fork, so they cost the same as before.
+ */
+export type Tracker = {
+  inverse: Operations;
+  inserted: Set<string>;
+  deleted: Map<string, DocNode>;
+  moved: Set<string>;
+};
 
-function nodeUndoChanges(doc: Doc, id: string) {
-  const changes = (doc["_undoChanges"] ??= createUndoChanges());
-  const nodes = (changes.nodes ??= new Map());
-  let node = nodes.get(id);
-  if (!node) {
-    node = {};
-    nodes.set(id, node);
+/** The trackers the current mutation must update. */
+function trackers(doc: Doc): Tracker[] {
+  const excluded =
+    doc.undoManager["_skipUndoDepth"] > 0 &&
+    // Initialization is excluded as a whole at commit.
+    !doc["_transactionFlags"].skipUndo;
+  if (!excluded) return doc["_trackers"];
+  if (!doc["_undo"]) {
+    doc["_undo"] = fork(doc["_full"]);
+    doc["_trackers"] = [doc["_full"], doc["_undo"]];
   }
-  return node;
+  return doc["_fullOnly"];
 }
 
-function trimUndoChanges(doc: Doc, id: string) {
-  const changes = doc["_undoChanges"];
-  const node = changes?.nodes?.get(id);
-  if (node) {
-    if (node.state?.size === 0) delete node.state;
-    if (isObjectEmpty(node)) changes!.nodes!.delete(id);
-  }
-  if (changes?.nodes?.size === 0) delete changes.nodes;
-  if (changes && isObjectEmpty(changes)) doc["_undoChanges"] = undefined;
-}
-
-function isExcluded(doc: Doc) {
-  // Initialization is excluded as a whole at commit and needs no differences.
-  return (
-    !doc["_transactionFlags"]?.skipUndo &&
-    Boolean(doc.undoManager?.["_skipUndoDepth"])
-  );
-}
-
-function undoHas(doc: Doc, kind: "inserted" | "deleted" | "moved", id: string) {
-  return (
-    doc["_undoChanges"]?.nodes?.get(id)?.[kind] ?? doc["_diff"][kind].has(id)
-  );
-}
-
-function setMembership(
-  doc: Doc,
-  node: DocNode,
-  kind: "inserted" | "deleted" | "moved",
-  full: boolean,
-  undo: boolean,
-) {
-  const diff = doc["_diff"];
-  if (!full) diff[kind].delete(node.id);
-  else if (kind === "deleted") diff.deleted.set(node.id, node);
-  else diff[kind].add(node.id);
-  if (full !== undo) nodeUndoChanges(doc, node.id)[kind] = undo;
-  else {
-    const change = doc["_undoChanges"]?.nodes?.get(node.id);
-    if (change) delete change[kind];
-    trimUndoChanges(doc, node.id);
-  }
-}
-
-// Missing key means inherit the full inverse; a stored undefined means omit it.
-function undoValue(doc: Doc, id: string, key: string) {
-  const state = doc["_undoChanges"]?.nodes?.get(id)?.state;
-  return state?.has(key)
-    ? state.get(key)
-    : doc["_inverseOperations"][1][id]?.[key];
-}
-
-function setInverseValue(
-  doc: Doc,
-  id: string,
-  key: string,
-  full: string | undefined,
-  undo: string | undefined,
-) {
-  const state = doc["_inverseOperations"][1];
-  if (full === undefined) {
-    const patch = state[id];
-    if (patch) {
-      delete patch[key];
-      if (isObjectEmpty(patch)) delete state[id];
-    }
-  } else (state[id] ??= {})[key] = full;
-  if (full !== undo)
-    (nodeUndoChanges(doc, id).state ??= new Map()).set(key, undo);
-  else {
-    doc["_undoChanges"]?.nodes?.get(id)?.state?.delete(key);
-    trimUndoChanges(doc, id);
-  }
-}
-
-function appendInverse(
-  doc: Doc,
-  operation: OrderedOperation,
-  full: boolean,
-  undo: boolean,
-) {
-  const ordered = doc["_inverseOperations"][0];
-  // Full ordered inverses are append-only until commit. This index also names
-  // the gap before the next full inverse, for operations needed only by undo.
-  const at = ordered.length;
-  if (full) ordered.push(operation);
-  if (full === undo) return;
-  const changes = (doc["_undoChanges"] ??= createUndoChanges());
-  const exceptions = (changes.ordered ??= new Map());
-  let change = exceptions.get(at);
-  if (!change) {
-    change = {};
-    exceptions.set(at, change);
-  }
-  if (full) change.omit = true;
-  else (change.before ??= []).push(operation);
+function fork(full: Tracker): Tracker {
+  const state: StatePatch = {};
+  for (const id in full.inverse[1]) state[id] = { ...full.inverse[1][id] };
+  return {
+    inverse: [full.inverse[0].slice(), state],
+    inserted: new Set(full.inserted),
+    deleted: new Map(full.deleted),
+    moved: new Set(full.moved),
+  };
 }
 
 function hasChanges(diff: Omit<Diff, "updated">, statePatch: StatePatch) {
@@ -173,14 +85,15 @@ export const onSetState = {
     const doc = node.doc;
     const value = stringifyStateKey(node, key);
     const full = doc["_inverseOperations"][1][node.id]?.[key];
-    const undo = undoValue(doc, node.id, key);
-    setInverseValue(
-      doc,
-      node.id,
-      key,
-      full === value ? undefined : full,
-      !isExcluded(doc) && undo === value ? undefined : undo,
-    );
+    // A write that returns to a tracker's captured value cancels its inverse.
+    for (const t of trackers(doc)) {
+      const state = t.inverse[1];
+      const patch = state[node.id];
+      if (patch?.[key] === value) {
+        delete patch[key];
+        if (isObjectEmpty(patch)) delete state[node.id];
+      }
+    }
     if (full === value) {
       const patch = doc["_operations"][1][node.id];
       if (patch) {
@@ -198,22 +111,14 @@ export const onSetState = {
   },
   inverseOps: (node: DocNode, key: string) => {
     const doc = node.doc;
-    const full = doc["_inverseOperations"][1][node.id]?.[key];
-    const undo = undoValue(doc, node.id, key);
-    const needsFull = !doc["_diff"].inserted.has(node.id) && full === undefined;
-    const needsUndo =
-      !isExcluded(doc) &&
-      !undoHas(doc, "inserted", node.id) &&
-      undo === undefined;
-    if (!needsFull && !needsUndo) return;
-    const value = stringifyStateKey(node, key);
-    setInverseValue(
-      doc,
-      node.id,
-      key,
-      needsFull ? value : full,
-      needsUndo ? value : undo,
-    );
+    let value: string | undefined;
+    for (const t of trackers(doc)) {
+      // The inverse of an insertion deletes the node, so its state is moot.
+      if (t.inserted.has(node.id)) continue;
+      const state = t.inverse[1];
+      if (state[node.id]?.[key] !== undefined) continue;
+      (state[node.id] ??= {})[key] = value ??= stringifyStateKey(node, key);
+    }
   },
 };
 
@@ -245,19 +150,16 @@ export const onInsertRange = (
     newPrev?.id ?? 0,
     newNext?.id ?? 0,
   ]);
-  const full = !doc["_diff"].inserted.has(newParent.id);
-  const undo = !isExcluded(doc) && !undoHas(doc, "inserted", newParent.id);
-  if (full || undo)
-    appendInverse(
-      doc,
-      [1, nodes[0]!.id, nodes.length > 1 ? nodes.at(-1)!.id : 0],
-      full,
-      undo,
-    );
+  const ts = trackers(doc);
+  pushInverse(ts, newParent, [
+    1,
+    nodes[0]!.id,
+    nodes.length > 1 ? nodes.at(-1)!.id : 0,
+  ]);
   nodes.forEach((topLevelNode) => {
-    copyInsertedToDiff(topLevelNode);
+    markInserted(doc, ts, topLevelNode);
     topLevelNode.descendants().forEach((node) => {
-      copyInsertedToDiff(node);
+      markInserted(doc, ts, node);
       const parent = node.parent!;
       if (!node.prev) {
         doc["_operations"][0].push([
@@ -267,44 +169,36 @@ export const onInsertRange = (
           0,
           0,
         ]);
-        const full = !doc["_diff"].inserted.has(parent.id);
-        const undo = !isExcluded(doc) && !undoHas(doc, "inserted", parent.id);
-        if (full || undo)
-          appendInverse(
-            doc,
-            [1, node.id, parent.last !== node ? parent.last!.id : 0],
-            full,
-            undo,
-          );
+        pushInverse(ts, parent, [
+          1,
+          node.id,
+          parent.last !== node ? parent.last!.id : 0,
+        ]);
       }
     });
   });
 };
 
-function copyInsertedToDiff(node: DocNode) {
-  const doc = node.doc;
-  const diff = doc["_diff"];
-  const deleted = diff.deleted.has(node.id);
-  const undoDeleted = undoHas(doc, "deleted", node.id);
-  const undoInserted = undoHas(doc, "inserted", node.id);
-  const undoMoved = undoHas(doc, "moved", node.id);
-  const excluded = isExcluded(doc);
-  setMembership(doc, node, "deleted", false, excluded ? undoDeleted : false);
-  setMembership(
-    doc,
-    node,
-    "inserted",
-    diff.inserted.has(node.id) || !deleted,
-    excluded ? undoInserted : undoInserted || !undoDeleted,
-  );
-  setMembership(
-    doc,
-    node,
-    "moved",
-    diff.moved.has(node.id) || deleted,
-    excluded ? undoMoved : undoMoved || undoDeleted,
-  );
-  if (deleted) diff.updated.add(node.id);
+/**
+ * A tracker that inserted the parent in this transaction needs no inverse for
+ * its children: undoing the parent's insertion removes the whole subtree.
+ */
+function pushInverse(
+  ts: Tracker[],
+  parent: DocNode,
+  operation: OrderedOperation,
+) {
+  for (const t of ts) {
+    if (!t.inserted.has(parent.id)) t.inverse[0].push(operation);
+  }
+}
+
+function markInserted(doc: Doc, ts: Tracker[], node: DocNode) {
+  if (doc["_diff"].deleted.has(node.id)) doc["_diff"].updated.add(node.id);
+  for (const t of ts) {
+    if (t.deleted.delete(node.id)) t.moved.add(node.id);
+    else t.inserted.add(node.id);
+  }
   // [#4GOSK]
   const jsonState = node["_stateToJson"]();
   if (!isObjectEmpty(jsonState)) doc["_operations"][1][node.id] = jsonState;
@@ -321,24 +215,27 @@ export const onDeleteRange = (
     startNode.id,
     startNode !== endNode ? endNode.id : 0,
   ]);
+  const ts = trackers(doc);
   const jsonNodes: [string, string][] = [];
+  // Iterating the range also validates it, so it must run before the parent
+  // is touched.
   startNode.to(endNode).forEach((node) => {
     jsonNodes.push([node.id, node.type]);
-    copyDeletedToDiff(node);
+    markDeleted(ts, node);
   });
-  // Rollback can omit descendants of a newly inserted parent; undo may still
-  // need them when that parent's insertion was excluded from history.
-  const full = !doc["_diff"].inserted.has(parent.id);
-  const undo = !isExcluded(doc) && !undoHas(doc, "inserted", parent.id);
-  const inverse: OrderedOperation[] = [];
-  if (full || undo)
-    inverse.push([
+  // Rollback can omit descendants of a parent inserted in this transaction;
+  // a tracker that did not see that insertion still needs them.
+  const targets = ts.filter((t) => !t.inserted.has(parent.id));
+  const inverse: OrderedOperation[] = [
+    [
       0,
       jsonNodes,
       parent === doc.root ? 0 : parent.id,
       startNode.prev?.id ?? 0,
       endNode.next?.id ?? 0,
-    ]);
+    ],
+  ];
+  detachRange(startNode, endNode);
   startNode.to(endNode).forEach((node) => {
     node.descendants({ includeSelf: true }).forEach((node) => {
       delete doc["_operations"][1][node.id];
@@ -346,20 +243,33 @@ export const onDeleteRange = (
       if (node.first) {
         const children: [string, string][] = [];
         node.children().forEach((child) => {
-          copyDeletedToDiff(child);
+          markDeleted(ts, child);
           children.push([child.id, child.type]);
         });
-        if (full || undo) inverse.push([0, children, node.id, 0, 0]);
+        inverse.push([0, children, node.id, 0, 0]);
       }
     });
   });
   // The commit reverses the complete sequence. Reverse this subtree first so
   // replay still restores each parent before its children.
-  inverse
-    .reverse()
-    .forEach((operation) => appendInverse(doc, operation, full, undo));
-  detachRange(startNode, endNode);
+  inverse.reverse();
+  targets.forEach((t) => t.inverse[0].push(...inverse));
 };
+
+function markDeleted(ts: Tracker[], node: DocNode) {
+  let state: Record<string, string> | undefined;
+  for (const t of ts) {
+    // Deleting a node inserted in this transaction cancels the insertion.
+    if (t.inserted.delete(node.id)) {
+      t.moved.delete(node.id);
+      continue;
+    }
+    // Keep the state as it was when this tracker first saw it.
+    state ??= node["_stateToJson"]();
+    t.inverse[1][node.id] = { ...state, ...t.inverse[1][node.id] };
+    t.deleted.set(node.id, node);
+  }
+}
 
 export const onMoveRange = (
   doc: Doc,
@@ -379,28 +289,20 @@ export const onMoveRange = (
     newNext?.id ?? 0,
   ]);
   const currentParent = startNode.parent!;
-  appendInverse(
-    doc,
-    [
-      2,
-      startNode.id,
-      endId,
-      currentParent === doc.root ? 0 : currentParent.id,
-      startNode.prev?.id ?? 0,
-      endNode.next?.id ?? 0,
-    ],
-    true,
-    !isExcluded(doc),
-  );
+  const inverse: OrderedOperation = [
+    2,
+    startNode.id,
+    endId,
+    currentParent === doc.root ? 0 : currentParent.id,
+    startNode.prev?.id ?? 0,
+    endNode.next?.id ?? 0,
+  ];
+  const ts = trackers(doc);
+  ts.forEach((t) => t.inverse[0].push(inverse));
   startNode.to(endNode).forEach((node) => {
-    const moved = undoHas(doc, "moved", node.id);
-    setMembership(
-      doc,
-      node,
-      "moved",
-      doc["_diff"].moved.has(node.id) || !doc["_diff"].inserted.has(node.id),
-      moved || (!isExcluded(doc) && !undoHas(doc, "inserted", node.id)),
-    );
+    for (const t of ts) {
+      if (!t.inserted.has(node.id)) t.moved.add(node.id);
+    }
   });
 };
 
@@ -489,6 +391,7 @@ export const maybeTriggerListeners = (doc: Doc, ignoreEmptyDiff = false) => {
   const hasDocumentChanges = () =>
     hasChanges(doc["_diff"], doc["_operations"][1]);
   if (hasDocumentChanges() || ignoreEmptyDiff) {
+    // Normalization is undoable by default; a normalizer opts out explicitly.
     const skipDepth = doc.undoManager["_skipUndoDepth"];
     doc.undoManager["_skipUndoDepth"] = 0;
     doc["_lifeCycleStage"] = "normalize";
@@ -506,13 +409,11 @@ export const maybeTriggerListeners = (doc: Doc, ignoreEmptyDiff = false) => {
       doc.undoManager["_skipUndoDepth"] = skipDepth;
     }
   }
-  const undo = getUndoOperations(doc);
-  // An ordinary transaction shares the entire inverse with history. Reverse
-  // shared arrays only once; mixed histories may have their own array of refs.
-  if (undo && undo[0] !== doc["_inverseOperations"][0]) undo[0].reverse();
+  // push + reverse is more performant than unshift at insertion time
   doc["_inverseOperations"][0].reverse();
+  const undo = getUndoOperations(doc);
   doc["_lifeCycleStage"] = "change";
-  const historyChanged = doc.undoManager?.["_record"](undo);
+  const historyChanged = doc.undoManager["_record"](undo);
   const documentChanged = hasDocumentChanges();
   if (!documentChanged && !historyChanged) return;
   doc["_changeListeners"].forEach((listener) =>
@@ -532,101 +433,35 @@ export const maybeTriggerListeners = (doc: Doc, ignoreEmptyDiff = false) => {
   );
 };
 
-function copyDeletedToDiff(node: DocNode) {
-  const doc = node.doc;
-  const diff = doc["_diff"];
-  const inserted = diff.inserted.has(node.id);
-  const undoInserted = undoHas(doc, "inserted", node.id);
-  const undoMoved = undoHas(doc, "moved", node.id);
-  const undoDeleted = undoHas(doc, "deleted", node.id);
-  const excluded = isExcluded(doc);
-  if (!inserted || (!excluded && !undoInserted)) {
-    const current: Record<string, string> = node["_stateToJson"]();
-    for (const key in current) {
-      const full = doc["_inverseOperations"][1][node.id]?.[key];
-      const undo = undoValue(doc, node.id, key);
-      setInverseValue(
-        doc,
-        node.id,
-        key,
-        inserted ? full : (full ?? current[key]),
-        excluded || undoInserted ? undo : (undo ?? current[key]),
-      );
-    }
-  }
-  setMembership(doc, node, "inserted", false, excluded ? undoInserted : false);
-  setMembership(
-    doc,
-    node,
-    "moved",
-    inserted ? false : diff.moved.has(node.id),
-    excluded ? undoMoved : undoInserted ? false : undoMoved,
-  );
-  setMembership(
-    doc,
-    node,
-    "deleted",
-    diff.deleted.has(node.id) || !inserted,
-    excluded ? undoDeleted : undoDeleted || !undoInserted,
-  );
-}
-
-function getUndoOperations(doc: Doc) {
-  if (doc["_transactionFlags"]?.skipUndo) return;
-  const base = doc["_inverseOperations"];
-  const changes = doc["_undoChanges"];
-  if (!changes)
-    return hasChanges(doc["_diff"], doc["_operations"][1]) ? base : undefined;
-  let state = base[1];
-  changes?.nodes?.forEach((node, id) => {
-    if (!node.state) return;
-    if (state === base[1]) state = { ...state };
-    const patch = { ...state[id] };
-    node.state.forEach((value, key) => {
-      if (value === undefined) delete patch[key];
-      else patch[key] = value;
-    });
-    if (isObjectEmpty(patch)) delete state[id];
-    else state[id] = patch;
-  });
-  // Excluded writes can cancel the final undo effect too. Preserve state for
-  // nodes whose inverse recreates them, even when their current value matches.
+function getUndoOperations(doc: Doc): Operations | undefined {
+  if (doc["_transactionFlags"].skipUndo) return;
+  const undo = doc["_undo"];
+  // An ordinary transaction shares its entire inverse with history.
+  if (!undo)
+    return hasChanges(doc["_diff"], doc["_operations"][1])
+      ? doc["_inverseOperations"]
+      : undefined;
+  undo.inverse[0].reverse();
+  const state = undo.inverse[1];
+  // Excluded writes can leave a captured value equal to the current one. Drop
+  // those, but keep the state of nodes whose inverse recreates them.
   for (const id in state) {
     const node = doc.getNodeById(id);
-    if (!node || undoHas(doc, "moved", id)) continue;
-    for (const key in state[id]) {
-      if (stringifyStateKey(node, key) !== state[id][key]) continue;
-      if (state === base[1]) state = { ...state };
-      if (state[id] === base[1][id]) state[id] = { ...state[id] };
-      delete state[id]![key];
+    if (!node || undo.moved.has(id)) continue;
+    const patch = state[id]!;
+    for (const key in patch) {
+      if (stringifyStateKey(node, key) === patch[key]) delete patch[key];
     }
-    if (isObjectEmpty(state[id]!)) delete state[id];
+    if (isObjectEmpty(patch)) delete state[id];
   }
-  let structuralCount =
-    doc["_diff"].inserted.size +
-    doc["_diff"].deleted.size +
-    doc["_diff"].moved.size;
-  changes?.nodes?.forEach((node, id) => {
-    for (const kind of ["inserted", "deleted", "moved"] as const) {
-      if (node[kind] !== undefined)
-        structuralCount +=
-          Number(node[kind]) - Number(doc["_diff"][kind].has(id));
-    }
-  });
-  if (!structuralCount && isObjectEmpty(state)) return;
-  let ordered = base[0];
-  if (changes?.ordered) {
-    ordered = [];
-    for (let at = 0; at <= base[0].length; at++) {
-      const change = changes.ordered.get(at);
-      if (change?.before) ordered.push(...change.before);
-      const operation = base[0][at];
-      if (operation && !change?.omit) ordered.push(operation);
-    }
-  }
-  if (ordered === base[0] && state === base[1]) return base;
-  const inverse: Operations = [ordered, state];
-  return inverse;
+  if (
+    !undo.inserted.size &&
+    !undo.deleted.size &&
+    !undo.moved.size &&
+    isObjectEmpty(state)
+  )
+    return;
+  return undo.inverse;
 }
 
 type InsertOperation = [

--- a/packages/docnode/src/undoManager.ts
+++ b/packages/docnode/src/undoManager.ts
@@ -41,50 +41,50 @@ export class UndoManager {
     this._doc = doc;
     this._maxUndoSteps = options?.maxUndoSteps ?? 0;
     this._mergeInterval = options?.mergeInterval ?? 500;
-    if (!this.isEnabled) return;
+  }
 
-    this._doc.onChange((event) => {
-      if (event.flags?.skipUndo) return;
-      const item: UndoStackItem = {
-        operations: event.inverseOperations,
-        meta: new Map(),
-      };
-      if (this._txType === "update") {
-        const now = Date.now();
-        const lastItem = this._undoStack.at(-1);
-        if (
-          lastItem &&
-          this._lastUpdate !== undefined &&
-          now - this._lastUpdate < this._mergeInterval
-        ) {
-          lastItem.operations = mergeOperations(
-            item.operations,
-            lastItem.operations,
-          );
-          this._pushHandlers.forEach((h) =>
-            h({ meta: lastItem.meta, type: "undo" }),
-          );
-        } else {
-          if (this._undoStack.length >= this._maxUndoSteps) {
-            this._undoStack.shift();
-          }
-          this._undoStack.push(item);
-          this._pushHandlers.forEach((h) =>
-            h({ meta: item.meta, type: "undo" }),
-          );
-        }
-        this._redoStack = [];
-        this._lastUpdate = now;
-      } else if (this._txType === "undo") {
-        this._redoStack.push(item);
-        this._txType = "update";
-        this._pushHandlers.forEach((h) => h({ meta: item.meta, type: "redo" }));
+  protected _record() {
+    if (!this.isEnabled) return;
+    const operations = this._doc["_undoInverseOperations"];
+    if (
+      !operations[0].length &&
+      !Object.values(operations[1]).some((patch) => Object.keys(patch).length)
+    )
+      return;
+    const item: UndoStackItem = { operations, meta: new Map() };
+    if (this._txType === "update") {
+      const now = Date.now();
+      const lastItem = this._undoStack.at(-1);
+      if (
+        lastItem &&
+        this._lastUpdate !== undefined &&
+        now - this._lastUpdate < this._mergeInterval
+      ) {
+        lastItem.operations = mergeOperations(
+          item.operations,
+          lastItem.operations,
+        );
+        this._pushHandlers.forEach((h) =>
+          h({ meta: lastItem.meta, type: "undo" }),
+        );
       } else {
+        if (this._undoStack.length >= this._maxUndoSteps) {
+          this._undoStack.shift();
+        }
         this._undoStack.push(item);
-        this._txType = "update";
         this._pushHandlers.forEach((h) => h({ meta: item.meta, type: "undo" }));
       }
-    });
+      this._redoStack = [];
+      this._lastUpdate = now;
+    } else if (this._txType === "undo") {
+      this._redoStack.push(item);
+      this._txType = "update";
+      this._pushHandlers.forEach((h) => h({ meta: item.meta, type: "redo" }));
+    } else {
+      this._undoStack.push(item);
+      this._txType = "update";
+      this._pushHandlers.forEach((h) => h({ meta: item.meta, type: "undo" }));
+    }
   }
 
   get isEnabled() {

--- a/packages/docnode/src/undoManager.ts
+++ b/packages/docnode/src/undoManager.ts
@@ -37,20 +37,40 @@ export class UndoManager {
   private _pushHandlers = new Set<Handler>();
   private _popHandlers = new Set<Handler>();
 
+  protected _skipUndoDepth = 0;
+
+  /** Excludes only synchronous mutations in the callback from user undo.
+   * Does not commit. Rollback and change events still include every mutation.
+   */
+  skipUndo<T>(callback: () => T extends PromiseLike<unknown> ? never : T): T {
+    this._skipUndoDepth++;
+    try {
+      const result = callback();
+      if (
+        result !== null &&
+        (typeof result === "object" || typeof result === "function") &&
+        "then" in result &&
+        typeof result.then === "function"
+      ) {
+        throw new Error("skipUndo requires a synchronous callback");
+      }
+      return result;
+    } catch (error) {
+      if (this._doc["_lifeCycleStage"] === "update") this._doc.abort();
+      throw error;
+    } finally {
+      this._skipUndoDepth--;
+    }
+  }
+
   constructor(doc: Doc, options?: UndoManagerConfig) {
     this._doc = doc;
     this._maxUndoSteps = options?.maxUndoSteps ?? 0;
     this._mergeInterval = options?.mergeInterval ?? 500;
   }
 
-  protected _record() {
-    if (!this.isEnabled) return;
-    const operations = this._doc["_undoInverseOperations"];
-    if (
-      !operations[0].length &&
-      !Object.values(operations[1]).some((patch) => Object.keys(patch).length)
-    )
-      return;
+  protected _record(operations: Operations | undefined) {
+    if (!this.isEnabled || !operations) return;
     const item: UndoStackItem = { operations, meta: new Map() };
     if (this._txType === "update") {
       const now = Date.now();
@@ -85,6 +105,7 @@ export class UndoManager {
       this._txType = "update";
       this._pushHandlers.forEach((h) => h({ meta: item.meta, type: "undo" }));
     }
+    return true;
   }
 
   get isEnabled() {

--- a/packages/docsync/src/bindings/docnode.ts
+++ b/packages/docsync/src/bindings/docnode.ts
@@ -34,7 +34,8 @@ export const DocNodeBinding = (docConfigs: DocConfig[]) => {
       cb: (ev: { operations: Operations; flags?: TransactionFlags }) => void,
     ) => doc.onChange(cb),
     applyOperations: (doc, operations, flags) => {
-      doc.applyOperations(operations, flags);
+      if (flags?.skipUndo) doc.skipUndo(() => doc.applyOperations(operations));
+      else doc.applyOperations(operations);
     },
     exportHistory: (doc) => doc.undoManager.exportHistory(),
     importHistory: (doc, history) => {

--- a/packages/docsync/src/bindings/docnode.ts
+++ b/packages/docsync/src/bindings/docnode.ts
@@ -32,9 +32,19 @@ export const DocNodeBinding = (docConfigs: DocConfig[]) => {
     onChange: (
       doc,
       cb: (ev: { operations: Operations; flags?: TransactionFlags }) => void,
-    ) => doc.onChange(cb),
+    ) =>
+      doc.onChange((event) => {
+        // DocNode also announces history-only changes. They are local to its
+        // undo manager and must not create sync work or broadcasts.
+        if (
+          event.operations[0].length ||
+          Object.keys(event.operations[1]).length
+        )
+          cb(event);
+      }),
     applyOperations: (doc, operations, flags) => {
-      if (flags?.skipUndo) doc.skipUndo(() => doc.applyOperations(operations));
+      if (flags?.skipUndo)
+        doc.undoManager.skipUndo(() => doc.applyOperations(operations));
       else doc.applyOperations(operations);
     },
     exportHistory: (doc) => doc.undoManager.exportHistory(),

--- a/packages/docsync2/src/client/bindings/docnode.ts
+++ b/packages/docsync2/src/client/bindings/docnode.ts
@@ -35,7 +35,8 @@ export const DocNodeBinding = (docConfigs: DocConfig[]) => {
     },
     onChange: (doc, cb) => doc.onChange(cb),
     applyOperations: (doc, operations, flags) => {
-      doc.applyOperations(operations, flags);
+      if (flags?.skipUndo) doc.skipUndo(() => doc.applyOperations(operations));
+      else doc.applyOperations(operations);
     },
   });
 };

--- a/packages/docsync2/src/client/bindings/docnode.ts
+++ b/packages/docsync2/src/client/bindings/docnode.ts
@@ -33,9 +33,18 @@ export const DocNodeBinding = (docConfigs: DocConfig[]) => {
       doc.forceCommit();
       return doc;
     },
-    onChange: (doc, cb) => doc.onChange(cb),
+    onChange: (doc, cb) =>
+      doc.onChange((event) => {
+        // History-only notifications are not document operations to sync.
+        if (
+          event.operations[0].length ||
+          Object.keys(event.operations[1]).length
+        )
+          cb(event);
+      }),
     applyOperations: (doc, operations, flags) => {
-      if (flags?.skipUndo) doc.skipUndo(() => doc.applyOperations(operations));
+      if (flags?.skipUndo)
+        doc.undoManager.skipUndo(() => doc.applyOperations(operations));
       else doc.applyOperations(operations);
     },
   });

--- a/tests/docnode-lexical/setupUndoManager.test.ts
+++ b/tests/docnode-lexical/setupUndoManager.test.ts
@@ -84,11 +84,11 @@ describe("setupUndoManager doc undo manager", () => {
       REDO_COMMAND,
       COMMAND_PRIORITY_HIGH,
     );
-    expect(listenerCount(doc)).toBe(1);
+    expect(listenerCount(doc)).toBe(0);
 
     const off1 = setupUndoManager(editor, doc, emptyKeyBinding());
-    // +1 from the built-in undo manager, +1 from CAN_UNDO/REDO dispatcher.
-    expect(listenerCount(doc)).toBe(2);
+    // The binding adds one CAN_UNDO/REDO dispatcher.
+    expect(listenerCount(doc)).toBe(1);
     expect(
       commandListenerCount(editor, UNDO_COMMAND, COMMAND_PRIORITY_HIGH),
     ).toBe(initialUndoHandlerCount + 1);
@@ -102,8 +102,8 @@ describe("setupUndoManager doc undo manager", () => {
     expect(doc.root.first).toBeDefined();
 
     off1();
-    // The CAN_* dispatcher is gone; doc.undoManager's listener stays.
-    expect(listenerCount(doc)).toBe(1);
+    // The CAN_* dispatcher is gone; history has no change listener.
+    expect(listenerCount(doc)).toBe(0);
     expect(
       commandListenerCount(editor, UNDO_COMMAND, COMMAND_PRIORITY_HIGH),
     ).toBe(initialUndoHandlerCount);
@@ -113,7 +113,7 @@ describe("setupUndoManager doc undo manager", () => {
 
     const off2 = setupUndoManager(editor, doc, emptyKeyBinding());
     // Only the CAN_* dispatcher is added.
-    expect(listenerCount(doc)).toBe(2);
+    expect(listenerCount(doc)).toBe(1);
 
     // The history survived the remount → UNDO_COMMAND reverts the doc change
     // through doc.undoManager.
@@ -213,11 +213,10 @@ describe("setupUndoManager doc undo manager", () => {
     const doc = createLexicalDoc({ mergeInterval: 500 });
     const editor = makeEditor();
     const docNode = doc.createNode(LexicalDocNode);
-    doc.forceCommit(
-      () => {
+    doc.skipUndo(() =>
+      doc.forceCommit(() => {
         doc.root.append(docNode);
-      },
-      { skipUndo: true },
+      }),
     );
 
     let textKey = "";

--- a/tests/docnode-lexical/setupUndoManager.test.ts
+++ b/tests/docnode-lexical/setupUndoManager.test.ts
@@ -67,6 +67,29 @@ const forceGc = async (): Promise<void> => {
 };
 
 describe("setupUndoManager doc undo manager", () => {
+  it("updates CAN_UNDO when only the document history changes", () => {
+    const doc = createLexicalDoc();
+    const editor = makeEditor();
+    const values: boolean[] = [];
+    const offCommand = editor.registerCommand(
+      CAN_UNDO_COMMAND,
+      (value) => {
+        values.push(value);
+        return false;
+      },
+      COMMAND_PRIORITY_LOW,
+    );
+    const off = setupUndoManager(editor, doc, emptyKeyBinding());
+    const node = doc.createNode(LexicalDocNode);
+    doc.undoManager.skipUndo(() => doc.root.append(node));
+    node.delete();
+    doc.forceCommit();
+    expect(doc.undoManager.canUndo()).toBe(true);
+    expect(values).toStrictEqual([false, true]);
+    off();
+    offCommand();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -213,7 +236,7 @@ describe("setupUndoManager doc undo manager", () => {
     const doc = createLexicalDoc({ mergeInterval: 500 });
     const editor = makeEditor();
     const docNode = doc.createNode(LexicalDocNode);
-    doc.skipUndo(() =>
+    doc.undoManager.skipUndo(() =>
       doc.forceCommit(() => {
         doc.root.append(docNode);
       }),

--- a/tests/docnode/coverage.test.ts
+++ b/tests/docnode/coverage.test.ts
@@ -202,7 +202,7 @@ describe("undoManager.ts coverage", () => {
     const doc = createTextDocWithUndo(2);
     const undoManager = doc.undoManager;
     expect(undoManager.isEnabled).toBe(true);
-    expect(doc["_changeListeners"].size).toBe(1);
+    expect(doc["_changeListeners"].size).toBe(0);
 
     doc.root.append(...text(doc, "1"));
     doc.forceCommit();

--- a/tests/docnode/skipUndo.test.ts
+++ b/tests/docnode/skipUndo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { Doc, defineNode, string, type ChangeEvent } from "@docukit/docnode";
+import { Doc, type ChangeEvent } from "@docukit/docnode";
 import {
   assertDoc,
   checkUndoManager,
@@ -521,50 +521,6 @@ describe("undo cancellation at commit", () => {
     expect(undo[1][other!.id]).toStrictEqual(inverse[1][other!.id]);
     doc.undoManager.undo();
     assertDoc(doc, ["0", "other"]);
-  });
-
-  test("pruning no-op state preserves the complete inverse when normalization changes structure", () => {
-    const Pair = defineNode({
-      type: "pair",
-      state: { first: string("0"), second: string("0") },
-    });
-    let addDuringNormalize = false;
-    const doc = new Doc({
-      type: "root",
-      undoManager: { maxUndoSteps: 10 },
-      extensions: [
-        {
-          nodes: [Pair],
-          register(doc) {
-            doc.onNormalize(() => {
-              if (!addDuringNormalize) return;
-              addDuringNormalize = false;
-              doc.undoManager.skipUndo(() =>
-                doc.root.append(doc.createNode(Pair)),
-              );
-            });
-          },
-        },
-      ],
-    });
-    const node = doc.createNode(Pair);
-    const events: ChangeEvent[] = [];
-    const unchanged = {
-      first: JSON.stringify("0"),
-      second: JSON.stringify("0"),
-    };
-    checkUndoManager(2, doc, () => {
-      doc.undoManager.skipUndo(() => doc.root.append(node));
-      doc.forceCommit();
-      doc.onChange((event) => events.push(event));
-      addDuringNormalize = true;
-      doc.applyOperations([[], { [node.id]: unchanged }]);
-    });
-    expect(doc.undoManager.canUndo()).toBe(false);
-    expect(events).toHaveLength(1);
-    expect(events[0]!.inverseOperations[1][node.id]).toStrictEqual(unchanged);
-    expect(doc.root.first!.next).toBe(doc.root.last);
-    expect(doc.root.last).not.toBe(node);
   });
 
   test("undo of a new parent also removes its excluded descendants", () => {

--- a/tests/docnode/skipUndo.test.ts
+++ b/tests/docnode/skipUndo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { Doc, type ChangeEvent } from "@docukit/docnode";
+import { Doc, defineNode, string, type ChangeEvent } from "@docukit/docnode";
 import {
   assertDoc,
   createTextDocWithUndo,
@@ -12,11 +12,11 @@ describe("skipUndo", () => {
   test("keeps one observable transaction and a different inverse for user undo", () => {
     const doc = createTextDocWithUndo();
     const [trash, projects] = text(doc, "Trash", "Projects");
-    doc.skipUndo(() => doc.root.append(trash!, projects!));
+    doc.undoManager.skipUndo(() => doc.root.append(trash!, projects!));
     doc.forceCommit();
     const events: ChangeEvent[] = [];
     doc.onChange((event) => events.push(event));
-    const page = doc.skipUndo(() => {
+    const page = doc.undoManager.skipUndo(() => {
       const [page] = text(doc, "Page");
       trash!.append(page!);
       return page!;
@@ -44,9 +44,9 @@ describe("skipUndo", () => {
   test("captures the value immediately before the undoable portion", () => {
     const doc = createTextDocWithUndo();
     const [node] = text(doc, "Original");
-    doc.skipUndo(() => doc.root.append(node!));
+    doc.undoManager.skipUndo(() => doc.root.append(node!));
     doc.forceCommit();
-    doc.skipUndo(() => node!.state.value.set("Automatic"));
+    doc.undoManager.skipUndo(() => node!.state.value.set("Automatic"));
     node!.state.value.set("Manual");
     doc.forceCommit();
     doc.undoManager.undo();
@@ -61,8 +61,8 @@ describe("skipUndo", () => {
     doc.root.append(...text(doc, "undoable"));
     doc.forceCommit();
     doc.undoManager.undo();
-    const result = doc.skipUndo(() =>
-      doc.skipUndo(() => {
+    const result = doc.undoManager.skipUndo(() =>
+      doc.undoManager.skipUndo(() => {
         doc.root.append(...text(doc, "excluded"));
         other.root.append(...text(other, "other"));
         return 42;
@@ -81,7 +81,7 @@ describe("skipUndo", () => {
     const doc = createTextDocWithUndo();
     doc.root.append(...text(doc, "normal"));
     expect(() =>
-      doc.skipUndo(() => {
+      doc.undoManager.skipUndo(() => {
         doc.root.append(...text(doc, "excluded"));
         throw new Error("failure");
       }),
@@ -95,13 +95,109 @@ describe("skipUndo", () => {
 });
 
 describe("mixed history boundaries", () => {
+  test("a state updater returning the current value leaves history unchanged", () => {
+    const doc = createTextDocWithUndo();
+    const [node] = text(doc, "0");
+    doc.undoManager.skipUndo(() => doc.root.append(node!));
+    doc.forceCommit();
+    let changes = 0;
+    doc.onChange(() => changes++);
+    node!.state.value.set((value) => value);
+    doc.forceCommit();
+    expect(doc.undoManager.canUndo()).toBe(false);
+    expect(changes).toBe(0);
+  });
+
+  test("cancelled undoable writes do not create history for an unrelated excluded edit", () => {
+    const doc = createTextDocWithUndo();
+    const [node, other] = text(doc, "0", "other");
+    doc.undoManager.skipUndo(() => doc.root.append(node!, other!));
+    doc.forceCommit();
+    const events: ChangeEvent[] = [];
+    doc.onChange((event) => events.push(event));
+    node!.state.value.set("1");
+    doc.undoManager.skipUndo(() => other!.state.value.set("automatic"));
+    node!.state.value.set("0");
+    doc.forceCommit();
+    expect(doc.undoManager.canUndo()).toBe(false);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.operations).toStrictEqual([
+      [],
+      { [other!.id]: { value: JSON.stringify("automatic") } },
+    ]);
+    expect(events[0]!.flags).toStrictEqual({ skipUndo: true });
+  });
+
+  for (const callbackChanges of [false, true]) {
+    test(`cancelled writes preserve redo with ${callbackChanges ? "cancelled" : "empty"} excluded mutations`, () => {
+      const doc = createTextDocWithUndo();
+      const [node] = text(doc, "0");
+      doc.undoManager.skipUndo(() => doc.root.append(node!));
+      doc.forceCommit();
+      node!.state.value.set("previous edit");
+      doc.forceCommit();
+      doc.undoManager.undo();
+      const history = doc.undoManager.exportHistory();
+      const events: ChangeEvent[] = [];
+      doc.onChange((event) => events.push(event));
+
+      node!.state.value.set("1");
+      doc.undoManager.skipUndo(() => {
+        if (callbackChanges) {
+          node!.state.value.set("2");
+          node!.state.value.set("1");
+        }
+      });
+      node!.state.value.set("0");
+      doc.forceCommit();
+
+      expect(node!.state.value.get()).toBe("0");
+      expect(doc.undoManager.canUndo()).toBe(false);
+      expect(doc.undoManager.exportHistory()).toStrictEqual(history);
+      expect(events).toHaveLength(0);
+      doc.undoManager.redo();
+      expect(node!.state.value.get()).toBe("previous edit");
+    });
+  }
+
+  test("history-only changes emit an empty change after updating undo and redo", () => {
+    const doc = createTextDocWithUndo();
+    doc.root.append(...text(doc, "previous edit"));
+    doc.forceCommit();
+    doc.undoManager.undo();
+    const events: ChangeEvent[] = [];
+    doc.onChange((event) => {
+      events.push(event);
+      expect(doc.undoManager.canUndo()).toBe(true);
+      expect(doc.undoManager.canRedo()).toBe(false);
+    });
+    const [node] = text(doc, "temporary");
+    doc.undoManager.skipUndo(() => doc.root.append(node!));
+    node!.delete();
+    doc.forceCommit();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toStrictEqual({
+      operations: [[], {}],
+      inverseOperations: [[], {}],
+      diff: {
+        inserted: new Set(),
+        deleted: new Map(),
+        moved: new Set(),
+        updated: new Set(),
+      },
+      flags: {},
+    });
+    doc.forceCommit();
+    expect(events).toHaveLength(1);
+  });
+
   test("normal, excluded and normal writes share one undo step", () => {
     const doc = createTextDocWithUndo();
     const [node] = text(doc, "0");
-    doc.skipUndo(() => doc.root.append(node!));
+    doc.undoManager.skipUndo(() => doc.root.append(node!));
     doc.forceCommit();
     node!.state.value.set("1");
-    doc.skipUndo(() => node!.state.value.set("2"));
+    doc.undoManager.skipUndo(() => node!.state.value.set("2"));
     node!.state.value.set("3");
     doc.forceCommit();
     expect(doc.undoManager.exportHistory().undoStack).toHaveLength(1);
@@ -114,7 +210,7 @@ describe("mixed history boundaries", () => {
   test("skipped state on an inserted node survives undo of a later state change", () => {
     const doc = createTextDocWithUndo();
     const [node] = text(doc, "seed");
-    doc.skipUndo(() => doc.root.append(node!));
+    doc.undoManager.skipUndo(() => doc.root.append(node!));
     node!.state.value.set("edited");
     doc.forceCommit();
     doc.undoManager.undo();
@@ -127,9 +223,9 @@ describe("mixed history boundaries", () => {
   test("a skipped deletion is not resurrected by unrelated undo", () => {
     const doc = createTextDocWithUndo();
     const [removed, kept] = text(doc, "removed", "kept");
-    doc.skipUndo(() => doc.root.append(removed!, kept!));
+    doc.undoManager.skipUndo(() => doc.root.append(removed!, kept!));
     doc.forceCommit();
-    doc.skipUndo(() => removed!.delete());
+    doc.undoManager.skipUndo(() => removed!.delete());
     kept!.state.value.set("changed");
     doc.forceCommit();
     doc.undoManager.undo();
@@ -141,7 +237,7 @@ describe("mixed history boundaries", () => {
   test("deleting a skipped insertion restores its ID, descendants and latest state", () => {
     const doc = createTextDocWithUndo();
     const [parent, child] = text(doc, "parent", "child");
-    doc.skipUndo(() => {
+    doc.undoManager.skipUndo(() => {
       doc.root.append(parent!);
       parent!.append(child!);
     });
@@ -159,10 +255,10 @@ describe("mixed history boundaries", () => {
   test("rollback restores both portions after a move and a deletion", () => {
     const doc = createTextDocWithUndo();
     const [a, b, c] = text(doc, "A", "B", "C");
-    doc.skipUndo(() => doc.root.append(a!, b!, c!));
+    doc.undoManager.skipUndo(() => doc.root.append(a!, b!, c!));
     doc.forceCommit();
     expect(() =>
-      doc.skipUndo(() => {
+      doc.undoManager.skipUndo(() => {
         a!.move(b!, "append");
         c!.delete();
         throw new Error("cancel");
@@ -176,14 +272,14 @@ describe("mixed history boundaries", () => {
     const doc = createTextDocWithUndo();
     let changes = 0;
     doc.onChange(() => changes++);
-    expect(doc.skipUndo(() => undefined)).toBeUndefined();
-    expect(doc.skipUndo(() => null)).toBeNull();
-    expect(doc.skipUndo(() => ({ then: false }))).toStrictEqual({
+    expect(doc.undoManager.skipUndo(() => undefined)).toBeUndefined();
+    expect(doc.undoManager.skipUndo(() => null)).toBeNull();
+    expect(doc.undoManager.skipUndo(() => ({ then: false }))).toStrictEqual({
       then: false,
     });
     doc.root.append(...text(doc, "temporary"));
     doc.root.deleteChildren();
-    doc.skipUndo(() => undefined);
+    doc.undoManager.skipUndo(() => undefined);
     doc.forceCommit();
     expect(changes).toBe(0);
     expect(doc.undoManager.canUndo()).toBe(false);
@@ -193,14 +289,14 @@ describe("mixed history boundaries", () => {
     const doc = createTextDocWithUndo();
     expect(() => {
       // @ts-expect-error Async results cannot be used with a synchronous scope.
-      void doc.skipUndo(() => {
+      void doc.undoManager.skipUndo(() => {
         doc.root.append(...text(doc, "discard"));
         return Promise.resolve();
       });
     }).toThrow("synchronous");
     assertDoc(doc, []);
     expect(() =>
-      doc.skipUndo(() => {
+      doc.undoManager.skipUndo(() => {
         throw new Error("empty");
       }),
     ).toThrow("empty");
@@ -225,7 +321,7 @@ for (const skipNormalization of [false, true]) {
               )
                 return;
               const update = () => first.state.value.set("normalized");
-              if (skipNormalization) doc.skipUndo(update);
+              if (skipNormalization) doc.undoManager.skipUndo(update);
               else update();
             });
           },
@@ -235,10 +331,10 @@ for (const skipNormalization of [false, true]) {
     });
     doc.forceCommit();
     const [node] = text(doc, "original");
-    doc.skipUndo(() => doc.root.append(node!));
+    doc.undoManager.skipUndo(() => doc.root.append(node!));
     doc.forceCommit();
     normalize = true;
-    doc.skipUndo(() => {
+    doc.undoManager.skipUndo(() => {
       node!.state.value.set("excluded");
       // Explicit commit inside the scope must not suppress the normalizer.
       doc.forceCommit();
@@ -258,7 +354,7 @@ for (const skipNormalization of [false, true]) {
 test("mixed history and metadata survive export/import without recreating IDs", () => {
   const source = createTextDocWithUndo();
   const [node] = text(source, "seed");
-  source.skipUndo(() => source.root.append(node!));
+  source.undoManager.skipUndo(() => source.root.append(node!));
   node!.state.value.set("edited");
   const off = source.undoManager.onPush(({ meta }) =>
     meta.set("focusedId", node!.id),
@@ -286,4 +382,192 @@ test("mixed history and metadata survive export/import without recreating IDs", 
   expect(replacement.root.first!.id).toBe(node!.id);
   replacement.undoManager.redo();
   assertDoc(replacement, ["edited"]);
+});
+
+describe("shared inverse storage", () => {
+  test("ordinary mutations reuse the transaction inverse without undo differences", () => {
+    const doc = createTextDocWithUndo();
+    const [node] = text(doc, "0");
+    doc.undoManager.skipUndo(() => doc.root.append(node!));
+    doc.forceCommit();
+    node!.state.value.set("1");
+    const inverse = doc["_inverseOperations"];
+    expect(doc).not.toHaveProperty("_undoCapture");
+    expect(doc["_undoChanges"]).toBeUndefined();
+    doc.forceCommit();
+    expect(doc.undoManager["_undoStack"].at(-1)!.operations).toBe(inverse);
+  });
+
+  test("the manager owns the skip scope and Doc has no public skipUndo method", () => {
+    const doc = createTextDocWithUndo();
+    expect(doc).not.toHaveProperty("skipUndo");
+    expect(doc.undoManager).toHaveProperty("skipUndo", expect.any(Function));
+  });
+});
+
+describe("sparse undo differences", () => {
+  test("only the field with a different inverse is overridden; other patches are shared", () => {
+    const doc = createTextDocWithUndo();
+    const [node, other] = text(doc, "0", "other");
+    doc.undoManager.skipUndo(() => doc.root.append(node!, other!));
+    doc.forceCommit();
+    doc.undoManager.skipUndo(() => node!.state.value.set("1"));
+    node!.state.value.set("2");
+    other!.state.value.set("edited");
+    const inverse = doc["_inverseOperations"];
+    expect(doc["_undoChanges"]!.nodes!.get(node!.id)!.state).toStrictEqual(
+      new Map([["value", JSON.stringify("1")]]),
+    );
+    expect(doc["_undoChanges"]!.nodes!.has(other!.id)).toBe(false);
+    doc.forceCommit();
+    const undo = doc.undoManager["_undoStack"].at(-1)!.operations;
+    expect(undo[0]).toBe(inverse[0]);
+    expect(undo[1][other!.id]).toBe(inverse[1][other!.id]);
+    expect(inverse[1][node!.id]!.value).toBe(JSON.stringify("0"));
+    doc.undoManager.undo();
+    assertDoc(doc, ["1", "other"]);
+    doc.undoManager.redo();
+    assertDoc(doc, ["2", "edited"]);
+  });
+
+  test("a normal child of an excluded folder needs an undo-only inverse", () => {
+    const doc = createTextDocWithUndo();
+    const [folder, child, sibling] = text(doc, "folder", "child", "sibling");
+    doc.undoManager.skipUndo(() => doc.root.append(folder!));
+    folder!.append(child!);
+    folder!.append(sibling!);
+    child!.move(doc.root, "append");
+    const inverse = doc["_inverseOperations"];
+    const move = inverse[0].at(-1)!;
+    doc.forceCommit();
+    const undo = doc.undoManager["_undoStack"].at(-1)!.operations;
+    expect(undo[0][0]).toBe(move);
+    doc.undoManager.undo();
+    assertDoc(doc, ["folder"]);
+    expect(doc.getNodeById(folder!.id)).toBe(folder);
+    doc.undoManager.redo();
+    assertDoc(doc, ["folder", "__sibling", "child"]);
+    expect(doc.root.last!.id).toBe(child!.id);
+  });
+
+  test("deleting a normal child of an excluded parent leaves no history", () => {
+    const doc = createTextDocWithUndo();
+    const [folder, child] = text(doc, "folder", "child");
+    doc.undoManager.skipUndo(() => doc.root.append(folder!));
+    folder!.append(child!);
+    child!.delete();
+    doc.forceCommit();
+    expect(doc.undoManager.canUndo()).toBe(false);
+    assertDoc(doc, ["folder"]);
+  });
+
+  test("excluded writes that undo themselves release their state differences", () => {
+    const doc = createTextDocWithUndo();
+    const [node] = text(doc, "0");
+    doc.undoManager.skipUndo(() => doc.root.append(node!));
+    doc.forceCommit();
+    doc.undoManager.skipUndo(() => {
+      node!.state.value.set("1");
+      expect(doc["_undoChanges"]).toBeDefined();
+      node!.state.value.set("0");
+      expect(doc["_undoChanges"]).toBeUndefined();
+    });
+    node!.state.value.set("2");
+    const inverse = doc["_inverseOperations"];
+    doc.forceCommit();
+    expect(doc.undoManager["_undoStack"].at(-1)!.operations).toBe(inverse);
+    doc.undoManager.undo();
+    assertDoc(doc, ["0"]);
+  });
+});
+
+describe("undo cancellation at commit", () => {
+  test("an excluded write can cancel the only undoable field without clearing redo", () => {
+    const doc = createTextDocWithUndo();
+    const [node] = text(doc, "0");
+    doc.undoManager.skipUndo(() => doc.root.append(node!));
+    doc.forceCommit();
+    node!.state.value.set("previous");
+    doc.forceCommit();
+    doc.undoManager.undo();
+    const history = doc.undoManager.exportHistory();
+    node!.state.value.set("1");
+    doc.undoManager.skipUndo(() => node!.state.value.set("0"));
+    doc.forceCommit();
+    expect(doc.undoManager.exportHistory()).toStrictEqual(history);
+    expect(doc.undoManager.canUndo()).toBe(false);
+  });
+
+  test("cancelled fields are omitted while unrelated undo state remains shared", () => {
+    const doc = createTextDocWithUndo();
+    const [node, other] = text(doc, "0", "other");
+    doc.undoManager.skipUndo(() => doc.root.append(node!, other!));
+    doc.forceCommit();
+    node!.state.value.set("1");
+    other!.state.value.set("edited");
+    doc.undoManager.skipUndo(() => node!.state.value.set("0"));
+    const inverse = doc["_inverseOperations"];
+    doc.forceCommit();
+    const undo = doc.undoManager["_undoStack"].at(-1)!.operations;
+    expect(undo[1][node!.id]).toBeUndefined();
+    expect(undo[1][other!.id]).toBe(inverse[1][other!.id]);
+    doc.undoManager.undo();
+    assertDoc(doc, ["0", "other"]);
+  });
+
+  test("pruning no-op state preserves the complete inverse when normalization changes structure", () => {
+    const Pair = defineNode({
+      type: "pair",
+      state: { first: string("0"), second: string("0") },
+    });
+    let addDuringNormalize = false;
+    const doc = new Doc({
+      type: "root",
+      undoManager: { maxUndoSteps: 10 },
+      extensions: [
+        {
+          nodes: [Pair],
+          register(doc) {
+            doc.onNormalize(() => {
+              if (!addDuringNormalize) return;
+              addDuringNormalize = false;
+              doc.undoManager.skipUndo(() =>
+                doc.root.append(doc.createNode(Pair)),
+              );
+            });
+          },
+        },
+      ],
+    });
+    const node = doc.createNode(Pair);
+    doc.root.append(node);
+    doc.forceCommit();
+    const events: ChangeEvent[] = [];
+    doc.onChange((event) => events.push(event));
+    addDuringNormalize = true;
+    const unchanged = {
+      first: JSON.stringify("0"),
+      second: JSON.stringify("0"),
+    };
+    doc.applyOperations([[], { [node.id]: unchanged }]);
+    expect(doc.undoManager.canUndo()).toBe(false);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.inverseOperations[1][node.id]).toStrictEqual(unchanged);
+    expect(doc.root.first!.next).toBe(doc.root.last);
+    expect(doc.root.last).not.toBe(node);
+  });
+
+  test("undo of a new parent also removes its excluded descendants and shares the inverse", () => {
+    const doc = createTextDocWithUndo();
+    const [parent, child] = text(doc, "parent", "child");
+    doc.root.append(parent!);
+    doc.undoManager.skipUndo(() => parent!.append(child!));
+    const inverse = doc["_inverseOperations"];
+    doc.forceCommit();
+    expect(doc.undoManager["_undoStack"].at(-1)!.operations).toBe(inverse);
+    doc.undoManager.undo();
+    assertDoc(doc, []);
+    doc.undoManager.redo();
+    assertDoc(doc, ["parent", "__child"]);
+  });
 });

--- a/tests/docnode/skipUndo.test.ts
+++ b/tests/docnode/skipUndo.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import { Doc, defineNode, string, type ChangeEvent } from "@docukit/docnode";
 import {
   assertDoc,
+  checkUndoManager,
   createTextDocWithUndo,
   text,
   TextExtension,
@@ -11,44 +12,37 @@ import {
 describe("skipUndo", () => {
   test("keeps one observable transaction and a different inverse for user undo", () => {
     const doc = createTextDocWithUndo();
-    const [trash, projects] = text(doc, "Trash", "Projects");
-    doc.undoManager.skipUndo(() => doc.root.append(trash!, projects!));
-    doc.forceCommit();
-    const events: ChangeEvent[] = [];
-    doc.onChange((event) => events.push(event));
-    const page = doc.undoManager.skipUndo(() => {
-      const [page] = text(doc, "Page");
-      trash!.append(page!);
-      return page!;
+    const [trash, projects, page] = text(doc, "Trash", "Projects", "Page");
+    let changes = 0;
+    checkUndoManager(2, doc, () => {
+      doc.undoManager.skipUndo(() => doc.root.append(trash!, projects!));
+      doc.forceCommit();
+      const off = doc.onChange(() => changes++);
+      doc.undoManager.skipUndo(() => trash!.append(page!));
+      page!.move(projects!, "append");
+      expect(changes).toBe(0);
+      doc.forceCommit();
+      expect(changes).toBe(1);
+      off();
     });
-    page.move(projects!, "append");
-    expect(events).toHaveLength(0);
-    doc.forceCommit();
-    expect(events).toHaveLength(1);
     doc.undoManager.undo();
-    expect(doc.getNodeById(page.id)).toBe(page);
-    expect(page.parent).toBe(trash);
+    expect(doc.getNodeById(page!.id)).toBe(page);
+    expect(page!.parent).toBe(trash);
     doc.undoManager.redo();
-    expect(page.parent).toBe(projects);
-    expect(page.state.value.get()).toBe("Page");
-    const replica = Doc.fromJSON(
-      { type: "root", extensions: [TextExtension] },
-      doc.toJSON(),
-    );
-    replica.forceCommit();
-    replica.applyOperations(events[0]!.inverseOperations);
-    expect(replica.getNodeById(page.id)).toBeUndefined();
-    replica.dispose();
+    expect(page!.parent).toBe(projects);
+    expect(page!.state.value.get()).toBe("Page");
   });
 
   test("captures the value immediately before the undoable portion", () => {
     const doc = createTextDocWithUndo();
     const [node] = text(doc, "Original");
-    doc.undoManager.skipUndo(() => doc.root.append(node!));
-    doc.forceCommit();
-    doc.undoManager.skipUndo(() => node!.state.value.set("Automatic"));
-    node!.state.value.set("Manual");
-    doc.forceCommit();
+    checkUndoManager(2, doc, () => {
+      doc.undoManager.skipUndo(() => doc.root.append(node!));
+      doc.forceCommit();
+      doc.undoManager.skipUndo(() => node!.state.value.set("Automatic"));
+      node!.state.value.set("Manual");
+      doc.forceCommit();
+    });
     doc.undoManager.undo();
     expect(node!.state.value.get()).toBe("Automatic");
     doc.undoManager.redo();
@@ -58,18 +52,20 @@ describe("skipUndo", () => {
   test("excluded changes preserve redo and nesting is local to the document", () => {
     const doc = createTextDocWithUndo();
     const other = createTextDocWithUndo();
-    doc.root.append(...text(doc, "undoable"));
-    doc.forceCommit();
-    doc.undoManager.undo();
-    const result = doc.undoManager.skipUndo(() =>
-      doc.undoManager.skipUndo(() => {
-        doc.root.append(...text(doc, "excluded"));
-        other.root.append(...text(other, "other"));
-        return 42;
-      }),
-    );
-    expect(result).toBe(42);
-    doc.forceCommit();
+    checkUndoManager(3, doc, () => {
+      doc.root.append(...text(doc, "undoable"));
+      doc.forceCommit();
+      doc.undoManager.undo();
+      const result = doc.undoManager.skipUndo(() =>
+        doc.undoManager.skipUndo(() => {
+          doc.root.append(...text(doc, "excluded"));
+          other.root.append(...text(other, "other"));
+          return 42;
+        }),
+      );
+      expect(result).toBe(42);
+      doc.forceCommit();
+    });
     other.forceCommit();
     expect(doc.undoManager.canRedo()).toBe(true);
     expect(other.undoManager.canUndo()).toBe(true);
@@ -79,16 +75,18 @@ describe("skipUndo", () => {
 
   test("an exception rolls back normal and excluded mutations", () => {
     const doc = createTextDocWithUndo();
-    doc.root.append(...text(doc, "normal"));
-    expect(() =>
-      doc.undoManager.skipUndo(() => {
-        doc.root.append(...text(doc, "excluded"));
-        throw new Error("failure");
-      }),
-    ).toThrow("failure");
-    assertDoc(doc, []);
-    doc.root.append(...text(doc, "next"));
-    doc.forceCommit();
+    checkUndoManager(1, doc, () => {
+      doc.root.append(...text(doc, "normal"));
+      expect(() =>
+        doc.undoManager.skipUndo(() => {
+          doc.root.append(...text(doc, "excluded"));
+          throw new Error("failure");
+        }),
+      ).toThrow("failure");
+      assertDoc(doc, []);
+      doc.root.append(...text(doc, "next"));
+      doc.forceCommit();
+    });
     doc.undoManager.undo();
     assertDoc(doc, []);
   });
@@ -98,12 +96,14 @@ describe("mixed history boundaries", () => {
   test("a state updater returning the current value leaves history unchanged", () => {
     const doc = createTextDocWithUndo();
     const [node] = text(doc, "0");
-    doc.undoManager.skipUndo(() => doc.root.append(node!));
-    doc.forceCommit();
     let changes = 0;
-    doc.onChange(() => changes++);
-    node!.state.value.set((value) => value);
-    doc.forceCommit();
+    checkUndoManager(1, doc, () => {
+      doc.undoManager.skipUndo(() => doc.root.append(node!));
+      doc.forceCommit();
+      doc.onChange(() => changes++);
+      node!.state.value.set((value) => value);
+      doc.forceCommit();
+    });
     expect(doc.undoManager.canUndo()).toBe(false);
     expect(changes).toBe(0);
   });
@@ -111,14 +111,16 @@ describe("mixed history boundaries", () => {
   test("cancelled undoable writes do not create history for an unrelated excluded edit", () => {
     const doc = createTextDocWithUndo();
     const [node, other] = text(doc, "0", "other");
-    doc.undoManager.skipUndo(() => doc.root.append(node!, other!));
-    doc.forceCommit();
     const events: ChangeEvent[] = [];
-    doc.onChange((event) => events.push(event));
-    node!.state.value.set("1");
-    doc.undoManager.skipUndo(() => other!.state.value.set("automatic"));
-    node!.state.value.set("0");
-    doc.forceCommit();
+    checkUndoManager(2, doc, () => {
+      doc.undoManager.skipUndo(() => doc.root.append(node!, other!));
+      doc.forceCommit();
+      doc.onChange((event) => events.push(event));
+      node!.state.value.set("1");
+      doc.undoManager.skipUndo(() => other!.state.value.set("automatic"));
+      node!.state.value.set("0");
+      doc.forceCommit();
+    });
     expect(doc.undoManager.canUndo()).toBe(false);
     expect(events).toHaveLength(1);
     expect(events[0]!.operations).toStrictEqual([
@@ -132,28 +134,28 @@ describe("mixed history boundaries", () => {
     test(`cancelled writes preserve redo with ${callbackChanges ? "cancelled" : "empty"} excluded mutations`, () => {
       const doc = createTextDocWithUndo();
       const [node] = text(doc, "0");
-      doc.undoManager.skipUndo(() => doc.root.append(node!));
-      doc.forceCommit();
-      node!.state.value.set("previous edit");
-      doc.forceCommit();
-      doc.undoManager.undo();
-      const history = doc.undoManager.exportHistory();
       const events: ChangeEvent[] = [];
-      doc.onChange((event) => events.push(event));
-
-      node!.state.value.set("1");
-      doc.undoManager.skipUndo(() => {
-        if (callbackChanges) {
-          node!.state.value.set("2");
-          node!.state.value.set("1");
-        }
+      checkUndoManager(3, doc, () => {
+        doc.undoManager.skipUndo(() => doc.root.append(node!));
+        doc.forceCommit();
+        node!.state.value.set("previous edit");
+        doc.forceCommit();
+        doc.undoManager.undo();
+        const history = doc.undoManager.exportHistory();
+        doc.onChange((event) => events.push(event));
+        node!.state.value.set("1");
+        doc.undoManager.skipUndo(() => {
+          if (callbackChanges) {
+            node!.state.value.set("2");
+            node!.state.value.set("1");
+          }
+        });
+        node!.state.value.set("0");
+        doc.forceCommit();
+        expect(node!.state.value.get()).toBe("0");
+        expect(doc.undoManager.canUndo()).toBe(false);
+        expect(doc.undoManager.exportHistory()).toStrictEqual(history);
       });
-      node!.state.value.set("0");
-      doc.forceCommit();
-
-      expect(node!.state.value.get()).toBe("0");
-      expect(doc.undoManager.canUndo()).toBe(false);
-      expect(doc.undoManager.exportHistory()).toStrictEqual(history);
       expect(events).toHaveLength(0);
       doc.undoManager.redo();
       expect(node!.state.value.get()).toBe("previous edit");
@@ -194,12 +196,14 @@ describe("mixed history boundaries", () => {
   test("normal, excluded and normal writes share one undo step", () => {
     const doc = createTextDocWithUndo();
     const [node] = text(doc, "0");
-    doc.undoManager.skipUndo(() => doc.root.append(node!));
-    doc.forceCommit();
-    node!.state.value.set("1");
-    doc.undoManager.skipUndo(() => node!.state.value.set("2"));
-    node!.state.value.set("3");
-    doc.forceCommit();
+    checkUndoManager(2, doc, () => {
+      doc.undoManager.skipUndo(() => doc.root.append(node!));
+      doc.forceCommit();
+      node!.state.value.set("1");
+      doc.undoManager.skipUndo(() => node!.state.value.set("2"));
+      node!.state.value.set("3");
+      doc.forceCommit();
+    });
     expect(doc.undoManager.exportHistory().undoStack).toHaveLength(1);
     doc.undoManager.undo();
     expect(node!.state.value.get()).toBe("0");
@@ -210,9 +214,11 @@ describe("mixed history boundaries", () => {
   test("skipped state on an inserted node survives undo of a later state change", () => {
     const doc = createTextDocWithUndo();
     const [node] = text(doc, "seed");
-    doc.undoManager.skipUndo(() => doc.root.append(node!));
-    node!.state.value.set("edited");
-    doc.forceCommit();
+    checkUndoManager(1, doc, () => {
+      doc.undoManager.skipUndo(() => doc.root.append(node!));
+      node!.state.value.set("edited");
+      doc.forceCommit();
+    });
     doc.undoManager.undo();
     expect(doc.getNodeById(node!.id)).toBe(node);
     expect(node!.state.value.get()).toBe("seed");
@@ -223,11 +229,13 @@ describe("mixed history boundaries", () => {
   test("a skipped deletion is not resurrected by unrelated undo", () => {
     const doc = createTextDocWithUndo();
     const [removed, kept] = text(doc, "removed", "kept");
-    doc.undoManager.skipUndo(() => doc.root.append(removed!, kept!));
-    doc.forceCommit();
-    doc.undoManager.skipUndo(() => removed!.delete());
-    kept!.state.value.set("changed");
-    doc.forceCommit();
+    checkUndoManager(2, doc, () => {
+      doc.undoManager.skipUndo(() => doc.root.append(removed!, kept!));
+      doc.forceCommit();
+      doc.undoManager.skipUndo(() => removed!.delete());
+      kept!.state.value.set("changed");
+      doc.forceCommit();
+    });
     doc.undoManager.undo();
     assertDoc(doc, ["kept"]);
     doc.undoManager.redo();
@@ -255,16 +263,18 @@ describe("mixed history boundaries", () => {
   test("rollback restores both portions after a move and a deletion", () => {
     const doc = createTextDocWithUndo();
     const [a, b, c] = text(doc, "A", "B", "C");
-    doc.undoManager.skipUndo(() => doc.root.append(a!, b!, c!));
-    doc.forceCommit();
-    expect(() =>
-      doc.undoManager.skipUndo(() => {
-        a!.move(b!, "append");
-        c!.delete();
-        throw new Error("cancel");
-      }),
-    ).toThrow("cancel");
-    assertDoc(doc, ["A", "B", "C"]);
+    checkUndoManager(1, doc, () => {
+      doc.undoManager.skipUndo(() => doc.root.append(a!, b!, c!));
+      doc.forceCommit();
+      expect(() =>
+        doc.undoManager.skipUndo(() => {
+          a!.move(b!, "append");
+          c!.delete();
+          throw new Error("cancel");
+        }),
+      ).toThrow("cancel");
+      assertDoc(doc, ["A", "B", "C"]);
+    });
     expect(doc.undoManager.canUndo()).toBe(false);
   });
 
@@ -272,34 +282,38 @@ describe("mixed history boundaries", () => {
     const doc = createTextDocWithUndo();
     let changes = 0;
     doc.onChange(() => changes++);
-    expect(doc.undoManager.skipUndo(() => undefined)).toBeUndefined();
-    expect(doc.undoManager.skipUndo(() => null)).toBeNull();
-    expect(doc.undoManager.skipUndo(() => ({ then: false }))).toStrictEqual({
-      then: false,
+    checkUndoManager(0, doc, () => {
+      expect(doc.undoManager.skipUndo(() => undefined)).toBeUndefined();
+      expect(doc.undoManager.skipUndo(() => null)).toBeNull();
+      expect(doc.undoManager.skipUndo(() => ({ then: false }))).toStrictEqual({
+        then: false,
+      });
+      doc.root.append(...text(doc, "temporary"));
+      doc.root.deleteChildren();
+      doc.undoManager.skipUndo(() => undefined);
+      doc.forceCommit();
     });
-    doc.root.append(...text(doc, "temporary"));
-    doc.root.deleteChildren();
-    doc.undoManager.skipUndo(() => undefined);
-    doc.forceCommit();
     expect(changes).toBe(0);
     expect(doc.undoManager.canUndo()).toBe(false);
   });
 
   test("thenable results are rejected and pending mutations are rolled back", () => {
     const doc = createTextDocWithUndo();
-    expect(() => {
-      // @ts-expect-error Async results cannot be used with a synchronous scope.
-      void doc.undoManager.skipUndo(() => {
-        doc.root.append(...text(doc, "discard"));
-        return Promise.resolve();
-      });
-    }).toThrow("synchronous");
-    assertDoc(doc, []);
-    expect(() =>
-      doc.undoManager.skipUndo(() => {
-        throw new Error("empty");
-      }),
-    ).toThrow("empty");
+    checkUndoManager(0, doc, () => {
+      expect(() => {
+        // @ts-expect-error Async results cannot be used with a synchronous scope.
+        void doc.undoManager.skipUndo(() => {
+          doc.root.append(...text(doc, "discard"));
+          return Promise.resolve();
+        });
+      }).toThrow("synchronous");
+      assertDoc(doc, []);
+      expect(() =>
+        doc.undoManager.skipUndo(() => {
+          throw new Error("empty");
+        }),
+      ).toThrow("empty");
+    });
   });
 });
 
@@ -331,17 +345,19 @@ for (const skipNormalization of [false, true]) {
     });
     doc.forceCommit();
     const [node] = text(doc, "original");
-    doc.undoManager.skipUndo(() => doc.root.append(node!));
-    doc.forceCommit();
-    normalize = true;
-    doc.undoManager.skipUndo(() => {
-      node!.state.value.set("excluded");
-      // Explicit commit inside the scope must not suppress the normalizer.
+    checkUndoManager(2, doc, () => {
+      doc.undoManager.skipUndo(() => doc.root.append(node!));
       doc.forceCommit();
+      normalize = true;
+      doc.undoManager.skipUndo(() => {
+        node!.state.value.set("excluded");
+        // Explicit commit inside the scope must not suppress the normalizer.
+        doc.forceCommit();
+      });
+      normalize = false;
     });
     expect(node!.state.value.get()).toBe("normalized");
     expect(doc.undoManager.canUndo()).toBe(!skipNormalization);
-    normalize = false;
     if (!skipNormalization) {
       doc.undoManager.undo();
       expect(node!.state.value.get()).toBe("excluded");
@@ -354,12 +370,14 @@ for (const skipNormalization of [false, true]) {
 test("mixed history and metadata survive export/import without recreating IDs", () => {
   const source = createTextDocWithUndo();
   const [node] = text(source, "seed");
-  source.undoManager.skipUndo(() => source.root.append(node!));
-  node!.state.value.set("edited");
   const off = source.undoManager.onPush(({ meta }) =>
     meta.set("focusedId", node!.id),
   );
-  source.forceCommit();
+  checkUndoManager(1, source, () => {
+    source.undoManager.skipUndo(() => source.root.append(node!));
+    node!.state.value.set("edited");
+    source.forceCommit();
+  });
   const history = source.undoManager.exportHistory();
   off();
   const replacement = Doc.fromJSON(
@@ -392,21 +410,14 @@ describe("shared inverse storage", () => {
     doc.forceCommit();
     node!.state.value.set("1");
     const inverse = doc["_inverseOperations"];
-    expect(doc).not.toHaveProperty("_undoCapture");
-    expect(doc["_undoChanges"]).toBeUndefined();
+    expect(doc["_undo"]).toBeUndefined();
     doc.forceCommit();
     expect(doc.undoManager["_undoStack"].at(-1)!.operations).toBe(inverse);
   });
-
-  test("the manager owns the skip scope and Doc has no public skipUndo method", () => {
-    const doc = createTextDocWithUndo();
-    expect(doc).not.toHaveProperty("skipUndo");
-    expect(doc.undoManager).toHaveProperty("skipUndo", expect.any(Function));
-  });
 });
 
-describe("sparse undo differences", () => {
-  test("only the field with a different inverse is overridden; other patches are shared", () => {
+describe("undo view", () => {
+  test("captures the value before the first undoable write while the full inverse keeps the original", () => {
     const doc = createTextDocWithUndo();
     const [node, other] = text(doc, "0", "other");
     doc.undoManager.skipUndo(() => doc.root.append(node!, other!));
@@ -415,14 +426,10 @@ describe("sparse undo differences", () => {
     node!.state.value.set("2");
     other!.state.value.set("edited");
     const inverse = doc["_inverseOperations"];
-    expect(doc["_undoChanges"]!.nodes!.get(node!.id)!.state).toStrictEqual(
-      new Map([["value", JSON.stringify("1")]]),
-    );
-    expect(doc["_undoChanges"]!.nodes!.has(other!.id)).toBe(false);
+    expect(doc["_undo"]!.inverse[1][node!.id]!.value).toBe(JSON.stringify("1"));
     doc.forceCommit();
     const undo = doc.undoManager["_undoStack"].at(-1)!.operations;
-    expect(undo[0]).toBe(inverse[0]);
-    expect(undo[1][other!.id]).toBe(inverse[1][other!.id]);
+    expect(undo[1][other!.id]).toStrictEqual(inverse[1][other!.id]);
     expect(inverse[1][node!.id]!.value).toBe(JSON.stringify("0"));
     doc.undoManager.undo();
     assertDoc(doc, ["1", "other"]);
@@ -453,29 +460,28 @@ describe("sparse undo differences", () => {
   test("deleting a normal child of an excluded parent leaves no history", () => {
     const doc = createTextDocWithUndo();
     const [folder, child] = text(doc, "folder", "child");
-    doc.undoManager.skipUndo(() => doc.root.append(folder!));
-    folder!.append(child!);
-    child!.delete();
-    doc.forceCommit();
+    checkUndoManager(1, doc, () => {
+      doc.undoManager.skipUndo(() => doc.root.append(folder!));
+      folder!.append(child!);
+      child!.delete();
+      doc.forceCommit();
+    });
     expect(doc.undoManager.canUndo()).toBe(false);
     assertDoc(doc, ["folder"]);
   });
 
-  test("excluded writes that undo themselves release their state differences", () => {
+  test("excluded writes that cancel themselves leave nothing for undo", () => {
     const doc = createTextDocWithUndo();
     const [node] = text(doc, "0");
     doc.undoManager.skipUndo(() => doc.root.append(node!));
     doc.forceCommit();
     doc.undoManager.skipUndo(() => {
       node!.state.value.set("1");
-      expect(doc["_undoChanges"]).toBeDefined();
       node!.state.value.set("0");
-      expect(doc["_undoChanges"]).toBeUndefined();
     });
+    expect(doc["_undo"]!.inverse[1]).toStrictEqual({});
     node!.state.value.set("2");
-    const inverse = doc["_inverseOperations"];
     doc.forceCommit();
-    expect(doc.undoManager["_undoStack"].at(-1)!.operations).toBe(inverse);
     doc.undoManager.undo();
     assertDoc(doc, ["0"]);
   });
@@ -485,16 +491,18 @@ describe("undo cancellation at commit", () => {
   test("an excluded write can cancel the only undoable field without clearing redo", () => {
     const doc = createTextDocWithUndo();
     const [node] = text(doc, "0");
-    doc.undoManager.skipUndo(() => doc.root.append(node!));
-    doc.forceCommit();
-    node!.state.value.set("previous");
-    doc.forceCommit();
-    doc.undoManager.undo();
-    const history = doc.undoManager.exportHistory();
-    node!.state.value.set("1");
-    doc.undoManager.skipUndo(() => node!.state.value.set("0"));
-    doc.forceCommit();
-    expect(doc.undoManager.exportHistory()).toStrictEqual(history);
+    checkUndoManager(3, doc, () => {
+      doc.undoManager.skipUndo(() => doc.root.append(node!));
+      doc.forceCommit();
+      node!.state.value.set("previous");
+      doc.forceCommit();
+      doc.undoManager.undo();
+      const history = doc.undoManager.exportHistory();
+      node!.state.value.set("1");
+      doc.undoManager.skipUndo(() => node!.state.value.set("0"));
+      doc.forceCommit();
+      expect(doc.undoManager.exportHistory()).toStrictEqual(history);
+    });
     expect(doc.undoManager.canUndo()).toBe(false);
   });
 
@@ -510,7 +518,7 @@ describe("undo cancellation at commit", () => {
     doc.forceCommit();
     const undo = doc.undoManager["_undoStack"].at(-1)!.operations;
     expect(undo[1][node!.id]).toBeUndefined();
-    expect(undo[1][other!.id]).toBe(inverse[1][other!.id]);
+    expect(undo[1][other!.id]).toStrictEqual(inverse[1][other!.id]);
     doc.undoManager.undo();
     assertDoc(doc, ["0", "other"]);
   });
@@ -540,16 +548,18 @@ describe("undo cancellation at commit", () => {
       ],
     });
     const node = doc.createNode(Pair);
-    doc.root.append(node);
-    doc.forceCommit();
     const events: ChangeEvent[] = [];
-    doc.onChange((event) => events.push(event));
-    addDuringNormalize = true;
     const unchanged = {
       first: JSON.stringify("0"),
       second: JSON.stringify("0"),
     };
-    doc.applyOperations([[], { [node.id]: unchanged }]);
+    checkUndoManager(2, doc, () => {
+      doc.undoManager.skipUndo(() => doc.root.append(node));
+      doc.forceCommit();
+      doc.onChange((event) => events.push(event));
+      addDuringNormalize = true;
+      doc.applyOperations([[], { [node.id]: unchanged }]);
+    });
     expect(doc.undoManager.canUndo()).toBe(false);
     expect(events).toHaveLength(1);
     expect(events[0]!.inverseOperations[1][node.id]).toStrictEqual(unchanged);
@@ -557,14 +567,16 @@ describe("undo cancellation at commit", () => {
     expect(doc.root.last).not.toBe(node);
   });
 
-  test("undo of a new parent also removes its excluded descendants and shares the inverse", () => {
+  test("undo of a new parent also removes its excluded descendants", () => {
     const doc = createTextDocWithUndo();
     const [parent, child] = text(doc, "parent", "child");
     doc.root.append(parent!);
     doc.undoManager.skipUndo(() => parent!.append(child!));
     const inverse = doc["_inverseOperations"];
     doc.forceCommit();
-    expect(doc.undoManager["_undoStack"].at(-1)!.operations).toBe(inverse);
+    expect(doc.undoManager["_undoStack"].at(-1)!.operations).toStrictEqual(
+      inverse,
+    );
     doc.undoManager.undo();
     assertDoc(doc, []);
     doc.undoManager.redo();

--- a/tests/docnode/skipUndo.test.ts
+++ b/tests/docnode/skipUndo.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from "vitest";
+import { Doc, type ChangeEvent } from "@docukit/docnode";
+import {
+  assertDoc,
+  createTextDocWithUndo,
+  text,
+  TextExtension,
+  Text,
+} from "./utils.js";
+
+describe("skipUndo", () => {
+  test("keeps one observable transaction and a different inverse for user undo", () => {
+    const doc = createTextDocWithUndo();
+    const [trash, projects] = text(doc, "Trash", "Projects");
+    doc.skipUndo(() => doc.root.append(trash!, projects!));
+    doc.forceCommit();
+    const events: ChangeEvent[] = [];
+    doc.onChange((event) => events.push(event));
+    const page = doc.skipUndo(() => {
+      const [page] = text(doc, "Page");
+      trash!.append(page!);
+      return page!;
+    });
+    page.move(projects!, "append");
+    expect(events).toHaveLength(0);
+    doc.forceCommit();
+    expect(events).toHaveLength(1);
+    doc.undoManager.undo();
+    expect(doc.getNodeById(page.id)).toBe(page);
+    expect(page.parent).toBe(trash);
+    doc.undoManager.redo();
+    expect(page.parent).toBe(projects);
+    expect(page.state.value.get()).toBe("Page");
+    const replica = Doc.fromJSON(
+      { type: "root", extensions: [TextExtension] },
+      doc.toJSON(),
+    );
+    replica.forceCommit();
+    replica.applyOperations(events[0]!.inverseOperations);
+    expect(replica.getNodeById(page.id)).toBeUndefined();
+    replica.dispose();
+  });
+
+  test("captures the value immediately before the undoable portion", () => {
+    const doc = createTextDocWithUndo();
+    const [node] = text(doc, "Original");
+    doc.skipUndo(() => doc.root.append(node!));
+    doc.forceCommit();
+    doc.skipUndo(() => node!.state.value.set("Automatic"));
+    node!.state.value.set("Manual");
+    doc.forceCommit();
+    doc.undoManager.undo();
+    expect(node!.state.value.get()).toBe("Automatic");
+    doc.undoManager.redo();
+    expect(node!.state.value.get()).toBe("Manual");
+  });
+
+  test("excluded changes preserve redo and nesting is local to the document", () => {
+    const doc = createTextDocWithUndo();
+    const other = createTextDocWithUndo();
+    doc.root.append(...text(doc, "undoable"));
+    doc.forceCommit();
+    doc.undoManager.undo();
+    const result = doc.skipUndo(() =>
+      doc.skipUndo(() => {
+        doc.root.append(...text(doc, "excluded"));
+        other.root.append(...text(other, "other"));
+        return 42;
+      }),
+    );
+    expect(result).toBe(42);
+    doc.forceCommit();
+    other.forceCommit();
+    expect(doc.undoManager.canRedo()).toBe(true);
+    expect(other.undoManager.canUndo()).toBe(true);
+    doc.undoManager.redo();
+    assertDoc(doc, ["excluded", "undoable"]);
+  });
+
+  test("an exception rolls back normal and excluded mutations", () => {
+    const doc = createTextDocWithUndo();
+    doc.root.append(...text(doc, "normal"));
+    expect(() =>
+      doc.skipUndo(() => {
+        doc.root.append(...text(doc, "excluded"));
+        throw new Error("failure");
+      }),
+    ).toThrow("failure");
+    assertDoc(doc, []);
+    doc.root.append(...text(doc, "next"));
+    doc.forceCommit();
+    doc.undoManager.undo();
+    assertDoc(doc, []);
+  });
+});
+
+describe("mixed history boundaries", () => {
+  test("normal, excluded and normal writes share one undo step", () => {
+    const doc = createTextDocWithUndo();
+    const [node] = text(doc, "0");
+    doc.skipUndo(() => doc.root.append(node!));
+    doc.forceCommit();
+    node!.state.value.set("1");
+    doc.skipUndo(() => node!.state.value.set("2"));
+    node!.state.value.set("3");
+    doc.forceCommit();
+    expect(doc.undoManager.exportHistory().undoStack).toHaveLength(1);
+    doc.undoManager.undo();
+    expect(node!.state.value.get()).toBe("0");
+    doc.undoManager.redo();
+    expect(node!.state.value.get()).toBe("3");
+  });
+
+  test("skipped state on an inserted node survives undo of a later state change", () => {
+    const doc = createTextDocWithUndo();
+    const [node] = text(doc, "seed");
+    doc.skipUndo(() => doc.root.append(node!));
+    node!.state.value.set("edited");
+    doc.forceCommit();
+    doc.undoManager.undo();
+    expect(doc.getNodeById(node!.id)).toBe(node);
+    expect(node!.state.value.get()).toBe("seed");
+    doc.undoManager.redo();
+    expect(node!.state.value.get()).toBe("edited");
+  });
+
+  test("a skipped deletion is not resurrected by unrelated undo", () => {
+    const doc = createTextDocWithUndo();
+    const [removed, kept] = text(doc, "removed", "kept");
+    doc.skipUndo(() => doc.root.append(removed!, kept!));
+    doc.forceCommit();
+    doc.skipUndo(() => removed!.delete());
+    kept!.state.value.set("changed");
+    doc.forceCommit();
+    doc.undoManager.undo();
+    assertDoc(doc, ["kept"]);
+    doc.undoManager.redo();
+    assertDoc(doc, ["changed"]);
+  });
+
+  test("deleting a skipped insertion restores its ID, descendants and latest state", () => {
+    const doc = createTextDocWithUndo();
+    const [parent, child] = text(doc, "parent", "child");
+    doc.skipUndo(() => {
+      doc.root.append(parent!);
+      parent!.append(child!);
+    });
+    const ids = [parent!.id, child!.id];
+    parent!.delete();
+    doc.forceCommit();
+    doc.undoManager.undo();
+    assertDoc(doc, ["parent", "__child"]);
+    expect(doc.root.first!.id).toBe(ids[0]);
+    expect(doc.root.first!.first!.id).toBe(ids[1]);
+    doc.undoManager.redo();
+    assertDoc(doc, []);
+  });
+
+  test("rollback restores both portions after a move and a deletion", () => {
+    const doc = createTextDocWithUndo();
+    const [a, b, c] = text(doc, "A", "B", "C");
+    doc.skipUndo(() => doc.root.append(a!, b!, c!));
+    doc.forceCommit();
+    expect(() =>
+      doc.skipUndo(() => {
+        a!.move(b!, "append");
+        c!.delete();
+        throw new Error("cancel");
+      }),
+    ).toThrow("cancel");
+    assertDoc(doc, ["A", "B", "C"]);
+    expect(doc.undoManager.canUndo()).toBe(false);
+  });
+
+  test("empty portions do not create history or emit changes", () => {
+    const doc = createTextDocWithUndo();
+    let changes = 0;
+    doc.onChange(() => changes++);
+    expect(doc.skipUndo(() => undefined)).toBeUndefined();
+    expect(doc.skipUndo(() => null)).toBeNull();
+    expect(doc.skipUndo(() => ({ then: false }))).toStrictEqual({
+      then: false,
+    });
+    doc.root.append(...text(doc, "temporary"));
+    doc.root.deleteChildren();
+    doc.skipUndo(() => undefined);
+    doc.forceCommit();
+    expect(changes).toBe(0);
+    expect(doc.undoManager.canUndo()).toBe(false);
+  });
+
+  test("thenable results are rejected and pending mutations are rolled back", () => {
+    const doc = createTextDocWithUndo();
+    expect(() => {
+      // @ts-expect-error Async results cannot be used with a synchronous scope.
+      void doc.skipUndo(() => {
+        doc.root.append(...text(doc, "discard"));
+        return Promise.resolve();
+      });
+    }).toThrow("synchronous");
+    assertDoc(doc, []);
+    expect(() =>
+      doc.skipUndo(() => {
+        throw new Error("empty");
+      }),
+    ).toThrow("empty");
+  });
+});
+
+for (const skipNormalization of [false, true]) {
+  test(`normalization is ${skipNormalization ? "explicitly excluded" : "undoable after excluded mutations"}`, () => {
+    let normalize = false;
+    const doc = new Doc({
+      type: "root",
+      extensions: [
+        {
+          nodes: [Text],
+          register(doc) {
+            doc.onNormalize(() => {
+              const first = doc.root.first;
+              if (
+                !normalize ||
+                !first?.is(Text) ||
+                first.state.value.get() === "normalized"
+              )
+                return;
+              const update = () => first.state.value.set("normalized");
+              if (skipNormalization) doc.skipUndo(update);
+              else update();
+            });
+          },
+        },
+      ],
+      undoManager: { maxUndoSteps: 10, mergeInterval: 0 },
+    });
+    doc.forceCommit();
+    const [node] = text(doc, "original");
+    doc.skipUndo(() => doc.root.append(node!));
+    doc.forceCommit();
+    normalize = true;
+    doc.skipUndo(() => {
+      node!.state.value.set("excluded");
+      // Explicit commit inside the scope must not suppress the normalizer.
+      doc.forceCommit();
+    });
+    expect(node!.state.value.get()).toBe("normalized");
+    expect(doc.undoManager.canUndo()).toBe(!skipNormalization);
+    normalize = false;
+    if (!skipNormalization) {
+      doc.undoManager.undo();
+      expect(node!.state.value.get()).toBe("excluded");
+      doc.undoManager.redo();
+      expect(node!.state.value.get()).toBe("normalized");
+    }
+  });
+}
+
+test("mixed history and metadata survive export/import without recreating IDs", () => {
+  const source = createTextDocWithUndo();
+  const [node] = text(source, "seed");
+  source.skipUndo(() => source.root.append(node!));
+  node!.state.value.set("edited");
+  const off = source.undoManager.onPush(({ meta }) =>
+    meta.set("focusedId", node!.id),
+  );
+  source.forceCommit();
+  const history = source.undoManager.exportHistory();
+  off();
+  const replacement = Doc.fromJSON(
+    {
+      type: "root",
+      extensions: [TextExtension],
+      undoManager: { maxUndoSteps: 10, mergeInterval: 0 },
+    },
+    source.toJSON(),
+  );
+  replacement.forceCommit();
+  replacement.undoManager.importHistory(history);
+  let restoredId: unknown;
+  replacement.undoManager.onPop(({ meta }) => {
+    restoredId = meta.get("focusedId");
+  });
+  replacement.undoManager.undo();
+  expect(restoredId).toBe(node!.id);
+  assertDoc(replacement, ["seed"]);
+  expect(replacement.root.first!.id).toBe(node!.id);
+  replacement.undoManager.redo();
+  assertDoc(replacement, ["edited"]);
+});

--- a/tests/docnode/transactions.test.ts
+++ b/tests/docnode/transactions.test.ts
@@ -48,7 +48,7 @@ describe("update", () => {
       flags.push(event.flags);
     });
 
-    doc.skipUndo(() =>
+    doc.undoManager.skipUndo(() =>
       doc.forceCommit(() => {
         doc.root.append(...text(doc, "seed"));
       }),
@@ -72,7 +72,7 @@ describe("update", () => {
       flags.push(event.flags);
     });
 
-    doc.skipUndo(() =>
+    doc.undoManager.skipUndo(() =>
       doc.forceCommit(() => {
         doc.abort();
       }),
@@ -107,7 +107,7 @@ describe("update", () => {
     });
 
     expect(() =>
-      doc.skipUndo(() =>
+      doc.undoManager.skipUndo(() =>
         doc.forceCommit(() => {
           doc.root.append(...text(doc, "seed"));
           throw new Error("boom");
@@ -124,7 +124,7 @@ describe("update", () => {
     const doc = createTextDocWithUndo(10);
 
     expect(() =>
-      doc.skipUndo(() =>
+      doc.undoManager.skipUndo(() =>
         doc.forceCommit(() => {
           doc.root.append(...text(doc, "seed"));
           doc.forceCommit();
@@ -911,7 +911,7 @@ describe("applyOperations", () => {
     const doc = createTextDocWithUndo();
     const flags = collectFlags(doc, () => {
       doc.root.append(...text(doc, "local"));
-      doc.skipUndo(() => doc.applyOperations(remoteOperations));
+      doc.undoManager.skipUndo(() => doc.applyOperations(remoteOperations));
     });
 
     expect(flags).toStrictEqual([{}, { skipUndo: true }]);
@@ -940,7 +940,7 @@ describe("applyOperations", () => {
     const doc = createTextDocWithUndo();
     const undoManager = doc.undoManager;
 
-    doc.skipUndo(() => doc.applyOperations(remoteOperations));
+    doc.undoManager.skipUndo(() => doc.applyOperations(remoteOperations));
     expect(undoManager.canUndo()).toBe(false);
 
     doc.root.append(...text(doc, "local"));
@@ -952,7 +952,7 @@ describe("applyOperations", () => {
     const remoteOperations = createRemoteInsertOperations("remote");
     const doc = new Doc({ type: "root", extensions: [TextExtension] });
     const flags = collectFlags(doc, () => {
-      doc.skipUndo(() => doc.applyOperations(remoteOperations));
+      doc.undoManager.skipUndo(() => doc.applyOperations(remoteOperations));
       doc.root.append(...text(doc, "local"));
     });
     expect(flags).toStrictEqual([{ skipUndo: true }, {}]);

--- a/tests/docnode/transactions.test.ts
+++ b/tests/docnode/transactions.test.ts
@@ -1035,10 +1035,14 @@ describe("applyOperations", () => {
   test("an undo step made redundant by an excluded change is skipped without breaking history", () => {
     const doc = createTextDocWithUndo();
     const [trash, other] = text(doc, "Trash", "other");
-    doc.forceCommit(() => doc.root.append(trash!, other!), { skipUndo: true });
+    doc.undoManager.skipUndo(() =>
+      doc.forceCommit(() => doc.root.append(trash!, other!)),
+    );
     trash!.delete();
     doc.forceCommit();
-    doc.forceCommit(() => doc.root.append(trash!), { skipUndo: true });
+    doc.undoManager.skipUndo(() =>
+      doc.forceCommit(() => doc.root.append(trash!)),
+    );
     doc.undoManager.undo();
     assertDoc(doc, ["other", "Trash"]);
     expect(doc.undoManager.canUndo()).toBe(false);
@@ -1055,12 +1059,14 @@ describe("applyOperations", () => {
   test("a redo step made redundant by an excluded change is skipped without breaking history", () => {
     const doc = createTextDocWithUndo();
     const [node] = text(doc, "node");
-    doc.forceCommit(() => doc.root.append(node!), { skipUndo: true });
+    doc.undoManager.skipUndo(() =>
+      doc.forceCommit(() => doc.root.append(node!)),
+    );
     node!.delete();
     doc.forceCommit();
     doc.undoManager.undo();
     assertDoc(doc, ["node"]);
-    doc.forceCommit(() => node!.delete(), { skipUndo: true });
+    doc.undoManager.skipUndo(() => doc.forceCommit(() => node!.delete()));
     doc.undoManager.redo();
     assertDoc(doc, []);
     expect(doc.undoManager.canRedo()).toBe(false);

--- a/tests/docnode/transactions.test.ts
+++ b/tests/docnode/transactions.test.ts
@@ -48,11 +48,10 @@ describe("update", () => {
       flags.push(event.flags);
     });
 
-    doc.forceCommit(
-      () => {
+    doc.skipUndo(() =>
+      doc.forceCommit(() => {
         doc.root.append(...text(doc, "seed"));
-      },
-      { skipUndo: true },
+      }),
     );
 
     expect(flags).toStrictEqual([{ skipUndo: true }]);
@@ -73,11 +72,10 @@ describe("update", () => {
       flags.push(event.flags);
     });
 
-    doc.forceCommit(
-      () => {
+    doc.skipUndo(() =>
+      doc.forceCommit(() => {
         doc.abort();
-      },
-      { skipUndo: true },
+      }),
     );
     doc.root.append(...text(doc, "local"));
     doc.forceCommit();
@@ -95,7 +93,7 @@ describe("update", () => {
 
     doc.forceCommit(() => {
       doc.root.append(...text(doc, "seed"));
-    }, {});
+    });
 
     expect(storedFlags).toStrictEqual([{}]);
     expect(doc.undoManager.canUndo()).toBe(true);
@@ -109,12 +107,11 @@ describe("update", () => {
     });
 
     expect(() =>
-      doc.forceCommit(
-        () => {
+      doc.skipUndo(() =>
+        doc.forceCommit(() => {
           doc.root.append(...text(doc, "seed"));
           throw new Error("boom");
-        },
-        { skipUndo: true },
+        }),
       ),
     ).toThrowError("boom");
 
@@ -127,12 +124,11 @@ describe("update", () => {
     const doc = createTextDocWithUndo(10);
 
     expect(() =>
-      doc.forceCommit(
-        () => {
+      doc.skipUndo(() =>
+        doc.forceCommit(() => {
           doc.root.append(...text(doc, "seed"));
           doc.forceCommit();
-        },
-        { skipUndo: true },
+        }),
       ),
     ).toThrowError("You can't call forceCommit inside a forceCommit callback");
 
@@ -518,7 +514,7 @@ describe("undoManager", () => {
         doc.forceCommit(() => {
           node = doc.createNode(Text);
           doc.root.append(node);
-        }, {});
+        });
         if (!node) throw new Error("Expected seed node to be created");
 
         setNow(1600);
@@ -915,7 +911,7 @@ describe("applyOperations", () => {
     const doc = createTextDocWithUndo();
     const flags = collectFlags(doc, () => {
       doc.root.append(...text(doc, "local"));
-      doc.applyOperations(remoteOperations, { skipUndo: true });
+      doc.skipUndo(() => doc.applyOperations(remoteOperations));
     });
 
     expect(flags).toStrictEqual([{}, { skipUndo: true }]);
@@ -944,7 +940,7 @@ describe("applyOperations", () => {
     const doc = createTextDocWithUndo();
     const undoManager = doc.undoManager;
 
-    doc.applyOperations(remoteOperations, { skipUndo: true });
+    doc.skipUndo(() => doc.applyOperations(remoteOperations));
     expect(undoManager.canUndo()).toBe(false);
 
     doc.root.append(...text(doc, "local"));
@@ -956,7 +952,7 @@ describe("applyOperations", () => {
     const remoteOperations = createRemoteInsertOperations("remote");
     const doc = new Doc({ type: "root", extensions: [TextExtension] });
     const flags = collectFlags(doc, () => {
-      doc.applyOperations(remoteOperations, { skipUndo: true });
+      doc.skipUndo(() => doc.applyOperations(remoteOperations));
       doc.root.append(...text(doc, "local"));
     });
     expect(flags).toStrictEqual([{ skipUndo: true }, {}]);

--- a/tests/docnode/transactions.test.ts
+++ b/tests/docnode/transactions.test.ts
@@ -149,6 +149,20 @@ describe("throw errors and abort", () => {
     });
   });
 
+  test("abort applies inverse operations in reverse order", () => {
+    const doc = new Doc({ type: "root", extensions: [TextExtension] });
+    checkUndoManager(0, doc, () => {
+      const [node] = text(doc, "1");
+      doc.root.append(node!);
+      node!.delete();
+      // Insert then delete: replaying the inverses in insertion order would
+      // re-insert the node with an empty state instead of leaving it deleted.
+      doc.abort();
+      assertDoc(doc, []);
+      expect(doc.getNodeById(node!.id)).toBeUndefined();
+    });
+  });
+
   test("should rollback to previous state and not trigger listeners", () => {
     const doc = new Doc({ type: "root", extensions: [TextExtension] });
     const { root } = doc;

--- a/tests/docnode/utils.ts
+++ b/tests/docnode/utils.ts
@@ -285,6 +285,9 @@ export function checkUndoManager(
   callback: () => void,
 ) {
   const IS_TEST_NODE = false;
+  // The baseline must be a committed state; detached nodes created before the
+  // callback (e.g. `text(doc, ...)`) leave a pending transaction behind.
+  doc.forceCommit();
   const jsonDoc = doc.toJSON();
   const nodes = Array.from(doc["_nodeDefs"]);
   // This document will replay all doc operations in a single update
@@ -468,7 +471,7 @@ export function checkUndoManager(
         expect(getStateSnapshot(doc3, IS_TEST_NODE)).toStrictEqual(
           snapshots[i + 1],
         );
-        expect(changeEvent).toStrictEqual(changeEvents[i]);
+        expectSameChange(changeEvent, changeEvents[i]!);
       },
     );
   }
@@ -485,7 +488,7 @@ export function checkUndoManager(
         expect(getStateSnapshot(doc4, IS_TEST_NODE)).toStrictEqual(
           snapshots[i + 1],
         );
-        expect(changeEvent).toStrictEqual(changeEvents[i]);
+        expectSameChange(changeEvent, changeEvents[i]!);
       },
     );
     doc4.applyOperations(changeEvent.operations);
@@ -533,6 +536,17 @@ export function checkUndoManager(
       },
     );
   }
+}
+
+// Replicas replay operations without skipUndo, so their `flags` differ. Deleted
+// nodes are live objects whose links keep changing after the event, so they are
+// compared by id.
+function expectSameChange(actual: ChangeEvent, expected: ChangeEvent) {
+  const comparable = ({ flags: _flags, diff, ...rest }: ChangeEvent) => ({
+    ...rest,
+    diff: { ...diff, deleted: [...diff.deleted.keys()] },
+  });
+  expect(comparable(actual)).toStrictEqual(comparable(expected));
 }
 
 export const getPrevError = [

--- a/tests/docsync/int/index.browser.test.ts
+++ b/tests/docsync/int/index.browser.test.ts
@@ -487,3 +487,49 @@ describe("Local-First", () => {
     });
   });
 });
+
+test("mixed skipUndo transaction syncs every mutation offline and preserves identity through undo/redo", async () => {
+  await testWrapper(async ({ reference, otherTab, otherDevice }) => {
+    await reference.loadDoc();
+    await otherTab.loadDoc();
+    await otherDevice.loadDoc();
+    reference.addChildSkippingUndo("Trash");
+    reference.addChildSkippingUndo("Projects");
+    await otherDevice.assertMemoryDoc(["Trash", "Projects"]);
+    reference.disconnect();
+    const doc = reference.doc!;
+    const trash = doc.root.first!;
+    const projects = doc.root.last!;
+    let changes = 0;
+    const off = doc.onChange(() => changes++);
+    const page = doc.skipUndo(() => {
+      reference.addChild("Page");
+      const page = doc.root.last!;
+      page.move(trash, "append");
+      return page;
+    });
+    page.move(projects, "append");
+    doc.forceCommit();
+    expect(changes).toBe(1);
+    off();
+    await expect
+      .poll(() => otherTab.doc?.getNodeById(page.id)?.parent?.id)
+      .toBe(projects.id);
+    reference.connect();
+    await expect
+      .poll(() => otherDevice.doc?.getNodeById(page.id)?.parent?.id)
+      .toBe(projects.id);
+    await otherDevice.assertCanUndo(false);
+    reference.doc!.undoManager.undo();
+    await expect
+      .poll(() => otherDevice.doc?.getNodeById(page.id)?.parent?.id)
+      .toBe(trash.id);
+    reference.doc!.undoManager.redo();
+    await expect
+      .poll(() => otherDevice.doc?.getNodeById(page.id)?.parent?.id)
+      .toBe(projects.id);
+    expect(reference.doc!.getNodeById(page.id)?.toJSON()[2]).toStrictEqual(
+      page.toJSON()[2],
+    );
+  });
+});

--- a/tests/docsync/int/index.browser.test.ts
+++ b/tests/docsync/int/index.browser.test.ts
@@ -1,6 +1,29 @@
 import { describe, test, expect, vi } from "vitest";
 import { emptyIDB, testWrapper, waitForLocalBroadcast } from "./utils.js";
 
+test("history-only notifications stay local and undo still syncs content", async () => {
+  await testWrapper(async ({ reference, otherDevice }) => {
+    await reference.loadDoc();
+    await otherDevice.loadDoc();
+    const doc = reference.doc!;
+    const localOperations = vi.spyOn(reference.client, "onLocalOperations");
+    const changes = vi.fn();
+    const off = doc.onChange(changes);
+    doc.undoManager.skipUndo(() => reference.addChild("Page"));
+    const page = doc.root.last!;
+    page.delete();
+    doc.forceCommit();
+    expect(changes).toHaveBeenCalledTimes(1);
+    expect(doc.undoManager.canUndo()).toBe(true);
+    expect(localOperations).not.toHaveBeenCalled();
+    doc.undoManager.undo();
+    expect(localOperations).toHaveBeenCalledTimes(1);
+    await otherDevice.assertMemoryDoc(["Page"]);
+    off();
+    localOperations.mockRestore();
+  });
+});
+
 describe("Local-First", () => {
   test("cannot load doc twice", async () => {
     await testWrapper(async (clients) => {
@@ -502,7 +525,7 @@ test("mixed skipUndo transaction syncs every mutation offline and preserves iden
     const projects = doc.root.last!;
     let changes = 0;
     const off = doc.onChange(() => changes++);
-    const page = doc.skipUndo(() => {
+    const page = doc.undoManager.skipUndo(() => {
       reference.addChild("Page");
       const page = doc.root.last!;
       page.move(trash, "append");

--- a/tests/docsync/int/utils.ts
+++ b/tests/docsync/int/utils.ts
@@ -372,7 +372,7 @@ const createClientUtils = async (
     addChildSkippingUndo: (text: string) => {
       if (!cachedDoc) throw new Error("Doc not loaded");
       const doc = cachedDoc;
-      doc.skipUndo(() =>
+      doc.undoManager.skipUndo(() =>
         doc.forceCommit(() => {
           const child = doc.createNode(ChildNode);
           child.state.value.set(text);

--- a/tests/docsync/int/utils.ts
+++ b/tests/docsync/int/utils.ts
@@ -372,13 +372,12 @@ const createClientUtils = async (
     addChildSkippingUndo: (text: string) => {
       if (!cachedDoc) throw new Error("Doc not loaded");
       const doc = cachedDoc;
-      doc.forceCommit(
-        () => {
+      doc.skipUndo(() =>
+        doc.forceCommit(() => {
           const child = doc.createNode(ChildNode);
           child.state.value.set(text);
           doc.root.append(child);
-        },
-        { skipUndo: true },
+        }),
       );
     },
     assertIDBDoc: async (expected?: { doc: string[]; ops: string[] }) => {

--- a/tests/docsync2/client/queries/getDoc/getDoc.browser.test.ts
+++ b/tests/docsync2/client/queries/getDoc/getDoc.browser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { isExistingGetDocData } from "@docukit/docsync2/client";
 import { tick } from "../../utils/async.js";
 import { createTestClient, TestNode } from "../../utils/client.js";
@@ -19,6 +19,37 @@ import {
 import { generateTestUserId } from "../../utils/generators.js";
 
 describe("getDoc", () => {
+  test("history-only notifications do not become sync operations", async () => {
+    const client = createTestClient({
+      undoManager: { maxUndoSteps: 10, mergeInterval: 0 },
+    });
+    const created = await createTestDoc(client);
+    const observed = observeTestDoc(client);
+    try {
+      await waitForDocStatus(client, observed, "idle");
+      const syncChanges = vi.fn();
+      const docChanges = vi.fn();
+      const offSync = client.docSync.on("change", syncChanges);
+      const offDoc = created.doc.onChange(docChanges);
+      const node = created.doc.createNode(TestNode);
+      created.doc.undoManager.skipUndo(() => created.doc.root.append(node));
+      node.delete();
+      created.doc.forceCommit();
+      expect(created.doc.undoManager.canUndo()).toBe(true);
+      expect(docChanges).toHaveBeenCalledTimes(1);
+      expect(syncChanges).not.toHaveBeenCalled();
+      created.doc.undoManager.undo();
+      expect(syncChanges).toHaveBeenCalledTimes(1);
+      expect(created.doc.getNodeById(node.id)).toBeDefined();
+      offDoc();
+      offSync();
+    } finally {
+      observed.unsubscribe();
+      client.docSync.disconnect();
+      client.docSync.dispose();
+    }
+  });
+
   test("two observers for the same doc id receive the same in-memory doc", async () => {
     const testClient = createTestClient();
     const created = await createTestDoc(testClient);


### PR DESCRIPTION
# Add scoped skipUndo without forcing transactions

`skipUndo` was a transaction flag, so excluding one mutation required a commit boundary. `doc.undoManager.skipUndo(callback)` now excludes synchronous mutations while leaving transaction boundaries unchanged. A caller can create a node in trash inside the scope and move it out afterward: observers receive one transaction, while undo moves the same node back to trash.

## How it works

A transaction keeps one tracker: its inverse operations plus the sets of inserted, deleted and moved nodes that the inverse depends on. Rollback and change events use it exactly as before. At the first mutation inside `skipUndo`, that tracker is forked into an undo tracker. From then on, excluded mutations update only the full tracker and undoable mutations update both, so the fork becomes the undo step. There is no second history stack: the step feeds DocNode's existing undo manager. At commit, captured values that already match the document are dropped from the step, and a transaction that changed history without changing content still notifies `onChange`, with empty operations, so `CAN_UNDO` can update.

Transactions without `skipUndo` never fork and run the same bookkeeping code as before. A fully excluded transaction (remote operations, seeds) forks an empty tracker and never writes to it. Only mixed transactions pay: one copy of what the transaction did before its first exclusion, then double bookkeeping.

Normalization remains undoable by default, including after excluded changes. A normalizer must explicitly call `doc.undoManager.skipUndo` to exclude its own corrections. Existing initialization exclusion is preserved.

## Breaking API migration

```ts
// Before
doc.forceCommit(callback, { skipUndo: true });
doc.applyOperations(operations, { skipUndo: true });

// After
doc.undoManager.skipUndo(callback);
doc.undoManager.skipUndo(() => doc.applyOperations(operations));
// If a synchronous commit is also needed:
doc.undoManager.skipUndo(() => doc.forceCommit(callback));
```

The wrapper is synchronous, nestable, scoped to one Doc and returns the callback result. If the callback throws, the active transaction is rolled back, including changes made before entering the scope, and the error is rethrown. Thenable results are rejected. It cannot cancel asynchronous work scheduled by a callback. Exclusion does not protect a change against the structural consequences of undoing another action.

DocNode's `ChangeEvent.flags.skipUndo` still identifies changes with no undoable inverse. It cannot express individual portions of a mixed change. DocSync keeps its generic binding flags and translates incoming exclusions at the DocNode adapter. Since #65, incoming broadcasts are always applied excluded, so a mixed transaction never reaches another tab's history.

## Validation

- Full Vitest run, node and browser projects: all passed. Coverage for `packages/docnode`: 100% statements, branches, functions and lines.
- `pnpm check`: formatting, ESLint, root TypeScript and every package typecheck.
- Playwright Chromium: the four editor undo tests, run against packages and docs rebuilt from this branch.
- `checkUndoManager` wraps the `skipUndo` tests wherever the harness applies. The harness now commits before taking its baseline and compares replayed events without `flags` and with deleted nodes by id.
- Performance with 20k nodes: parity with `main` for inserts, deletes and `applyOperations`, undoable or excluded, with undo enabled or disabled. State writes cost about 6% more. Mixed transactions pay the fork.

Rebased on `main` at 312458b (#66). The tolerant `applyOperations` and the undo/redo mode reset from #66 are included; its two tests were migrated to `doc.undoManager.skipUndo`, and one test that relied on a no-op state patch emitting a change was removed.

No release, package publication, Fluski sidebar implementation or merge is included. Leave this PR in draft.
