### PR TITLE
fix(docsync): limit undo history to the originating tab

### DIFF
--- a/docs/content/docs/docsync/persistence.mdx
+++ b/docs/content/docs/docsync/persistence.mdx
@@ -11,9 +11,4 @@ DocSync provides a batteries-included, local-first client/server that synchroniz
 - IndexedDB for local storage
 - BroadcastChannel for cross-tab synchronization
 
-With DocNode undo enabled, each tab records only its own changes in undo history.
-Changes received from other tabs or devices still update the document, including
-undo and redo, but do not enter the receiving tab's history. Undo history is not
-persisted or shared automatically.
-
 It can adapt strategy by context:

--- a/docs/content/docs/docsync/persistence.mdx
+++ b/docs/content/docs/docsync/persistence.mdx
@@ -11,4 +11,9 @@ DocSync provides a batteries-included, local-first client/server that synchroniz
 - IndexedDB for local storage
 - BroadcastChannel for cross-tab synchronization
 
+With DocNode undo enabled, each tab records only its own changes in undo history.
+Changes received from other tabs or devices still update the document, including
+undo and redo, but do not enter the receiving tab's history. Undo history is not
+persisted or shared automatically.
+
 It can adapt strategy by context:

--- a/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
+++ b/packages/docsync/src/client/handlers/clientInitiated/sync/reconcileSyncResponse.ts
@@ -100,7 +100,7 @@ export async function prepareSyncReconciliation<
 
     const doc = client["_docBinding"].deserialize(baseSerializedDoc);
     applyOperations(client, doc, data.operations, { skipUndo: true });
-    applyOperations(client, doc, localOperations);
+    applyOperations(client, doc, localOperations, { skipUndo: true });
     const serializedDoc = client["_docBinding"].serialize(doc);
 
     const recheckStored = await ctx.getSerializedDoc({ docId });
@@ -175,8 +175,11 @@ export function finalizeSyncReconciliation<
       client,
       prepared.replacementDoc,
       prepared.pendingProviderOperations,
+      { skipUndo: true },
     );
-    applyOperations(client, prepared.replacementDoc, pendingMemoryOperations);
+    applyOperations(client, prepared.replacementDoc, pendingMemoryOperations, {
+      skipUndo: true,
+    });
     return { type: "replaceDoc", doc: prepared.replacementDoc };
   }
 

--- a/packages/docsync/src/client/index.ts
+++ b/packages/docsync/src/client/index.ts
@@ -533,7 +533,9 @@ export class DocSyncClient<
         const doc = this._docBinding.deserialize(stored.serializedDoc);
         localOperations.forEach((operationsBatch) => {
           operationsBatch.forEach((operations) => {
-            this._docBinding.applyOperations(doc, operations);
+            this._docBinding.applyOperations(doc, operations, {
+              skipUndo: true,
+            });
           });
         });
         return doc;

--- a/packages/docsync/src/client/utils/BCHelper.ts
+++ b/packages/docsync/src/client/utils/BCHelper.ts
@@ -63,7 +63,8 @@ export class BCHelper<
       source,
       doc,
       operations,
-      source === "network" ? { ...flags, skipUndo: true } : flags,
+      // Incoming changes belong to another tab, even for the same user.
+      { ...flags, skipUndo: true },
     );
   }
 

