### PR TITLE
fix(docnode): treat already-applied operations as no-ops in applyOperations

### DIFF
--- a/packages/docnode/src/operations.ts
+++ b/packages/docnode/src/operations.ts
@@ -237,9 +237,14 @@ export const onApplyOperations = (doc: Doc, operations: Operations) => {
   operations[0].forEach((operation) => {
     switch (operation[0]) {
       case 0:
-        const nodes = operation[1].map((jsonNode) =>
-          doc["_createNodeFromJson"]([jsonNode[0], jsonNode[1], {}]),
-        );
+        // Deleting or moving a missing node skips that operation and keeps
+        // applying the batch. Inserting a node that already exists is treated
+        // the same way: the intent is already satisfied. Undo steps depend on
+        // this when an excluded change restored the node first.
+        const nodes = operation[1]
+          .filter(([id]) => !doc.getNodeById(id))
+          .map(([id, type]) => doc["_createNodeFromJson"]([id, type, {}]));
+        if (nodes.length === 0) break;
         const prev = operation[3] ? doc.getNodeById(operation[3]) : undefined;
         if (prev) {
           doc["_insertRange"](prev, "after", nodes);
@@ -287,24 +292,22 @@ export const onApplyOperations = (doc: Doc, operations: Operations) => {
   for (const id in toApplyStatePatch) {
     const node = doc.getNodeById(id);
     if (!node) continue;
-    currentStatePatch[id] = {
-      ...currentStatePatch[id],
-      ...toApplyStatePatch[id],
-    };
-    if (!doc["_diff"].inserted.has(id)) doc["_diff"].updated.add(id);
     const insertedInSameTransaction = doc["_diff"].inserted.has(id);
     for (const key in toApplyStatePatch[id]) {
-      // Only if it was inserted in the same transaction, it is NOT added to the inverseOps.
-      // Because the inverseOp is a delete, and therefore the state doesn't matter
+      const value = toApplyStatePatch[id][key]!;
+      // The state of a node inserted in this transaction is part of its
+      // creation and needs no inverse: the inverse operation is a delete.
       if (!insertedInSameTransaction) {
-        if (!Boolean(currentInverseStatePatch[id]?.[key])) {
-          const originalStringifiedState = stringifyStateKey(node, key);
-          (currentInverseStatePatch[id] ??= {})[key] ??=
-            originalStringifiedState;
-        }
+        const current = stringifyStateKey(node, key);
+        // A value already in place is treated as applied, like an insert of
+        // an existing node. It changes nothing and needs no inverse.
+        if (current === value) continue;
+        doc["_diff"].updated.add(id);
+        (currentInverseStatePatch[id] ??= {})[key] ??= current;
       }
+      (currentStatePatch[id] ??= {})[key] = value;
       const state = (node as DocNode<UnsafeDefinition>)["_state"];
-      state[key] = parseStateKey(node, key, toApplyStatePatch[id][key]!);
+      state[key] = parseStateKey(node, key, value);
     }
   }
 };

--- a/packages/docnode/src/undoManager.ts
+++ b/packages/docnode/src/undoManager.ts
@@ -97,7 +97,13 @@ export class UndoManager {
     if (!item) return;
     this._txType = "undo";
     this._lastUpdate = undefined;
-    this._doc.applyOperations(item.operations);
+    try {
+      this._doc.applyOperations(item.operations);
+    } finally {
+      // Nothing may have changed (every operation was skipped), in which case
+      // no change event resets the mode. It must not leak into the next edit.
+      this._txType = "update";
+    }
     this._popHandlers.forEach((h) => h({ meta: item.meta, type: "undo" }));
   }
 
@@ -107,7 +113,11 @@ export class UndoManager {
     if (!item) return;
     this._txType = "redo";
     this._lastUpdate = undefined;
-    this._doc.applyOperations(item.operations);
+    try {
+      this._doc.applyOperations(item.operations);
+    } finally {
+      this._txType = "update";
+    }
     this._popHandlers.forEach((h) => h({ meta: item.meta, type: "redo" }));
   }
 

--- a/tests/docnode/transactions.test.ts
+++ b/tests/docnode/transactions.test.ts
@@ -962,6 +962,103 @@ describe("applyOperations", () => {
     expect(flags).toStrictEqual([{ skipUndo: true }, {}]);
     assertDoc(doc, ["remote", "local"]);
   });
+
+  test("skips inserts of nodes that already exist and applies the rest", () => {
+    const doc = createTextDocWithUndo();
+    checkUndoManager(2, doc, () => {
+      const [existing] = text(doc, "existing");
+      const created = doc.createNode(Text);
+      doc.root.append(existing!);
+      doc.forceCommit();
+      doc.applyOperations([
+        [
+          [
+            0,
+            [
+              [existing!.id, "text"],
+              [created.id, "text"],
+            ],
+            0,
+            0,
+            0,
+          ],
+        ],
+        {
+          [existing!.id]: { value: JSON.stringify("updated") },
+          [created.id]: { value: JSON.stringify("created") },
+        },
+      ]);
+      assertDoc(doc, ["updated", "created"]);
+      expect(doc.getNodeById(existing!.id)).toBe(existing);
+    });
+  });
+
+  test("a batch whose inserts all exist still applies its state patch", () => {
+    const doc = createTextDocWithUndo();
+    checkUndoManager(2, doc, () => {
+      const [existing] = text(doc, "existing");
+      doc.root.append(existing!);
+      doc.forceCommit();
+      doc.applyOperations([
+        [[0, [[existing!.id, "text"]], 0, 0, 0]],
+        { [existing!.id]: { value: JSON.stringify("updated") } },
+      ]);
+      assertDoc(doc, ["updated"]);
+    });
+  });
+
+  test("an operation that cannot be created still aborts the batch silently", () => {
+    const doc = createTextDocWithUndo();
+    const [existing] = text(doc, "existing");
+    doc.root.append(existing!);
+    doc.forceCommit();
+    const id = doc.createNode(Text).id;
+    expect(() =>
+      doc.applyOperations([
+        [[0, [[id, "unregistered"]], 0, 0, 0]],
+        { [existing!.id]: { value: JSON.stringify("updated") } },
+      ]),
+    ).not.toThrow();
+    assertDoc(doc, ["existing"]);
+  });
+
+  test("an undo step made redundant by an excluded change is skipped without breaking history", () => {
+    const doc = createTextDocWithUndo();
+    const [trash, other] = text(doc, "Trash", "other");
+    doc.forceCommit(() => doc.root.append(trash!, other!), { skipUndo: true });
+    trash!.delete();
+    doc.forceCommit();
+    doc.forceCommit(() => doc.root.append(trash!), { skipUndo: true });
+    doc.undoManager.undo();
+    assertDoc(doc, ["other", "Trash"]);
+    expect(doc.undoManager.canUndo()).toBe(false);
+    expect(doc.undoManager.canRedo()).toBe(false);
+    other!.state.value.set("edited");
+    doc.forceCommit();
+    // The undo that changed nothing must not leave the manager in undo mode.
+    expect(doc.undoManager.canUndo()).toBe(true);
+    expect(doc.undoManager.canRedo()).toBe(false);
+    doc.undoManager.undo();
+    assertDoc(doc, ["other", "Trash"]);
+  });
+
+  test("a redo step made redundant by an excluded change is skipped without breaking history", () => {
+    const doc = createTextDocWithUndo();
+    const [node] = text(doc, "node");
+    doc.forceCommit(() => doc.root.append(node!), { skipUndo: true });
+    node!.delete();
+    doc.forceCommit();
+    doc.undoManager.undo();
+    assertDoc(doc, ["node"]);
+    doc.forceCommit(() => node!.delete(), { skipUndo: true });
+    doc.undoManager.redo();
+    assertDoc(doc, []);
+    expect(doc.undoManager.canRedo()).toBe(false);
+    doc.root.append(...text(doc, "next"));
+    doc.forceCommit();
+    expect(doc.undoManager.canUndo()).toBe(true);
+    expect(doc.undoManager.canRedo()).toBe(false);
+  });
 });
 
 describe("change", () => {


### PR DESCRIPTION
## Summary

`applyOperations` already skips a delete or a move of a missing node and keeps applying the batch. Two cases were inconsistent with that:

- An insert whose node already exists threw inside `_insertRange`, and `withTransaction` swallowed the error by aborting the **whole** batch.
- A state patch whose value was already in place produced a spurious change event.

Both are the same "intent already satisfied" situation, so they are now treated the same way: the insert of an existing node is skipped, and a value already in place on a pre-existing node is skipped. Nodes inserted in the same batch still take their state verbatim, since it is part of their creation. Genuinely invalid operations (for example an unregistered type) still abort the batch as before.

This matters for undo. A step that re-inserts a node an excluded change (`skipUndo`) had already restored lost the entire step silently. Because no change event fired, `_txType` stayed in `undo` mode and the next local edit landed on the redo stack. `undo()` and `redo()` now reset the mode in a `finally`.

Found while reviewing #64; independent of it (#64 carries the same `finally`, which will be a trivial conflict on rebase).

## Validation

- New tests in `tests/docnode/transactions.test.ts`: partial and fully redundant inserts, redundant undo and redo steps, and an invalid batch that still aborts.
- `pnpm check`, node and browser vitest suites, and coverage: `packages/docnode` at 100% except the pre-existing `flags ?? {}` branch of `forceCommit`, which typed code cannot reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