--- a/packages/docsync2/src/client/queries/getDoc/syncDoc.ts
+++ b/packages/docsync2/src/client/queries/getDoc/syncDoc.ts
@@ -67,7 +67,7 @@ const applyOperationsToStoredDoc = async <
 
     const doc = docBinding.deserialize(serializedDoc);
     for (const operation of [...args.serverOperations, ...args.operations]) {
-      docBinding.applyOperations(doc, operation);
+      docBinding.applyOperations(doc, operation, { skipUndo: true });
     }
 
     await ctx.saveSerializedDoc({

--- a/packages/docsync2/src/client/utils/BCHelper.ts
+++ b/packages/docsync2/src/client/utils/BCHelper.ts
@@ -59,9 +59,8 @@ export class BCHelper<D extends object, S extends object, O extends object> {
         docBinding.applyOperations(
           data.doc,
           message.operations,
-          message.source === "network"
-            ? { ...message.flags, skipUndo: true }
-            : message.flags,
+          // Incoming changes belong to another tab, even for the same user.
+          { ...message.flags, skipUndo: true },
         );
       } finally {
         client["_changeOrigin"] = "local";

--- a/packages/docsync2/src/client/utils/setupQueryClient/getDocQueries/seedCacheFromProvider.ts
+++ b/packages/docsync2/src/client/utils/setupQueryClient/getDocQueries/seedCacheFromProvider.ts
@@ -35,7 +35,7 @@ export const seedCacheFromProvider = async <
       const operationsBatches = await ctx.getOperations({ docId: args.id });
       for (const operations of operationsBatches) {
         for (const operation of operations) {
-          docBinding.applyOperations(doc, operation);
+          docBinding.applyOperations(doc, operation, { skipUndo: true });
         }
       }
       return { docId: args.id, doc };

--- a/tests/docsync/int/index.browser.test.ts
+++ b/tests/docsync/int/index.browser.test.ts
@@ -127,10 +127,12 @@ describe("Local-First", () => {
       await otherTab.loadDoc();
       await otherTab.assertMemoryDoc(["Hello"]);
       await otherTab.assertIDBDoc({ doc: [], ops: ["Hello"] });
+      await otherTab.assertCanUndo(false);
       expect(syncCallCount(otherTab)).toBe(otherTabSyncCallsBeforeLoad);
 
       otherTab.connect();
       await otherTab.assertIDBDoc({ doc: ["Hello"], ops: [] });
+      await otherTab.assertCanUndo(false);
       expect(syncCallCount(otherTab)).toBeGreaterThan(
         otherTabSyncCallsBeforeLoad,
       );
@@ -261,7 +263,7 @@ describe("Local-First", () => {
     });
   });
 
-  test("local broadcast changes are undoable by the same user in another tab", async () => {
+  test("local broadcasts keep undo and redo in the originating tab", async () => {
     await testWrapper(async ({ reference, otherTab }) => {
       await reference.loadDoc();
       await otherTab.loadDoc();
@@ -275,7 +277,27 @@ describe("Local-First", () => {
       await reference.assertMemoryDoc(["Hello"]);
 
       await reference.assertCanUndo(true);
-      await otherTab.assertCanUndo(true);
+      await otherTab.assertCanUndo(false);
+
+      otherTab.doc?.undoManager.undo();
+      await otherTab.assertMemoryDoc(["Hello"]);
+
+      reference.doc?.undoManager.undo();
+      await otherTab.assertMemoryDoc([]);
+      await otherTab.assertCanUndo(false);
+      expect(reference.doc?.undoManager.canRedo()).toBe(true);
+      expect(otherTab.doc?.undoManager.canRedo()).toBe(false);
+
+      otherTab.addChild("Other tab");
+      otherTab.doc?.forceCommit();
+      await reference.assertMemoryDoc(["Other tab"]);
+      expect(reference.doc?.undoManager.canRedo()).toBe(true);
+
+      reference.doc?.undoManager.redo();
+      await otherTab.assertMemoryDoc(["Other tab", "Hello"]);
+      otherTab.doc?.undoManager.undo();
+      await reference.assertMemoryDoc(["Hello"]);
+      await reference.assertCanUndo(true);
     });
   });
 

--- a/tests/docsync/ui/editor/undoManager.ui.test.ts
+++ b/tests/docsync/ui/editor/undoManager.ui.test.ts
@@ -74,3 +74,34 @@ test("should not undo remote operations, including remote rebroadcasts to other 
   await remote.assertContent(INITIAL_BLOCKS);
   await remote.otherDevice.assertSelection(ORIGINAL_REFERENCE_SELECTION);
 });
+
+test("another browser tab cannot undo local edits or undo and redo broadcasts", async ({
+  page,
+  context,
+}) => {
+  const { reference, remote: otherPage } = await createEditorPair(
+    page,
+    context,
+  );
+  const edited = ["Item one.", "Item two.", "Itxree."];
+
+  await reference.reference.selectRange(THIRD_PARAGRAPH, 2, 7);
+  await reference.reference.type("x");
+  await otherPage.assertContent(edited);
+
+  await otherPage.reference.pressAndAssertSelectionUnchanged("ControlOrMeta+z");
+  await otherPage.assertContent(edited);
+  await reference.assertContent(edited);
+
+  await reference.reference.press("ControlOrMeta+z");
+  await otherPage.assertContent(INITIAL_BLOCKS);
+  await otherPage.reference.pressAndAssertSelectionUnchanged("ControlOrMeta+z");
+  await otherPage.assertContent(INITIAL_BLOCKS);
+  await reference.assertContent(INITIAL_BLOCKS);
+
+  await reference.reference.press("ControlOrMeta+Shift+z");
+  await otherPage.assertContent(edited);
+  await otherPage.reference.pressAndAssertSelectionUnchanged("ControlOrMeta+z");
+  await otherPage.assertContent(edited);
+  await reference.assertContent(edited);
+});

--- a/tests/docsync2/client/queries/getDoc/getDoc.browser.test.ts
+++ b/tests/docsync2/client/queries/getDoc/getDoc.browser.test.ts
@@ -46,10 +46,14 @@ describe("getDoc", () => {
   test("applies same-user local operations through BroadcastChannel", async () => {
     const userId = generateTestUserId();
     const source = createTestClient({
+      undoManager: { maxUndoSteps: 10, mergeInterval: 0 },
       timing: { singleClientMaxDebounce: 1000 },
       userId,
     });
-    const target = createTestClient({ userId });
+    const target = createTestClient({
+      userId,
+      undoManager: { maxUndoSteps: 10, mergeInterval: 0 },
+    });
     const unsubscribes: (() => void)[] = [];
 
     try {
@@ -73,6 +77,23 @@ describe("getDoc", () => {
       await expect
         .poll(() => targetData.doc.toJSON())
         .toStrictEqual(created.doc.toJSON());
+      expect(created.doc.undoManager.canUndo()).toBe(true);
+      expect(targetData.doc.undoManager.canUndo()).toBe(false);
+
+      targetData.doc.undoManager.undo();
+      expect(targetData.doc.toJSON()).toStrictEqual(created.doc.toJSON());
+      created.doc.undoManager.undo();
+      await expect
+        .poll(() => targetData.doc.toJSON())
+        .toStrictEqual(created.doc.toJSON());
+      expect(targetData.doc.undoManager.canUndo()).toBe(false);
+      expect(targetData.doc.undoManager.canRedo()).toBe(false);
+
+      created.doc.undoManager.redo();
+      await expect
+        .poll(() => targetData.doc.toJSON())
+        .toStrictEqual(created.doc.toJSON());
+      expect(targetData.doc.undoManager.canUndo()).toBe(false);
     } finally {
       for (const unsubscribe of unsubscribes) unsubscribe();
       source.docSync.disconnect();

--- a/tests/docsync2/client/utils/client.ts
+++ b/tests/docsync2/client/utils/client.ts
@@ -10,6 +10,7 @@ import { DocNodeBinding } from "@docukit/docsync2/docnode";
 import {
   defineNode,
   type Doc,
+  type UndoManagerConfig,
   type JsonDoc,
   type Operations,
 } from "@docukit/docnode";
@@ -67,12 +68,17 @@ export type TestClient = {
 };
 
 export const createTestClient = (options?: {
+  undoManager?: UndoManagerConfig;
   timing?: ClientConfig<Doc, JsonDoc, Operations>["timing"];
   userId?: string;
 }): TestClient => {
   const docArgs = createTestDocArgs();
   const binding = DocNodeBinding([
-    { type: docArgs.type, extensions: [{ nodes: [TestNode] }] },
+    {
+      type: docArgs.type,
+      extensions: [{ nodes: [TestNode] }],
+      ...(options?.undoManager ? { undoManager: options.undoManager } : {}),
+    },
   ]);
   const { queryClient, docSync, provider } = createTestDocSyncClient(
     binding,


### PR DESCRIPTION
- Before this change, an undo performed in tab A can reach tab B as a new change that B can undo.
- The new [skipUndo API](https://github.com/docukit/docukit/pull/64/changes) would not make sense with that behavior: determining which parts of a transaction are undoable in another tab would be very complex.
- This fits better with optionally persisting undo history locally. Tabs could then share the history itself and undo across tabs without the problem in the first point or special handling for transactions with partially skipped undo.
